### PR TITLE
[SDK] Expose transport client

### DIFF
--- a/pkg/client-sdk/ark_sdk.go
+++ b/pkg/client-sdk/ark_sdk.go
@@ -3,6 +3,7 @@ package arksdk
 import (
 	"context"
 
+	"github.com/ark-network/ark/pkg/client-sdk/client"
 	"github.com/ark-network/ark/pkg/client-sdk/store"
 )
 
@@ -26,6 +27,8 @@ type ArkClient interface {
 	) (string, error)
 	SendAsync(ctx context.Context, withExpiryCoinselect bool, receivers []Receiver) (string, error)
 	ClaimAsync(ctx context.Context) (string, error)
+
+	Client() client.ASPClient
 }
 
 type Receiver interface {

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -47,6 +47,10 @@ type arkClient struct {
 	client   client.ASPClient
 }
 
+func (a *arkClient) Client() client.ASPClient {
+	return a.client
+}
+
 func (a *arkClient) GetConfigData(
 	_ context.Context,
 ) (*store.StoreData, error) {


### PR DESCRIPTION
This makes the transport client of the SDK accessible so that the consumer can interact directly with the ASP for custom purposes.

Closes #263.

Please @louisinger @bordalix review.