### PR TITLE
Update event and projection stores in sync

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -34,7 +34,7 @@ lint:
 run: clean
 	@echo "Running arkd in dev mode..."
 	@export ARK_WALLET_ADDR=localhost:18000; \
-	export ARK_ROUND_INTERVAL=30; \
+	export ARK_ROUND_INTERVAL=10; \
 	go run ./cmd/arkd
 
 ## test: runs unit and component tests

--- a/server/internal/core/domain/round_repo.go
+++ b/server/internal/core/domain/round_repo.go
@@ -5,7 +5,7 @@ import (
 )
 
 type RoundEventRepository interface {
-	Save(ctx context.Context, id string, events ...RoundEvent) error
+	Save(ctx context.Context, id string, events ...RoundEvent) (*Round, error)
 	Load(ctx context.Context, id string) (*Round, error)
 }
 

--- a/server/internal/infrastructure/db/badger/event_repo.go
+++ b/server/internal/infrastructure/db/badger/event_repo.go
@@ -59,18 +59,18 @@ func NewRoundEventRepository(config ...interface{}) (dbtypes.EventStore, error) 
 
 func (r *eventRepository) Save(
 	ctx context.Context, id string, events ...domain.RoundEvent,
-) error {
+) (*domain.Round, error) {
 	allEvents, err := r.get(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	allEvents = append(allEvents, events...)
 	if err := r.upsert(ctx, id, allEvents); err != nil {
-		return err
+		return nil, err
 	}
 	go r.publishEvents(allEvents)
-	return nil
+	return domain.NewRoundFromEvents(allEvents), nil
 }
 func (r *eventRepository) Load(
 	ctx context.Context, id string,

--- a/server/internal/infrastructure/db/service_test.go
+++ b/server/internal/infrastructure/db/service_test.go
@@ -180,10 +180,11 @@ func testRoundEventRepository(t *testing.T, svc ports.RepoManager) {
 		for _, f := range fixtures {
 			svc.RegisterEventsHandler(f.handler)
 
-			err := svc.Events().Save(ctx, f.roundId, f.events...)
+			round, err := svc.Events().Save(ctx, f.roundId, f.events...)
 			require.NoError(t, err)
+			require.NotNil(t, round)
 
-			round, err := svc.Events().Load(ctx, f.roundId)
+			round, err = svc.Events().Load(ctx, f.roundId)
 			require.NoError(t, err)
 			require.NotNil(t, round)
 			require.Equal(t, f.roundId, round.Id)


### PR DESCRIPTION
This fixes a subtle problem that becomes evident when running the server in a docker environment: the service relies on having event and projection stores always in sync, while the application logic enforces async updates. 

With this, the app service makes sure to update both the event and projection store at the same time.

NOTE: this adds a small change to the event repo's `Save()` method to spare a call to `Load()` in the app service.

Please @louisinger review this.