### PR TITLE
do not set expireAt=0 when vtxo is swept

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -22,3 +22,5 @@ DS_Store
 
 go.work
 go.work.sum
+
+.vscode/

--- a/server/internal/infrastructure/db/badger/vtxo_repo.go
+++ b/server/internal/infrastructure/db/badger/vtxo_repo.go
@@ -271,7 +271,6 @@ func (r *vtxoRepository) sweepVtxo(ctx context.Context, vtxoKey domain.VtxoKey) 
 	}
 
 	vtxo.Swept = true
-	vtxo.ExpireAt = 0
 	if ctx.Value("tx") != nil {
 		tx := ctx.Value("tx").(*badger.Txn)
 		err = r.store.TxUpdate(tx, vtxoKey.Hash(), *vtxo)


### PR DESCRIPTION
This PR removes the reset statement on expireAt member. Thus, a swept Vtxo will keep its `expireAt` timestamp value.

it closes #170 

@bordalix @tiero please review