### PR TITLE
Hotfix bct embedded wallet w/ ZMQ

### DIFF
--- a/server/internal/infrastructure/wallet/btc-embedded/wallet.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/wallet.go
@@ -226,7 +226,7 @@ func WithPollingBitcoind(host, user, pass string) WalletOption {
 				User: bitcoindConfig.User,
 				Pass: bitcoindConfig.Pass,
 			},
-			"CONSERVATIVE",
+			"ECONOMICAL",
 			chainfee.AbsoluteFeePerKwFloor,
 		)
 		if err != nil {
@@ -304,7 +304,7 @@ func WithBitcoindZMQ(block, tx string, host, user, pass string) WalletOption {
 				User: bitcoindConfig.User,
 				Pass: bitcoindConfig.Pass,
 			},
-			"CONSERVATIVE",
+			"ECONOMICAL",
 			chainfee.AbsoluteFeePerKwFloor,
 		)
 		if err != nil {


### PR DESCRIPTION
This solves the error when unlocking the btc wallet connected via ZMQ to `bitcoind`.

Please @louisinger @tiero review.