### PR TITLE
persist public key in noah state

### DIFF
--- a/noah/config.go
+++ b/noah/config.go
@@ -7,6 +7,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var networkFlag = cli.StringFlag{
+	Name:     "network",
+	Usage:    "network to use (mainnet, testnet)",
+	Value:    "mainnet",
+	Required: false,
+}
+
 var configCommand = cli.Command{
 	Name:   "config",
 	Usage:  "Print local configuration of the Noah CLI",
@@ -14,8 +21,11 @@ var configCommand = cli.Command{
 	Subcommands: []*cli.Command{
 		{
 			Name:   "connect",
-			Usage:  "connect <ARK_URL>",
+			Usage:  "connect <ARK_URL> [--network <NETWORK>]",
 			Action: connectAction,
+			Flags: []cli.Flag{
+				&networkFlag,
+			},
 		},
 	},
 }
@@ -35,9 +45,15 @@ func connectAction(ctx *cli.Context) error {
 	}
 
 	url := ctx.Args().First()
+	network := ctx.String("network")
+
+	if network != "mainnet" && network != "testnet" {
+		return fmt.Errorf("invalid network: %s", network)
+	}
 
 	updateState := map[string]string{
 		"ark_url": url,
+		"network": network,
 	}
 
 	if err := setState(updateState); err != nil {
@@ -66,5 +82,6 @@ func connectAction(ctx *cli.Context) error {
 	return printJSON(map[string]string{
 		"ark_url":    url,
 		"ark_pubkey": resp.Pubkey,
+		"network":    network,
 	})
 }

--- a/noah/init.go
+++ b/noah/init.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/ark-network/ark/common"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/urfave/cli/v2"
@@ -62,6 +63,13 @@ func initAction(ctx *cli.Context) error {
 
 	cypher := NewAES128Cypher()
 
+	net := getNetwork()
+
+	publicKey, err := common.EncodePubKey(net.PubKey, privateKey.PubKey())
+	if err != nil {
+		return err
+	}
+
 	encryptedPrivateKey, err := cypher.Encrypt(privateKey.Serialize(), []byte(password))
 	if err != nil {
 		return err
@@ -72,6 +80,7 @@ func initAction(ctx *cli.Context) error {
 	state := map[string]string{
 		"encrypted_private_key": hex.EncodeToString(encryptedPrivateKey),
 		"password_hash":         hex.EncodeToString(passwordHash),
+		"public_key":            publicKey,
 	}
 
 	if err := setState(state); err != nil {

--- a/noah/main.go
+++ b/noah/main.go
@@ -29,6 +29,8 @@ var (
 		"ark_pubkey":            "",
 		"encrypted_private_key": "",
 		"password_hash":         "",
+		"public_key":            "",
+		"network":               "mainnet",
 	}
 )
 

--- a/noah/send.go
+++ b/noah/send.go
@@ -55,6 +55,7 @@ func sendAction(ctx *cli.Context) error {
 
 	receiversOutput := make([]*arkv1.Output, 0)
 	sumOfReceivers := uint64(0)
+	net := getNetwork()
 
 	for _, receiver := range receiversJSON {
 		_, userKey, aspKey, err := common.DecodeAddress(receiver.To)
@@ -70,7 +71,7 @@ func sendAction(ctx *cli.Context) error {
 			return fmt.Errorf("invalid amount: %d", receiver.Amount)
 		}
 
-		encodedKey, err := common.EncodePubKey(common.MainNet.PubKey, userKey)
+		encodedKey, err := common.EncodePubKey(net.PubKey, userKey)
 		if err != nil {
 			return err
 		}
@@ -103,7 +104,7 @@ func sendAction(ctx *cli.Context) error {
 		}
 
 		walletPubKey := walletPrvKey.PubKey()
-		encodedPubKey, err := common.EncodePubKey(common.MainNet.PubKey, walletPubKey)
+		encodedPubKey, err := common.EncodePubKey(net.PubKey, walletPubKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* `connect` command now accept an optional flag `--network` (default to mainnet)
* the `init` command persists the wallet public key in order to avoid useless password prompt (receive and faucet)
 
@altafan please review