### PR TITLE
Add auto-unlocker

### DIFF
--- a/server/cmd/arkd/main.go
+++ b/server/cmd/arkd/main.go
@@ -79,18 +79,20 @@ func mainAction(_ *cli.Context) error {
 		BitcoindRpcPass:       cfg.BitcoindRpcPass,
 		BitcoindRpcHost:       cfg.BitcoindRpcHost,
 		BoardingExitDelay:     cfg.BoardingExitDelay,
+		UnlockerType:          cfg.UnlockerType,
+		UnlockerFilePath:      cfg.UnlockerFilePath,
 	}
 	svc, err := grpcservice.NewService(svcConfig, appConfig)
 	if err != nil {
 		return err
 	}
 
-	log.RegisterExitHandler(svc.Stop)
-
 	log.Info("starting service...")
 	if err := svc.Start(); err != nil {
 		return err
 	}
+
+	log.RegisterExitHandler(svc.Stop)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT, os.Interrupt)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	BitcoindRpcHost       string
 	TLSExtraIPs           []string
 	TLSExtraDomains       []string
+	UnlockerType          string
+	UnlockerFilePath      string
 }
 
 var (
@@ -59,12 +61,14 @@ var (
 	// #nosec G101
 	BitcoindRpcUser = "BITCOIND_RPC_USER"
 	// #nosec G101
-	BitcoindRpcPass = "BITCOIND_RPC_PASS"
-	BitcoindRpcHost = "BITCOIND_RPC_HOST"
-	NoMacaroons     = "NO_MACAROONS"
-	NoTLS           = "NO_TLS"
-	TLSExtraIP      = "TLS_EXTRA_IP"
-	TLSExtraDomain  = "TLS_EXTRA_DOMAIN"
+	BitcoindRpcPass  = "BITCOIND_RPC_PASS"
+	BitcoindRpcHost  = "BITCOIND_RPC_HOST"
+	NoMacaroons      = "NO_MACAROONS"
+	NoTLS            = "NO_TLS"
+	TLSExtraIP       = "TLS_EXTRA_IP"
+	TLSExtraDomain   = "TLS_EXTRA_DOMAIN"
+	UnlockerType     = "UNLOCKER_TYPE"
+	UnlockerFilePath = "UNLOCKER_FILE_PATH"
 
 	defaultDatadir               = common.AppDataDir("arkd", false)
 	defaultRoundInterval         = 5
@@ -142,6 +146,8 @@ func LoadConfig() (*Config, error) {
 		NoMacaroons:           viper.GetBool(NoMacaroons),
 		TLSExtraIPs:           viper.GetStringSlice(TLSExtraIP),
 		TLSExtraDomains:       viper.GetStringSlice(TLSExtraDomain),
+		UnlockerType:          viper.GetString(UnlockerType),
+		UnlockerFilePath:      viper.GetString(UnlockerFilePath),
 	}, nil
 }
 

--- a/server/internal/core/ports/unlocker.go
+++ b/server/internal/core/ports/unlocker.go
@@ -1,0 +1,7 @@
+package ports
+
+import "context"
+
+type Unlocker interface {
+	GetPassword(ctx context.Context) (string, error)
+}

--- a/server/internal/infrastructure/unlocker/file/service.go
+++ b/server/internal/infrastructure/unlocker/file/service.go
@@ -1,0 +1,33 @@
+package fileunlocker
+
+import (
+	"bytes"
+	"context"
+	"os"
+
+	"github.com/ark-network/ark/server/internal/core/ports"
+)
+
+type service struct {
+	filePath string
+}
+
+func NewService(filePath string) (ports.Unlocker, error) {
+	if _, err := os.Stat(filePath); err != nil {
+		return nil, err
+	}
+	return &service{filePath: filePath}, nil
+}
+
+func (s *service) GetPassword(_ context.Context) (string, error) {
+	buf, err := os.ReadFile(s.filePath)
+	if err != nil {
+		return "", err
+	}
+
+	password := bytes.TrimFunc(buf, func(r rune) bool {
+		return r == 10 || r == 13 || r == 32
+	})
+
+	return string(password), nil
+}

--- a/server/internal/infrastructure/unlocker/file/service.go
+++ b/server/internal/infrastructure/unlocker/file/service.go
@@ -3,6 +3,7 @@ package fileunlocker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/ark-network/ark/server/internal/core/ports"
@@ -14,6 +15,9 @@ type service struct {
 
 func NewService(filePath string) (ports.Unlocker, error) {
 	if _, err := os.Stat(filePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("password file not found at path %s", filePath)
+		}
 		return nil, err
 	}
 	return &service{filePath: filePath}, nil

--- a/server/internal/infrastructure/wallet/btc-embedded/wallet.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/wallet.go
@@ -304,6 +304,10 @@ func (s *service) Restore(_ context.Context, seed, password string) error {
 }
 
 func (s *service) Unlock(_ context.Context, password string) error {
+	if !s.walletInitialized() {
+		return fmt.Errorf("wallet not initialized")
+	}
+
 	if !s.walletLoaded() {
 		pwd := []byte(password)
 		opt := btcwallet.LoaderWithLocalWalletDB(s.cfg.Datadir, false, time.Minute)

--- a/server/internal/interface/grpc/service.go
+++ b/server/internal/interface/grpc/service.go
@@ -323,9 +323,17 @@ func (s *service) onInit(password string) {
 func (s *service) autoUnlock() error {
 	ctx := context.Background()
 	wallet := s.appConfig.WalletService()
-	unlocker := s.appConfig.UnlockerService()
 
-	password, err := unlocker.GetPassword(ctx)
+	status, err := wallet.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get wallet status: %s", err)
+	}
+	if !status.IsInitialized() {
+		log.Debug("wallet not initiialized, skipping auto unlock")
+		return nil
+	}
+
+	password, err := s.appConfig.UnlockerService().GetPassword(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get password: %s", err)
 	}


### PR DESCRIPTION
This adds the auto unlocking feature.

The unlocker can be configured to source the password from anywhere, like for example an S3 bucket or a simple file. For now only a "file based" unlocker is available, but later we can add as many as we want.
For this, the server now has a new env vars `ARK_UNLOCKER_TYPE` to specify the unlocker type to use, and a `ARK_UNLOCKER_FILE_PATH` to specify the path of the file containing the password for the file based unlocker.

If the asp is not initialized, the auto unlock is simply skipped even if configured, the wallet must be unlocked manually after creation and the unlocking will work as expected from the next restart.

Closes #335.

Please @louisinger review.