### PR TITLE
add `RoundRepository.GetVtxoTreeWithTxid` method

### DIFF
--- a/server/internal/core/application/sweeper.go
+++ b/server/internal/core/application/sweeper.go
@@ -65,7 +65,7 @@ func (s *sweeper) start() error {
 			return err
 		}
 
-		task := s.createTask(txid, *vtxoTree)
+		task := s.createTask(txid, vtxoTree)
 		task()
 	}
 

--- a/server/internal/core/application/sweeper.go
+++ b/server/internal/core/application/sweeper.go
@@ -60,12 +60,12 @@ func (s *sweeper) start() error {
 	}
 
 	for _, txid := range expiredRounds {
-		round, err := s.repoManager.Rounds().GetRoundWithTxid(ctx, txid)
+		vtxoTree, err := s.repoManager.Rounds().GetVtxoTreeWithTxid(ctx, txid)
 		if err != nil {
 			return err
 		}
 
-		task := s.createTask(round.Txid, round.VtxoTree)
+		task := s.createTask(txid, *vtxoTree)
 		task()
 	}
 

--- a/server/internal/core/domain/round_repo.go
+++ b/server/internal/core/domain/round_repo.go
@@ -17,7 +17,7 @@ type RoundRepository interface {
 	AddOrUpdateRound(ctx context.Context, round Round) error
 	GetRoundWithId(ctx context.Context, id string) (*Round, error)
 	GetRoundWithTxid(ctx context.Context, txid string) (*Round, error)
-	GetVtxoTreeWithTxid(ctx context.Context, txid string) (*tree.VtxoTree, error)
+	GetVtxoTreeWithTxid(ctx context.Context, txid string) (tree.VtxoTree, error)
 	GetExpiredRoundsTxid(ctx context.Context) ([]string, error)
 	GetRoundsIds(ctx context.Context, startedAfter int64, startedBefore int64) ([]string, error)
 	GetSweptRoundsConnectorAddress(ctx context.Context) ([]string, error)

--- a/server/internal/core/domain/round_repo.go
+++ b/server/internal/core/domain/round_repo.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"context"
+
+	"github.com/ark-network/ark/common/tree"
 )
 
 type RoundEventRepository interface {
@@ -15,6 +17,7 @@ type RoundRepository interface {
 	AddOrUpdateRound(ctx context.Context, round Round) error
 	GetRoundWithId(ctx context.Context, id string) (*Round, error)
 	GetRoundWithTxid(ctx context.Context, txid string) (*Round, error)
+	GetVtxoTreeWithTxid(ctx context.Context, txid string) (*tree.VtxoTree, error)
 	GetExpiredRoundsTxid(ctx context.Context) ([]string, error)
 	GetRoundsIds(ctx context.Context, startedAfter int64, startedBefore int64) ([]string, error)
 	GetSweptRoundsConnectorAddress(ctx context.Context) ([]string, error)

--- a/server/internal/infrastructure/db/badger/round_repo.go
+++ b/server/internal/infrastructure/db/badger/round_repo.go
@@ -141,12 +141,12 @@ func (r *roundRepository) GetRoundsIds(ctx context.Context, startedAfter int64, 
 
 func (r *roundRepository) GetVtxoTreeWithTxid(
 	ctx context.Context, txid string,
-) (*tree.VtxoTree, error) {
+) (tree.VtxoTree, error) {
 	round, err := r.GetRoundWithTxid(ctx, txid)
 	if err != nil {
 		return nil, err
 	}
-	return &round.VtxoTree, nil
+	return round.VtxoTree, nil
 }
 
 func (r *roundRepository) Close() {

--- a/server/internal/infrastructure/db/badger/round_repo.go
+++ b/server/internal/infrastructure/db/badger/round_repo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/ark-network/ark/common/tree"
 	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/dgraph-io/badger/v4"
 	"github.com/timshannon/badgerhold/v4"
@@ -136,6 +137,16 @@ func (r *roundRepository) GetRoundsIds(ctx context.Context, startedAfter int64, 
 	}
 
 	return ids, nil
+}
+
+func (r *roundRepository) GetVtxoTreeWithTxid(
+	ctx context.Context, txid string,
+) (*tree.VtxoTree, error) {
+	round, err := r.GetRoundWithTxid(ctx, txid)
+	if err != nil {
+		return nil, err
+	}
+	return &round.VtxoTree, nil
 }
 
 func (r *roundRepository) Close() {

--- a/server/internal/infrastructure/db/service_test.go
+++ b/server/internal/infrastructure/db/service_test.go
@@ -329,6 +329,11 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		require.NotNil(t, roundById)
 		require.Condition(t, roundsMatch(*finalizedRound, *roundById))
 
+		resultTree, err := svc.Rounds().GetVtxoTreeWithTxid(ctx, txid)
+		require.NoError(t, err)
+		require.NotNil(t, resultTree)
+		require.Equal(t, finalizedRound.VtxoTree, *resultTree)
+
 		roundByTxid, err := svc.Rounds().GetRoundWithTxid(ctx, txid)
 		require.NoError(t, err)
 		require.NotNil(t, roundByTxid)

--- a/server/internal/infrastructure/db/service_test.go
+++ b/server/internal/infrastructure/db/service_test.go
@@ -332,7 +332,7 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		resultTree, err := svc.Rounds().GetVtxoTreeWithTxid(ctx, txid)
 		require.NoError(t, err)
 		require.NotNil(t, resultTree)
-		require.Equal(t, finalizedRound.VtxoTree, *resultTree)
+		require.Equal(t, finalizedRound.VtxoTree, resultTree)
 
 		roundByTxid, err := svc.Rounds().GetRoundWithTxid(ctx, txid)
 		require.NoError(t, err)

--- a/server/internal/infrastructure/db/sqlite/round_repo.go
+++ b/server/internal/infrastructure/db/sqlite/round_repo.go
@@ -270,7 +270,7 @@ func (r *roundRepository) GetSweptRoundsConnectorAddress(ctx context.Context) ([
 	return r.querier.SelectSweptRoundsConnectorAddress(ctx)
 }
 
-func (r *roundRepository) GetVtxoTreeWithTxid(ctx context.Context, txid string) (*tree.VtxoTree, error) {
+func (r *roundRepository) GetVtxoTreeWithTxid(ctx context.Context, txid string) (tree.VtxoTree, error) {
 	rows, err := r.querier.SelectTreeTxsWithRoundTxid(ctx, txid)
 	if err != nil {
 		return nil, err
@@ -292,7 +292,7 @@ func (r *roundRepository) GetVtxoTreeWithTxid(ctx context.Context, txid string) 
 		}
 	}
 
-	return &vtxoTree, nil
+	return vtxoTree, nil
 }
 
 func rowToReceiver(row queries.RequestReceiverVw) domain.Receiver {

--- a/server/internal/infrastructure/db/sqlite/round_repo.go
+++ b/server/internal/infrastructure/db/sqlite/round_repo.go
@@ -270,6 +270,31 @@ func (r *roundRepository) GetSweptRoundsConnectorAddress(ctx context.Context) ([
 	return r.querier.SelectSweptRoundsConnectorAddress(ctx)
 }
 
+func (r *roundRepository) GetVtxoTreeWithTxid(ctx context.Context, txid string) (*tree.VtxoTree, error) {
+	rows, err := r.querier.SelectTreeTxsWithRoundTxid(ctx, txid)
+	if err != nil {
+		return nil, err
+	}
+
+	vtxoTree := make(tree.VtxoTree, 0)
+
+	for _, tx := range rows {
+		level := tx.TreeLevel
+		vtxoTree = extendArray(vtxoTree, int(level.Int64))
+		vtxoTree[int(level.Int64)] = extendArray(vtxoTree[int(level.Int64)], int(tx.Position.Int64))
+		if vtxoTree[int(level.Int64)][tx.Position.Int64] == (tree.Node{}) {
+			vtxoTree[int(level.Int64)][tx.Position.Int64] = tree.Node{
+				Tx:         tx.Tx.String,
+				Txid:       tx.Txid.String,
+				ParentTxid: tx.ParentTxid.String,
+				Leaf:       tx.IsLeaf.Bool,
+			}
+		}
+	}
+
+	return &vtxoTree, nil
+}
+
 func rowToReceiver(row queries.RequestReceiverVw) domain.Receiver {
 	return domain.Receiver{
 		Amount:         uint64(row.Amount.Int64),

--- a/server/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/server/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -190,3 +190,8 @@ RETURNING *;
 
 -- name: GetLatestMarketHour :one
 SELECT * FROM market_hour ORDER BY updated_at DESC LIMIT 1;
+
+-- name: SelectTreeTxsWithRoundTxid :many
+SELECT tx.* FROM round
+LEFT OUTER JOIN tx ON round.id=tx.round_id
+WHERE round.txid = ? AND tx.type = 'tree'


### PR DESCRIPTION
This PR adds a more granular method `GetVtxoTreeWithTxid` in Round repository. It aims to reduce the sweeper starting time. 

@altafan please review