### PR TITLE
Add action to check REST client built from swagger

### DIFF
--- a/.github/workflows/ark.autogen_client.yaml
+++ b/.github/workflows/ark.autogen_client.yaml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Compare Generated Client
       run: |
-        if ! diff -r path/to/client-folder temp_client; then
+        if ! diff -r client/rest/service tmp; then
           echo "Generated client differs from the committed version."
           echo "Please run 'make genrest' locally and commit the changes."
           exit 1

--- a/.github/workflows/ark.autogen_client.yaml
+++ b/.github/workflows/ark.autogen_client.yaml
@@ -1,0 +1,43 @@
+name: Verify SDK Autogen REST Client
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  verify-client:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '>=1.23.1'
+
+    - name: Run go work sync
+      run: go work sync
+
+    - name: Install Swagger
+      run: |
+        go install github.com/go-swagger/go-swagger/cmd/swagger@latest
+
+    - name: Generate Client
+      run: |
+        cd pkg/client-sdk
+        mkdir -p tmp
+        REST_DIR=tmp make genrest
+
+    - name: Compare Generated Client
+      run: |
+        if ! diff -r path/to/client-folder temp_client; then
+          echo "Generated client differs from the committed version."
+          echo "Please run 'make genrest' locally and commit the changes."
+          exit 1
+        fi
+
+    - name: Clean up
+      run: rm -rf temp_client

--- a/.github/workflows/ark.autogen_client.yaml
+++ b/.github/workflows/ark.autogen_client.yaml
@@ -22,23 +22,20 @@ jobs:
       run: go work sync
 
     - name: Install Swagger
-      run: |
-        go install github.com/go-swagger/go-swagger/cmd/swagger@latest
+      run: go install github.com/go-swagger/go-swagger/cmd/swagger@latest
 
     - name: Generate Client
       working-directory: pkg/client-sdk
-      run: |
-        REST_DIR=tmp make genrest
+      run: make genrest
 
-    - name: Compare Generated Client
-      working-directory: pkg/client-sdk
+    - name: Check for uncommitted changes
       run: |
-        if ! diff -r client/rest/service tmp; then
-          echo "Generated client differs from the committed version."
-          echo "Please run 'make genrest' locally and commit the changes."
-          exit 1
-        fi
+        git add .
+        git diff --staged --exit-code
 
-    - name: Clean up
-      working-directory: pkg/client-sdk
-      run: rm -rf tmp
+    - name: Fail if changes detected
+      if: failure()
+      run: |
+        echo "❌ Generated client is out of date!"
+        echo "Please run 'make genrest' and commit the changes."
+        exit 1

--- a/.github/workflows/ark.autogen_client.yaml
+++ b/.github/workflows/ark.autogen_client.yaml
@@ -2,9 +2,15 @@ name: Verify SDK Autogen REST Client
 
 on:
   push:
-    branches: [ "*" ]
+    branches: 
+      - master
+    paths:
+      - "api-spec/**"
   pull_request:
-    branches: [ "*" ]
+    branches:
+      - master
+    paths:
+      - "api-spec/**"
 
 jobs:
   verify-client:

--- a/.github/workflows/ark.autogen_client.yaml
+++ b/.github/workflows/ark.autogen_client.yaml
@@ -26,12 +26,12 @@ jobs:
         go install github.com/go-swagger/go-swagger/cmd/swagger@latest
 
     - name: Generate Client
+      working-directory: pkg/client-sdk
       run: |
-        cd pkg/client-sdk
-        mkdir -p tmp
         REST_DIR=tmp make genrest
 
     - name: Compare Generated Client
+      working-directory: pkg/client-sdk
       run: |
         if ! diff -r client/rest/service tmp; then
           echo "Generated client differs from the committed version."
@@ -40,4 +40,5 @@ jobs:
         fi
 
     - name: Clean up
-      run: rm -rf temp_client
+      working-directory: pkg/client-sdk
+      run: rm -rf tmp

--- a/pkg/client-sdk/Makefile
+++ b/pkg/client-sdk/Makefile
@@ -1,14 +1,14 @@
 .PHONY: genrest test vet lint prepare-wasm-test
 
-REST_DIR = $(PWD)/client/rest/service
+client_dir = $(or $(REST_DIR),$(PWD)/client/rest/service)
 
 ## genrest: compiles rest client from stub with https://github.com/go-swagger/go-swagger
 genrest:
 	@echo "Cleaning existing files..."
-	@rm -rf $(REST_DIR)
+	@rm -rf $(client_dir)
 	@echo "Generating rest client from stub..."
-	@mkdir -p $(REST_DIR)
-	@swagger generate client -f ../../api-spec/openapi/swagger/ark/v1/service.swagger.json -t $(REST_DIR) --client-package=arkservice
+	@mkdir -p $(client_dir)
+	@swagger generate client -f ../../api-spec/openapi/swagger/ark/v1/service.swagger.json -t $(client_dir) --client-package=arkservice
 
 ## test: runs unit tests
 test:


### PR DESCRIPTION
This adds a new github action to ensure the client generated from swagger is up-to-date.

NOTE: the action is triggered if api-spec/ contains changes, so it's not expected to be executed by this pr. 

Closes #315 

Please @louisinger @sekulicd review