### PR TITLE
add flag --version

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -17,8 +17,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var version = "alpha"
-
 var (
 	balanceCommand = cli.Command{
 		Name:  "balance",
@@ -151,12 +149,14 @@ var (
 	}
 )
 
+var Version string
+
 func main() {
 	app := cli.NewApp()
 
-	app.Version = version
 	app.Name = "Ark CLI"
-	app.Usage = "ark wallet command line interface"
+	app.Version = Version
+	app.Usage = "Ark wallet command line interface"
 	app.Commands = append(
 		app.Commands,
 		&balanceCommand,

--- a/server/cmd/arkd/main.go
+++ b/server/cmd/arkd/main.go
@@ -15,12 +15,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-//nolint:all
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
+// Version will be set during build time
+var Version string
 
 // flags
 var (
@@ -105,7 +101,7 @@ func mainAction(_ *cli.Context) error {
 
 func main() {
 	app := cli.NewApp()
-	app.Version = version
+	app.Version = Version
 	app.Name = "Arkd CLI"
 	app.Usage = "arkd command line interface"
 	app.Commands = append(app.Commands, walletCmd)


### PR DESCRIPTION
Now both `ark` and `arkd` can use a `--version` flag 

It closes #235 