### PR TITLE
Application service: broadcast `RoundFailed` events

### DIFF
--- a/asp/internal/core/application/service.go
+++ b/asp/internal/core/application/service.go
@@ -388,7 +388,7 @@ func (s *service) propagateEvents(round *domain.Round) {
 			PoolTx:             e.PoolTx,
 			UnsignedForfeitTxs: forfeitTxs,
 		}
-	case domain.RoundFinalized:
+	case domain.RoundFinalized, domain.RoundFailed:
 		s.eventsCh <- e
 	}
 }


### PR DESCRIPTION
This PR fixes the `propagateEvents` function to handle `RoundFailed` events.

it closes #59 

@altafan please review