### PR TITLE
Fix metadata

### DIFF
--- a/website/blog/2023-11-10-liquidity-requirements/index.md
+++ b/website/blog/2023-11-10-liquidity-requirements/index.md
@@ -1,28 +1,11 @@
 ---
-slug: liquidity-requirements
-title: Understanding Ark Liquidity Requirements
 authors: bordalix
-tags: [liquidity, ark, bitcoin]
+description: Dive into the depths of Ark with our comprehensive guide on Liquidity Requirements. Explore how Ark liquidity intersect with money velocity
 image: /img/ark-agora.png
+slug: liquidity-requirements
+tags: [liquidity, ark, bitcoin]
+title: Understanding Ark Liquidity Requirements
 ---
-
-<head>
-  <meta name="description" content="Dive into the depths of Ark with our comprehensive guide on Liquidity Requirements. Explore how Ark liquidity intersect with money velocity" />
-  <meta property="og:type" content="website" />
-  <meta property="og:title" content="Understanding Ark Liquidity Requirements" />
-  <meta property="og:description" content="Dive into the depths of Ark with our comprehensive guide on Liquidity Requirements. Explore how Ark liquidity intersect with money velocity" />
-  <meta property="og:image" content="/img/ark-agora.png" />
-  <meta property="og:image:type" content="image/png" />
-  <meta property="og:image:width" content="896" />
-  <meta property="og:image:height" content="512" />
-  <meta property="twitter:card" content="summary_large_image" />
-  <meta property="twitter:title" content="Understanding Ark Liquidity Requirements" />
-  <meta property="twitter:description" content="Dive into the depths of Ark with our comprehensive guide on Liquidity Requirements. Explore how Ark liquidity intersect with money velocity" />
-  <meta name="twitter:label1" content="Author" />
-  <meta name="twitter:data1" content="João Bordalo" />
-  <meta name="twitter:label2" content="Reading time" />
-  <meta name="twitter:data2" content="17 minutes" />
-</head>
 
 ![Bitcoin agora](/img/ark-agora.png)
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,8 @@
 ---
-title: 'Introduction'
+description: Detailed information about the protocol, guidance on providing liquidity, and instructions on how to efficiently spend your coins off-chain in a secure manner
 sidebar_position: 1
 slug: /
+title: Introduction to Ark
 ---
 
 **Welcome to Ark's developer hub.** Here, you'll find detailed information about the protocol, guidance on providing liquidity, and instructions on how to efficiently spend your coins off-chain in a secure manner.
@@ -29,7 +30,6 @@ Should the digital bank cease to exist, **users can still retrieve their digital
 ### 🔨 How Does it Work?
 
 Start by exploring the [Nomenclature](/docs/learn/nomenclature.md) to familiarize yourself with key concepts and terminology. Then, learn how to [Board the Ark](/docs/learn/boarding.md), [Send Payments](/docs/learn/payments.md), and eventually [Leave the Ark](/docs/learn/leaving.md) to withdraw your funds back to the Bitcoin blockchain in case of server unresponsiveness.
-
 
 ### 👩‍💻 Integrate Ark
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-
 const lightCodeTheme = require('prism-react-renderer/themes/synthwave84')
 const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 
@@ -27,7 +26,7 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          routeBasePath: "/",
+          routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
@@ -37,7 +36,11 @@ const config = {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/ark-network/ark/edit/master/website/blog',
+          editUrl:
+            'https://github.com/ark-network/ark/edit/master/website/blog',
+
+          blogTitle: 'Ark blog',
+          blogDescription: 'Posts about Ark development',
         },
       }),
     ],
@@ -90,7 +93,7 @@ const config = {
               {
                 label: 'Leave an Ark',
                 to: '/learn/leaving',
-              }
+              },
             ],
           },
           {
@@ -124,7 +127,7 @@ const config = {
               {
                 label: 'Github',
                 href: 'https://github.com/ark-network',
-              }
+              },
             ],
           },
           {
@@ -133,10 +136,10 @@ const config = {
               {
                 label: 'Blog',
                 to: '/blog',
-              }
+              },
             ],
           },
-        ]
+        ],
       },
       colorMode: {
         defaultMode: 'light',


### PR DESCRIPTION
- Remove all usages of `<head>`, it transpiles to other pages
- Sort markdown front matter in alphabetical order
- Add `description` front matter to blog index and blog post
- Set blog title and description on docusaurus.config