### PR TITLE
[Server] Round repo light APIs

### DIFF
--- a/server/internal/core/application/admin.go
+++ b/server/internal/core/application/admin.go
@@ -125,14 +125,19 @@ func (a *adminService) GetRounds(ctx context.Context, after int64, before int64)
 }
 
 func (a *adminService) GetScheduledSweeps(ctx context.Context) ([]ScheduledSweep, error) {
-	sweepableRounds, err := a.repoManager.Rounds().GetSweepableRounds(ctx)
+	sweepableRounds, err := a.repoManager.Rounds().GetExpiredRoundsTxid(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	scheduledSweeps := make([]ScheduledSweep, 0, len(sweepableRounds))
 
-	for _, round := range sweepableRounds {
+	for _, txid := range sweepableRounds {
+		round, err := a.repoManager.Rounds().GetRoundWithTxid(ctx, txid)
+		if err != nil {
+			return nil, err
+		}
+
 		sweepable, err := findSweepableOutputs(
 			ctx, a.walletSvc, a.txBuilder, a.sweeperTimeUnit, round.VtxoTree,
 		)

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1052,7 +1052,7 @@ func (s *covenantlessService) startFinalization() {
 		return
 	}
 
-	sweptRounds, err := s.repoManager.Rounds().GetSweptRounds(ctx)
+	connectorAddresses, err := s.repoManager.Rounds().GetSweptRoundsConnectorAddress(ctx)
 	if err != nil {
 		round.Fail(fmt.Errorf("failed to retrieve swept rounds: %s", err))
 		log.WithError(err).Warn("failed to retrieve swept rounds")
@@ -1069,11 +1069,7 @@ func (s *covenantlessService) startFinalization() {
 	cosigners = append(cosigners, ephemeralKey.PubKey())
 
 	unsignedRoundTx, vtxoTree, connectorAddress, connectors, err := s.builder.BuildRoundTx(
-		s.pubkey,
-		requests,
-		boardingInputs,
-		sweptRounds,
-		cosigners...,
+		s.pubkey, requests, boardingInputs, connectorAddresses, cosigners...,
 	)
 	if err != nil {
 		round.Fail(fmt.Errorf("failed to create round tx: %s", err))
@@ -1665,19 +1661,18 @@ func (s *covenantlessService) stopWatchingVtxos(vtxos []domain.Vtxo) {
 }
 
 func (s *covenantlessService) restoreWatchingVtxos() error {
-	sweepableRounds, err := s.repoManager.Rounds().GetSweepableRounds(context.Background())
+	ctx := context.Background()
+
+	expiredRounds, err := s.repoManager.Rounds().GetExpiredRoundsTxid(ctx)
 	if err != nil {
 		return err
 	}
 
 	vtxos := make([]domain.Vtxo, 0)
-
-	for _, round := range sweepableRounds {
-		fromRound, err := s.repoManager.Vtxos().GetVtxosForRound(
-			context.Background(), round.Txid,
-		)
+	for _, txid := range expiredRounds {
+		fromRound, err := s.repoManager.Vtxos().GetVtxosForRound(ctx, txid)
 		if err != nil {
-			log.WithError(err).Warnf("failed to retrieve vtxos for round %s", round.Txid)
+			log.WithError(err).Warnf("failed to retrieve vtxos for round %s", txid)
 			continue
 		}
 		for _, v := range fromRound {

--- a/server/internal/core/application/sweeper.go
+++ b/server/internal/core/application/sweeper.go
@@ -52,12 +52,19 @@ func newSweeper(
 func (s *sweeper) start() error {
 	s.scheduler.Start()
 
-	allRounds, err := s.repoManager.Rounds().GetSweepableRounds(context.Background())
+	ctx := context.Background()
+
+	expiredRounds, err := s.repoManager.Rounds().GetExpiredRoundsTxid(ctx)
 	if err != nil {
 		return err
 	}
 
-	for _, round := range allRounds {
+	for _, txid := range expiredRounds {
+		round, err := s.repoManager.Rounds().GetRoundWithTxid(ctx, txid)
+		if err != nil {
+			return err
+		}
+
 		task := s.createTask(round.Txid, round.VtxoTree)
 		task()
 	}

--- a/server/internal/core/domain/round_repo.go
+++ b/server/internal/core/domain/round_repo.go
@@ -15,9 +15,9 @@ type RoundRepository interface {
 	AddOrUpdateRound(ctx context.Context, round Round) error
 	GetRoundWithId(ctx context.Context, id string) (*Round, error)
 	GetRoundWithTxid(ctx context.Context, txid string) (*Round, error)
-	GetSweepableRounds(ctx context.Context) ([]Round, error)
+	GetExpiredRoundsTxid(ctx context.Context) ([]string, error)
 	GetRoundsIds(ctx context.Context, startedAfter int64, startedBefore int64) ([]string, error)
-	GetSweptRounds(ctx context.Context) ([]Round, error)
+	GetSweptRoundsConnectorAddress(ctx context.Context) ([]string, error)
 	Close()
 }
 

--- a/server/internal/core/ports/tx_builder.go
+++ b/server/internal/core/ports/tx_builder.go
@@ -28,11 +28,14 @@ type BoardingInput struct {
 }
 
 type TxBuilder interface {
-	// BuildRoundTx builds a round tx for the given tx requests, boarding inputs
-	// it selects coin from swept rounds and server wallet
-	// returns the round partial tx, the vtxo tree and the set of connectors
+	// BuildRoundTx builds a round tx for the given offchain and boarding tx
+	// requests. It expects an optional list of connector addresses of expired
+	// rounds from which selecting UTXOs as inputs of the transaction.
+	// Returns the round tx, the VTXO tree, the connector chain and its root
+	// address.
 	BuildRoundTx(
-		serverPubkey *secp256k1.PublicKey, txRequests []domain.TxRequest, boardingInputs []BoardingInput, sweptRounds []domain.Round,
+		serverPubkey *secp256k1.PublicKey, txRequests []domain.TxRequest,
+		boardingInputs []BoardingInput, connectorAddresses []string,
 		cosigners ...*secp256k1.PublicKey,
 	) (
 		roundTx string,
@@ -41,11 +44,10 @@ type TxBuilder interface {
 		connectors []string,
 		err error,
 	)
-	// VerifyForfeitTxs verifies the given forfeit txs for the given vtxos and connectors
+	// VerifyForfeitTxs verifies a list of forfeit txs against a set of VTXOs and
+	// connectors.
 	VerifyForfeitTxs(
-		vtxos []domain.Vtxo,
-		connectors []string,
-		txs []string,
+		vtxos []domain.Vtxo, connectors []string, txs []string,
 	) (valid map[domain.VtxoKey][]string, err error)
 	BuildSweepTx(inputs []SweepInput) (signedSweepTx string, err error)
 	GetSweepInput(node tree.Node) (lifetime *common.Locktime, sweepInput SweepInput, err error)

--- a/server/internal/infrastructure/db/badger/round_repo.go
+++ b/server/internal/infrastructure/db/badger/round_repo.go
@@ -80,18 +80,38 @@ func (r *roundRepository) GetRoundWithTxid(
 	return round, nil
 }
 
-func (r *roundRepository) GetSweepableRounds(
+func (r *roundRepository) GetExpiredRoundsTxid(
 	ctx context.Context,
-) ([]domain.Round, error) {
+) ([]string, error) {
 	query := badgerhold.Where("Stage.Code").Eq(domain.FinalizationStage).
 		And("Stage.Ended").Eq(true).And("Swept").Eq(false)
-	return r.findRound(ctx, query)
+	rounds, err := r.findRound(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	txids := make([]string, 0, len(rounds))
+	for _, r := range rounds {
+		txids = append(txids, r.Txid)
+	}
+	return txids, nil
 }
 
-func (r *roundRepository) GetSweptRounds(ctx context.Context) ([]domain.Round, error) {
+func (r *roundRepository) GetSweptRoundsConnectorAddress(
+	ctx context.Context,
+) ([]string, error) {
 	query := badgerhold.Where("Stage.Code").Eq(domain.FinalizationStage).
 		And("Stage.Ended").Eq(true).And("Swept").Eq(true).And("ConnectorAddress").Ne("")
-	return r.findRound(ctx, query)
+	rounds, err := r.findRound(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	txids := make([]string, 0, len(rounds))
+	for _, r := range rounds {
+		txids = append(txids, r.Txid)
+	}
+	return txids, nil
 }
 
 func (r *roundRepository) GetRoundsIds(ctx context.Context, startedAfter int64, startedBefore int64) ([]string, error) {

--- a/server/internal/infrastructure/db/sqlite/round_repo.go
+++ b/server/internal/infrastructure/db/sqlite/round_repo.go
@@ -262,66 +262,12 @@ func (r *roundRepository) GetRoundWithTxid(ctx context.Context, txid string) (*d
 	return nil, errors.New("round not found")
 }
 
-func (r *roundRepository) GetSweepableRounds(ctx context.Context) ([]domain.Round, error) {
-	rows, err := r.querier.SelectSweepableRounds(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	rvs := make([]combinedRow, 0, len(rows))
-	for _, row := range rows {
-		rvs = append(rvs, combinedRow{
-			round:    row.Round,
-			request:  row.RoundRequestVw,
-			tx:       row.RoundTxVw,
-			receiver: row.RequestReceiverVw,
-			vtxo:     row.RequestVtxoVw,
-		})
-	}
-
-	rounds, err := rowsToRounds(rvs)
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]domain.Round, 0)
-
-	for _, round := range rounds {
-		res = append(res, *round)
-	}
-
-	return res, nil
+func (r *roundRepository) GetExpiredRoundsTxid(ctx context.Context) ([]string, error) {
+	return r.querier.SelectExpiredRoundsTxid(ctx)
 }
 
-func (r *roundRepository) GetSweptRounds(ctx context.Context) ([]domain.Round, error) {
-	rows, err := r.querier.SelectSweptRounds(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	rvs := make([]combinedRow, 0, len(rows))
-	for _, row := range rows {
-		rvs = append(rvs, combinedRow{
-			round:    row.Round,
-			request:  row.RoundRequestVw,
-			tx:       row.RoundTxVw,
-			receiver: row.RequestReceiverVw,
-			vtxo:     row.RequestVtxoVw,
-		})
-	}
-
-	rounds, err := rowsToRounds(rvs)
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]domain.Round, 0)
-
-	for _, round := range rounds {
-		res = append(res, *round)
-	}
-
-	return res, nil
+func (r *roundRepository) GetSweptRoundsConnectorAddress(ctx context.Context) ([]string, error) {
+	return r.querier.SelectSweptRoundsConnectorAddress(ctx)
 }
 
 func rowToReceiver(row queries.RequestReceiverVw) domain.Receiver {

--- a/server/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/server/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -79,30 +79,12 @@ FROM round
          LEFT OUTER JOIN request_vtxo_vw ON round_request_vw.id=request_vtxo_vw.request_id
 WHERE round.txid = ?;
 
--- name: SelectSweepableRounds :many
-SELECT sqlc.embed(round),
-       sqlc.embed(round_request_vw),
-       sqlc.embed(round_tx_vw),
-       sqlc.embed(request_receiver_vw),
-       sqlc.embed(request_vtxo_vw)
-FROM round
-         LEFT OUTER JOIN round_request_vw ON round.id=round_request_vw.round_id
-         LEFT OUTER JOIN round_tx_vw ON round.id=round_tx_vw.round_id
-         LEFT OUTER JOIN request_receiver_vw ON round_request_vw.id=request_receiver_vw.request_id
-         LEFT OUTER JOIN request_vtxo_vw ON round_request_vw.id=request_vtxo_vw.request_id
+-- name: SelectExpiredRoundsTxid :many
+SELECT round.txid FROM round
 WHERE round.swept = false AND round.ended = true AND round.failed = false;
 
--- name: SelectSweptRounds :many
-SELECT sqlc.embed(round),
-       sqlc.embed(round_request_vw),
-       sqlc.embed(round_tx_vw),
-       sqlc.embed(request_receiver_vw),
-       sqlc.embed(request_vtxo_vw)
-FROM round
-         LEFT OUTER JOIN round_request_vw ON round.id=round_request_vw.round_id
-         LEFT OUTER JOIN round_tx_vw ON round.id=round_tx_vw.round_id
-         LEFT OUTER JOIN request_receiver_vw ON round_request_vw.id=request_receiver_vw.request_id
-         LEFT OUTER JOIN request_vtxo_vw ON round_request_vw.id=request_vtxo_vw.request_id
+-- name: SelectSweptRoundsConnectorAddress :many
+SELECT round.connector_address FROM round
 WHERE round.swept = true AND round.failed = false AND round.ended = true AND round.connector_address <> '';
 
 -- name: SelectRoundIdsInRange :many

--- a/server/internal/infrastructure/tx-builder/covenant/builder_test.go
+++ b/server/internal/infrastructure/tx-builder/covenant/builder_test.go
@@ -67,7 +67,7 @@ func TestBuildRoundTx(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
 			for _, f := range fixtures.Valid {
 				roundTx, vtxoTree, connAddr, _, err := builder.BuildRoundTx(
-					pubkey, f.Requests, []ports.BoardingInput{}, []domain.Round{},
+					pubkey, f.Requests, []ports.BoardingInput{}, []string{},
 				)
 				require.NoError(t, err)
 				require.NotEmpty(t, roundTx)
@@ -88,7 +88,7 @@ func TestBuildRoundTx(t *testing.T) {
 		t.Run("invalid", func(t *testing.T) {
 			for _, f := range fixtures.Invalid {
 				roundTx, vtxoTree, connAddr, _, err := builder.BuildRoundTx(
-					pubkey, f.Requests, []ports.BoardingInput{}, []domain.Round{},
+					pubkey, f.Requests, []ports.BoardingInput{}, []string{},
 				)
 				require.EqualError(t, err, f.ExpectedErr)
 				require.Empty(t, roundTx)

--- a/server/internal/infrastructure/tx-builder/covenant/coinselection.go
+++ b/server/internal/infrastructure/tx-builder/covenant/coinselection.go
@@ -3,19 +3,20 @@ package txbuilder
 import (
 	"context"
 
-	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/ark-network/ark/server/internal/core/ports"
 )
 
-func (b *txBuilder) selectUtxos(ctx context.Context, sweptRounds []domain.Round, amount uint64) ([]ports.TxInput, uint64, error) {
+func (b *txBuilder) selectUtxos(
+	ctx context.Context, connectorAddresses []string, amount uint64,
+) ([]ports.TxInput, uint64, error) {
 	selectedConnectorsUtxos := make([]ports.TxInput, 0)
 	selectedConnectorsAmount := uint64(0)
 
-	for _, round := range sweptRounds {
+	for _, addr := range connectorAddresses {
 		if selectedConnectorsAmount >= amount {
 			break
 		}
-		connectors, err := b.wallet.ListConnectorUtxos(ctx, round.ConnectorAddress)
+		connectors, err := b.wallet.ListConnectorUtxos(ctx, addr)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/server/internal/infrastructure/tx-builder/covenantless/builder_test.go
+++ b/server/internal/infrastructure/tx-builder/covenantless/builder_test.go
@@ -77,7 +77,7 @@ func TestBuildRoundTx(t *testing.T) {
 				}
 
 				roundTx, vtxoTree, connAddr, _, err := builder.BuildRoundTx(
-					pubkey, f.Requests, []ports.BoardingInput{}, []domain.Round{}, cosigners...,
+					pubkey, f.Requests, []ports.BoardingInput{}, []string{}, cosigners...,
 				)
 				require.NoError(t, err)
 				require.NotEmpty(t, roundTx)
@@ -98,7 +98,7 @@ func TestBuildRoundTx(t *testing.T) {
 		t.Run("invalid", func(t *testing.T) {
 			for _, f := range fixtures.Invalid {
 				roundTx, vtxoTree, connAddr, _, err := builder.BuildRoundTx(
-					pubkey, f.Requests, []ports.BoardingInput{}, []domain.Round{},
+					pubkey, f.Requests, []ports.BoardingInput{}, []string{},
 				)
 				require.EqualError(t, err, f.ExpectedErr)
 				require.Empty(t, roundTx)


### PR DESCRIPTION
These changes propose a lighter version of some round repo APIs. The problem with the existing APIs is that they return all rounds data but in the end, only specific fields are used at app level.
The query used in the sqlite db to implement such APIs can lead to memory spikes in case it's a very a large one.

The solution proposed here is to change the round APIs so that they return exactly what is needed by the app svc.

Please @louisinger @sekulicd review this.