### PR TITLE
Give expiration details only when flag --expiry-details is set

### DIFF
--- a/client/balance.go
+++ b/client/balance.go
@@ -24,7 +24,7 @@ var balanceCommand = cli.Command{
 }
 
 func balanceAction(ctx *cli.Context) error {
-	expiryDetails := ctx.Bool("expiry-details")
+	withExpiryDetails := ctx.Bool("expiry-details")
 
 	client, cancel, err := getClientFromState(ctx)
 	if err != nil {
@@ -44,7 +44,9 @@ func balanceAction(ctx *cli.Context) error {
 	go func() {
 		defer wg.Done()
 		explorer := NewExplorer()
-		balance, amountByExpiration, err := getOffchainBalance(ctx, explorer, client, offchainAddr, true)
+		balance, amountByExpiration, err := getOffchainBalance(
+			ctx, explorer, client, offchainAddr, withExpiryDetails,
+		)
 		if err != nil {
 			chRes <- balanceRes{0, 0, nil, err}
 			return
@@ -134,7 +136,7 @@ func balanceAction(ctx *cli.Context) error {
 		offchainBalanceJSON["next_expiration"] = fancyTimeExpiration
 	}
 
-	if expiryDetails {
+	if withExpiryDetails {
 		offchainBalanceJSON["details"] = details
 	}
 


### PR DESCRIPTION
This make the `balance` command return expiry details only when the relative flag is set.

Since the operation can take too long to be completed, let's do it only when the users really want to see that info.

Closes #115.

Please @bordalix @louisinger review this.