### PR TITLE
Fix execution of handler in event repo & minor fixes

### DIFF
--- a/server/internal/app-config/config.go
+++ b/server/internal/app-config/config.go
@@ -65,8 +65,8 @@ func (c *Config) Validate() error {
 	if !supportedScanners.supports(c.BlockchainScannerType) {
 		return fmt.Errorf("blockchain scanner type not supported, please select one of: %s", supportedScanners)
 	}
-	if c.RoundInterval < 5 {
-		return fmt.Errorf("invalid round interval, must be at least 5 seconds")
+	if c.RoundInterval < 2 {
+		return fmt.Errorf("invalid round interval, must be at least 2 seconds")
 	}
 	if c.Network.Name != "liquid" && c.Network.Name != "testnet" {
 		return fmt.Errorf("invalid network, must be either liquid or testnet")

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -42,7 +42,7 @@ var (
 	RoundLifetime         = "ROUND_LIFETIME"
 
 	defaultDatadir               = common.AppDataDir("arkd", false)
-	defaultRoundInterval         = 60
+	defaultRoundInterval         = 10
 	defaultPort                  = 6000
 	defaultDbType                = "badger"
 	defaultSchedulerType         = "gocron"


### PR DESCRIPTION
This fixes the execution of the handler registered for the event repository.

The problem was affecting the UX of the asp/wallet: when doing a tx from the wallet, the process never completed, hanging instead.

This also sets the min allowed round interval to 2 seconds instead of 5, and the default one to 10 instead of 60.

Please @louisinger review this.