### PR TITLE
check go work sync in unit test

### DIFF
--- a/.github/workflows/ark.unit.yaml
+++ b/.github/workflows/ark.unit.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: '>=1.22.6'
 
       - name: Run go work sync
         run: go work sync
@@ -45,9 +45,9 @@ jobs:
       run:
         working-directory: ./server
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ">1.17.2"
+          go-version: '>=1.22.6'
       - uses: actions/checkout@v3
       - name: check linting
         uses: golangci/golangci-lint-action@v3
@@ -69,9 +69,9 @@ jobs:
       run:
         working-directory: ./pkg/client-sdk
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: ">1.17.2"
+          go-version: '>=1.22.6'
       - uses: actions/checkout@v3
       - name: check linting
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/ark.unit.yaml
+++ b/.github/workflows/ark.unit.yaml
@@ -14,6 +14,30 @@ on:
       - "pkg/client-sdk/**"
 
 jobs:
+  check-go-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+
+      - name: Run go work sync
+        run: go work sync
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Check for changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Changes detected after running go work sync and go mod tidy"
+            git diff
+            exit 1
+          fi
+
   test-server:
     name: server unit tests
     runs-on: ubuntu-latest
@@ -33,7 +57,7 @@ jobs:
       - name: check code integrity
         uses: securego/gosec@master
         with:
-          args: '-severity high -quiet ./...'
+          args: "-severity high -quiet ./..."
       - run: go get -v -t -d ./...
       - name: unit testing
         run: make test
@@ -57,7 +81,7 @@ jobs:
       - name: check code integrity
         uses: securego/gosec@master
         with:
-          args: '-severity high -quiet ./...'
+          args: "-severity high -quiet ./..."
       - run: go get -v -t -d ./...
       - name: unit testing
         run: make test

--- a/.github/workflows/ark.unit.yaml
+++ b/.github/workflows/ark.unit.yaml
@@ -27,9 +27,6 @@ jobs:
       - name: Run go work sync
         run: go work sync
 
-      - name: Run go mod tidy
-        run: go mod tidy
-
       - name: Check for changes
         run: |
           if [[ -n $(git status --porcelain) ]]; then

--- a/pkg/client-sdk/go.mod
+++ b/pkg/client-sdk/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect

--- a/pkg/client-sdk/go.sum
+++ b/pkg/client-sdk/go.sum
@@ -1,10 +1,6 @@
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/ark-network/ark/api-spec v0.0.0-20240812230256-910716f72d1a h1:9Jt/77jO6tA6iWe1fuH7sm3M6NefKnBbOm277vapPfc=
-github.com/ark-network/ark/api-spec v0.0.0-20240812230256-910716f72d1a/go.mod h1:0B5seq/gzuGL8OZGUaO12yj73ZJKAde8L+nmLQAZ7IA=
 github.com/ark-network/ark/api-spec v0.0.0-20240815203029-edc4534dfc87 h1:VBY4KqHqxE4q6NnmvEZTLvLZoNA0Q6NhMhjBs1hzy9Y=
 github.com/ark-network/ark/api-spec v0.0.0-20240815203029-edc4534dfc87/go.mod h1:m5H86Dx+k8cQjLXeYL1MV+h3x/XnhJCXJP/PL3KgZqY=
-github.com/ark-network/ark/common v0.0.0-20240812230256-910716f72d1a h1:vjuHW6OF/dPV9CmwpqmWb+KmkdqNeksovhIRojRTpRE=
-github.com/ark-network/ark/common v0.0.0-20240812230256-910716f72d1a/go.mod h1:8DYeb06Dl8onmrV09xfsdDMGv5HoVtWoKhLBLXOYHew=
 github.com/ark-network/ark/common v0.0.0-20240815203029-edc4534dfc87 h1:TIv00zlpxLKmY2LjFAIMF8RxNtn9rFqQsv73Lwoj2ds=
 github.com/ark-network/ark/common v0.0.0-20240815203029-edc4534dfc87/go.mod h1:aYAGDfoeBLofnZt9n85wusFyCkrS7hvwdo5TynBlkuY=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=


### PR DESCRIPTION
`go work sync` runs `tidy` under the hood on each module. The current master doesnt has the last version. I have introduced a gh action to automatically check this during unit tests