### PR TITLE
Make embedded btc wallet produce less logs

### DIFF
--- a/server/internal/infrastructure/wallet/btc-embedded/wallet.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/wallet.go
@@ -1299,5 +1299,7 @@ func fromOutputScript(script []byte, netParams *chaincfg.Params) (btcutil.Addres
 }
 
 func logger(subsystem string) btclog.Logger {
-	return btclog.NewBackend(log.StandardLogger().Writer()).Logger(subsystem)
+	logger := btclog.NewBackend(log.StandardLogger().Writer()).Logger(subsystem)
+	logger.SetLevel(btclog.LevelWarn)
+	return logger
 }


### PR DESCRIPTION
There's no way to change the level of the logs a service produces. Rather, we can set the the min log level for it and make those of the levels above disappear.

This makes the embedded btc wallet produce fewer logs by setting the log level of all components to warning.

NOTE: There's no way to set a log level for the sqlite db we use currently `modernc.org/sqlite`. Maybe we should move to something else? Is there a specific reason we chose this one? @louisinger @tiero

Closes #287

Please @louisinger @tiero review