### PR TITLE
Update protos

### DIFF
--- a/api-spec/protobuf/coordinator/v1/service.proto
+++ b/api-spec/protobuf/coordinator/v1/service.proto
@@ -11,57 +11,78 @@ service CoordinatorService {
       body: "*"
     };
   };
+  rpc ClaimPayment(ClaimPaymentRequest) returns (ClaimPaymentResponse) {
+    option (google.api.http) = {
+      post: "/v1/payment/claim"
+      body: "*"
+    };
+  };
   rpc FinalizePayment(FinalizePaymentRequest) returns (FinalizePaymentResponse) {
     option (google.api.http) = {
       post: "/v1/payment/finalize"
       body: "*"
     };
   };
-  rpc ListPoolTransactions(ListPoolTransactionsRequest) returns (ListPoolTransactionsResponse) {
+  rpc ListRounds(ListRoundsRequest) returns (ListRoundsResponse) {
     option (google.api.http) = {
-      post: "/v1/pools"
+      post: "/v1/rounds"
       body: "*"
     };
   };
-  rpc GetPoolTransaction(GetPoolTransactionRequest) returns (GetPoolTransactionResponse) {
+  rpc GetRound(GetRoundRequest) returns (GetRoundResponse) {
     option (google.api.http) = {
-      get: "/v1/pool/{txid}"
+      get: "/v1/round/{txid}"
     };
   };
 }
 
 message RegisterPaymentRequest {
-  repeated Input inputs = 1;
-  repeated Output outputs = 2;
-}
-message RegisterPaymentResponse {
+  // Unsigned forfeit tx sending all funds back to the ASP.
   string vtx = 1;
 }
+message RegisterPaymentResponse {
+  // Mocks wabisabi's credentials.
+  string id = 1;
+  // Forfeit tx signed by the ASP.
+  string signed_vtx = 2;
+}
+
+message ClaimPaymentRequest {
+  // Mocks wabisabi's credentials.
+  string id = 1;
+  // List of receivers for a registered payment. 
+  repeated Output outputs = 2;
+}
+message ClaimPaymentResponse {}
 
 message FinalizePaymentRequest {
+  // Forfeit tx signed also by the user. 
   string signed_vtx = 1;
 }
 message FinalizePaymentResponse {}
 
-message ListPoolTransactionsRequest {
+message ListRoundsRequest {
   int64 start = 1;
   int64 end = 2;
 }
-message ListPoolTransactionsResponse {
-  repeated string txs = 1;
+message ListRoundsResponse {
+  repeated Round rounds = 1;
 }
 
-message GetPoolTransactionRequest {
+message GetRoundRequest {
   string txid = 1;
 }
-message GetPoolTransactionResponse {
-  string txhex = 1;
+message GetRoundResponse {
+  Round round = 1;
 }
 
-message Input {
-  string txid = 1;
-  uint32 vout = 2;
+message Round {
+  int64 start = 1;
+  int64 end = 2;
+  string txid = 3;
+  repeated Output outputs = 4;
 }
+
 message Output {
   string pubkey = 1;
   uint64 amount = 2;


### PR DESCRIPTION
This updates the protos to have 2 distinct endpoints the user must consume for registering inputs and outputs of an ark payment. The purpose is to prevent simplifying too much the flow of a real ASP.

I decided to not use the same naming used by wasbisabi since in the ark protocol something different is made under the hood, so i used:
- `RegisterPayment` to send an unsigned forfeit tx to the ASP (wabisabi's input registration phase)
- `ClaimPayment` to tell the ASP the vTXOs to be created for a registered payment (wabisabi's output registration phase)
- `FinalizePayment` to send a signed forfeit tx to the ASP (wabisabi's signing phase)

The simplification lies in the (not) usage of the blinded credentials: I thought the ASP can simply assign a unique ID for every registered payment, to be used by the user to then communicate the receiver(s) of that payment as we're not really interested in provding privacy features at this stage.

NOTE: I also gave another name to the endpoints for listing pool txs. I thought using a more abstract "round" fits better so we can add as many metadata we want related to a single pool transaction.

Please @louisinger review this.