### PR TITLE
Hotfix in sweep flow

### DIFF
--- a/asp/internal/core/application/sweeper.go
+++ b/asp/internal/core/application/sweeper.go
@@ -186,7 +186,7 @@ func (s *sweeper) createTask(
 						continue
 					}
 
-					firstVtxo, err := s.repoManager.Vtxos().GetVtxos(ctx, sweepableVtxos[1:])
+					firstVtxo, err := s.repoManager.Vtxos().GetVtxos(ctx, sweepableVtxos[:1])
 					if err != nil {
 						log.Error(fmt.Errorf("error while getting vtxo: %w", err))
 						sweepInputs = append(sweepInputs, input) // add the input anyway in order to try to sweep it


### PR DESCRIPTION
It fixes an error in sweeper causing panics while sweepableVtxos length is 1 (when it remains only 1 vtxo to sweep in the round)

[1:] != [:1] :face_with_spiral_eyes: 

@altafan please review