### PR TITLE
add --enable-expiry-coinselect flag in redeem & send cmds

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -186,19 +186,21 @@ func getUnilateralExitDelay() (int64, error) {
 	return int64(redeemDelay), nil
 }
 
-func coinSelect(vtxos []vtxo, amount uint64) ([]vtxo, uint64, error) {
+func coinSelect(vtxos []vtxo, amount uint64, sortByExpirationTime bool) ([]vtxo, uint64, error) {
 	selected := make([]vtxo, 0)
 	notSelected := make([]vtxo, 0)
 	selectedAmount := uint64(0)
 
-	// sort vtxos by expiration (older first)
-	sort.SliceStable(vtxos, func(i, j int) bool {
-		if vtxos[i].expireAt == nil || vtxos[j].expireAt == nil {
-			return false
-		}
+	if sortByExpirationTime {
+		// sort vtxos by expiration (older first)
+		sort.SliceStable(vtxos, func(i, j int) bool {
+			if vtxos[i].expireAt == nil || vtxos[j].expireAt == nil {
+				return false
+			}
 
-		return vtxos[i].expireAt.Before(*vtxos[j].expireAt)
-	})
+			return vtxos[i].expireAt.Before(*vtxos[j].expireAt)
+		})
+	}
 
 	for _, vtxo := range vtxos {
 		if selectedAmount >= amount {

--- a/client/send.go
+++ b/client/send.go
@@ -36,13 +36,18 @@ var (
 		Name:  "amount",
 		Usage: "amount to send in sats",
 	}
+	enableExpiryCoinselectFlag = cli.BoolFlag{
+		Name:  "enable-expiry-coinselect",
+		Usage: "select vtxos that are about to expire first",
+		Value: false,
+	}
 )
 
 var sendCommand = cli.Command{
 	Name:   "send",
 	Usage:  "Send your onchain or offchain funds to one or many receivers",
 	Action: sendAction,
-	Flags:  []cli.Flag{&receiversFlag, &toFlag, &amountFlag},
+	Flags:  []cli.Flag{&receiversFlag, &toFlag, &amountFlag, &enableExpiryCoinselectFlag},
 }
 
 func sendAction(ctx *cli.Context) error {
@@ -110,6 +115,8 @@ func sendAction(ctx *cli.Context) error {
 }
 
 func sendOffchain(ctx *cli.Context, receivers []receiver) error {
+	withExpiryCoinselect := ctx.Bool("enable-expiry-coinselect")
+
 	offchainAddr, _, _, err := getAddress()
 	if err != nil {
 		return err
@@ -153,12 +160,11 @@ func sendOffchain(ctx *cli.Context, receivers []receiver) error {
 
 	explorer := NewExplorer()
 
-	vtxos, err := getVtxos(ctx.Context, explorer, client, offchainAddr, true)
+	vtxos, err := getVtxos(ctx.Context, explorer, client, offchainAddr, withExpiryCoinselect)
 	if err != nil {
 		return err
 	}
-
-	selectedCoins, changeAmount, err := coinSelect(vtxos, sumOfReceivers)
+	selectedCoins, changeAmount, err := coinSelect(vtxos, sumOfReceivers, withExpiryCoinselect)
 	if err != nil {
 		return err
 	}
@@ -213,7 +219,7 @@ func sendOffchain(ctx *cli.Context, receivers []receiver) error {
 	})
 }
 
-func sendOnchain(ctx *cli.Context, receivers []receiver) (string, error) {
+func sendOnchain(_ *cli.Context, receivers []receiver) (string, error) {
 	pset, err := psetv2.New(nil, nil, nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This PR removes the default strategy used by `coinselect` (sort by expiration time).

- `enable-expiry-coinselect` flag on `redeem` & `send` let to select expiry-first vtxos (slow)
- by default coinselect won't use the expiry time of vtxos (fast)

@altafan @tiero please review