### PR TITLE
fix: `Ping` event stream for REST client

### DIFF
--- a/pkg/client-sdk/client/rest/client.go
+++ b/pkg/client-sdk/client/rest/client.go
@@ -228,7 +228,6 @@ func (a *restClient) GetEventStream(
 
 	go func(payID string) {
 		defer close(eventsCh)
-		defer close(stopCh)
 
 		timeout := time.After(a.requestTimeout)
 
@@ -262,7 +261,10 @@ func (a *restClient) GetEventStream(
 	}(paymentID)
 
 	close := func() {
-		stopCh <- struct{}{}
+		go func() {
+			stopCh <- struct{}{}
+			close(stopCh)
+		}()
 	}
 
 	return eventsCh, close, nil

--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -421,7 +421,6 @@ func (s *covenantService) startRound() {
 	round := domain.NewRound(dustAmount)
 	//nolint:all
 	round.StartRegistration()
-	s.lastEvent = nil
 	s.currentRound = round
 
 	defer func() {

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -712,7 +712,6 @@ func (s *covenantlessService) startRound() {
 	round := domain.NewRound(dustAmount)
 	//nolint:all
 	round.StartRegistration()
-	s.lastEvent = nil
 	s.currentRound = round
 
 	defer func() {


### PR DESCRIPTION
- [SDK] fix `restClient.GetEventStream` close channel, preventing it to panic if something went wrong during the round process.
- [application] do not set `lastEvent` to `nil` when the registration starts. It allows the REST client to get the previous `RoundFinalized` event.

@altafan please review