### PR TITLE
[server] fix unexpected panics when the wallet is not initialized

### DIFF
--- a/server/internal/infrastructure/wallet/btc-embedded/wallet.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/wallet.go
@@ -68,9 +68,10 @@ const (
 )
 
 var (
-	p2wpkhKeyScope     = waddrmgr.KeyScopeBIP0084
-	p2trKeyScope       = waddrmgr.KeyScopeBIP0086
-	outputLockDuration = time.Minute
+	ErrWalletNotInitialized = fmt.Errorf("wallet not initialized")
+	p2wpkhKeyScope          = waddrmgr.KeyScopeBIP0084
+	p2trKeyScope            = waddrmgr.KeyScopeBIP0086
+	outputLockDuration      = time.Minute
 )
 
 type service struct {
@@ -221,7 +222,7 @@ func NewService(cfg WalletConfig, options ...WalletOption) (ports.WalletService,
 }
 
 func (s *service) Close() {
-	if s.wallet != nil {
+	if s.isInitialized() {
 		if err := s.wallet.Stop(); err != nil {
 			log.WithError(err).Warn("failed to gracefully stop the wallet, forcing shutdown")
 		}
@@ -245,7 +246,7 @@ func (s *service) Restore(_ context.Context, seed, password string) error {
 }
 
 func (s *service) Unlock(_ context.Context, password string) error {
-	if s.wallet == nil {
+	if !s.isInitialized() {
 		pwd := []byte(password)
 		opt := btcwallet.LoaderWithLocalWalletDB(s.cfg.Datadir, false, time.Minute)
 		config := btcwallet.Config{
@@ -325,8 +326,8 @@ func (s *service) Unlock(_ context.Context, password string) error {
 }
 
 func (s *service) Lock(_ context.Context, _ string) error {
-	if err := s.expectWallet(); err != nil {
-		return err
+	if !s.isInitialized() {
+		return ErrWalletNotInitialized
 	}
 
 	s.wallet.InternalWallet().Lock()
@@ -583,7 +584,7 @@ func (s *service) SignTransactionTapscript(ctx context.Context, partialTx string
 }
 
 func (s *service) Status(ctx context.Context) (ports.WalletStatus, error) {
-	if s.wallet == nil {
+	if !s.isInitialized() {
 		return status{}, nil
 	}
 
@@ -906,8 +907,8 @@ func (s *service) initWallet(wallet *btcwallet.BtcWallet) error {
 }
 
 func (s *service) getBalance(account accountName) (uint64, error) {
-	if err := s.expectWallet(); err != nil {
-		return 0, err
+	if !s.isInitialized() {
+		return 0, ErrWalletNotInitialized
 	}
 
 	balance, err := s.wallet.ConfirmedBalance(0, string(account))
@@ -920,18 +921,15 @@ func (s *service) getBalance(account accountName) (uint64, error) {
 
 // this only supports deriving segwit v0 accounts
 func (s *service) deriveNextAddress(account accountName) (btcutil.Address, error) {
-	if err := s.expectWallet(); err != nil {
-		return nil, err
+	if !s.isInitialized() {
+		return nil, ErrWalletNotInitialized
 	}
 
 	return s.wallet.NewAddress(lnwallet.WitnessPubKey, false, string(account))
 }
 
-func (s *service) expectWallet() error {
-	if s.wallet == nil {
-		return fmt.Errorf("wallet not initialized")
-	}
-	return nil
+func (s *service) isInitialized() bool {
+	return s.wallet != nil
 }
 
 func withChainSource(chainSource chain.Interface) WalletOption {


### PR DESCRIPTION
This PR contains small fixes regarding `admin/wallet` APIs panics (`wallet/balance` & `wallet/address` should return an error if the wallet is nil)

it closes #250 

@tiero please review