### PR TITLE
pkg/client-sdk: expose IsLocked 

### DIFF
--- a/pkg/client-sdk/ark_sdk.go
+++ b/pkg/client-sdk/ark_sdk.go
@@ -10,6 +10,7 @@ type ArkClient interface {
 	GetConfigData(ctx context.Context) (*store.StoreData, error)
 	Init(ctx context.Context, args InitArgs) error
 	InitWithWallet(ctx context.Context, args InitWithWalletArgs) error
+	IsLocked(ctx context.Context) bool
 	Unlock(ctx context.Context, password string) error
 	Lock(ctx context.Context, password string) error
 	Balance(ctx context.Context, computeExpiryDetails bool) (*Balance, error)

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -196,6 +196,10 @@ func (a *arkClient) Lock(ctx context.Context, pasword string) error {
 	return a.wallet.Lock(ctx, pasword)
 }
 
+func (a *arkClient) IsLocked(ctx context.Context) bool {
+	return a.wallet.IsLocked()
+}
+
 func (a *arkClient) Receive(ctx context.Context) (string, string, error) {
 	offchainAddr, onchainAddr, err := a.wallet.NewAddress(ctx, false)
 	if err != nil {

--- a/pkg/client-sdk/wallet/wallet_test.go
+++ b/pkg/client-sdk/wallet/wallet_test.go
@@ -134,6 +134,15 @@ func TestWallet(t *testing.T) {
 
 			err = walletSvc.Lock(ctx, "")
 			require.NoError(t, err)
+
+			locked := walletSvc.IsLocked()
+			require.True(t, locked)
+
+			_, err = walletSvc.Unlock(ctx, password)
+			require.NoError(t, err)
+
+			locked = walletSvc.IsLocked()
+			require.False(t, locked)
 		})
 	}
 }

--- a/pkg/client-sdk/wasm/browser/exports.go
+++ b/pkg/client-sdk/wasm/browser/exports.go
@@ -25,6 +25,7 @@ func init() {
 	js.Global().Set("init", InitWrapper())
 	js.Global().Set("unlock", UnlockWrapper())
 	js.Global().Set("lock", LockWrapper())
+	js.Global().Set("locked", IsLockedWrapper())
 	js.Global().Set("balance", BalanceWrapper())
 	js.Global().Set("onboard", OnboardWrapper())
 	js.Global().Set("receive", ReceiveWrapper())

--- a/pkg/client-sdk/wasm/browser/wrappers.go
+++ b/pkg/client-sdk/wasm/browser/wrappers.go
@@ -76,6 +76,12 @@ func InitWrapper() js.Func {
 	})
 }
 
+func IsLockedWrapper() js.Func {
+	return js.FuncOf(func(this js.Value, p []js.Value) interface{} {
+		return js.ValueOf(arkSdkClient.IsLocked(context.Background()))
+	})
+}
+
 func UnlockWrapper() js.Func {
 	return JSPromise(func(args []js.Value) (interface{}, error) {
 		if len(args) != 1 {


### PR DESCRIPTION
With this commit, the `pkg/client-sdk` now expose a IsLocked that maps to the wallet internal status

You can try with @bordalix 

```sh
go get -v github.com/ark-network/ark/pkg/client-sdk@50c9594da9d946a6a17118ac4734ca413bdaca55
```