### PR TITLE
fix: make VTXO scripts miniscript compatible

### DIFF
--- a/common/bitcointree/script.go
+++ b/common/bitcointree/script.go
@@ -103,7 +103,7 @@ func (d *CSVSigClosure) Leaf() (*txscript.TapLeaf, error) {
 
 func (d *CSVSigClosure) Decode(script []byte) (bool, error) {
 	csvIndex := bytes.Index(
-		script, []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP},
+		script, []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_VERIFY},
 	)
 	if csvIndex == -1 || csvIndex == 0 {
 		return false, nil
@@ -174,7 +174,7 @@ func encodeCsvScript(seconds uint) ([]byte, error) {
 		AddInt64(int64(sequence)).
 		AddOps([]byte{
 			txscript.OP_CHECKSEQUENCEVERIFY,
-			txscript.OP_DROP,
+			txscript.OP_VERIFY,
 		}).
 		Script()
 }

--- a/common/descriptor/expression.go
+++ b/common/descriptor/expression.go
@@ -139,7 +139,7 @@ func (e *Older) Script(bool) (string, error) {
 		AddInt64(int64(sequence)).
 		AddOps([]byte{
 			txscript.OP_CHECKSEQUENCEVERIFY,
-			txscript.OP_DROP,
+			txscript.OP_VERIFY,
 		}).
 		Script()
 	if err != nil {

--- a/common/tree/script.go
+++ b/common/tree/script.go
@@ -124,7 +124,7 @@ func (d *CSVSigClosure) Leaf() (*taproot.TapElementsLeaf, error) {
 
 func (d *CSVSigClosure) Decode(script []byte) (bool, error) {
 	csvIndex := bytes.Index(
-		script, []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP},
+		script, []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_VERIFY},
 	)
 	if csvIndex == -1 || csvIndex == 0 {
 		return false, nil
@@ -381,7 +381,7 @@ func encodeCsvScript(seconds uint) ([]byte, error) {
 		AddInt64(int64(sequence)).
 		AddOps([]byte{
 			txscript.OP_CHECKSEQUENCEVERIFY,
-			txscript.OP_DROP,
+			txscript.OP_VERIFY,
 		}).
 		Script()
 }


### PR DESCRIPTION
miniscript uses `OP_CSV OP_VERIFY` instead of `OP_CSV OP_DROP`. This seems to be a miniscript specific rule. I couldn't find the exact reason for this. The only documentation was [this comment](https://arklabshq.slack.com/archives/C07TWFTS4P9/p1730886013553069?thread_ts=1730866846.191849&cid=C07TWFTS4P9). With this change we were able to make the asp compatible with the following miniscript on the client side: `tr(UNSPENDABLE_KEY,{and_v(v:pk(ASP),pk(USER_1)),and_v(v:older(TIMEOUT),pk(USER_0))})`

BREAKING CHANGE: `OP_VERIFY` is now used instead of `OP_DROP` in all VTXO scripts.