### PR TITLE
[SDK] Make grpc client support `http://`-prefixed server url

### DIFF
--- a/pkg/client-sdk/client/grpc/client.go
+++ b/pkg/client-sdk/client/grpc/client.go
@@ -31,8 +31,9 @@ func NewClient(serverUrl string) (client.TransportClient, error) {
 		return nil, fmt.Errorf("missing server url")
 	}
 
-	creds := insecure.NewCredentials()
 	port := 80
+	creds := insecure.NewCredentials()
+	serverUrl = strings.TrimPrefix(serverUrl, "http://")
 	if strings.HasPrefix(serverUrl, "https://") {
 		serverUrl = strings.TrimPrefix(serverUrl, "https://")
 		creds = credentials.NewTLS(nil)


### PR DESCRIPTION
This makes the grpc client of the client SDK support server URLs with `http://` prefix just like it supports the `https://` one.

Please @tiero review.