### PR TITLE
[Server] Embed migrations & Drop related env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,10 @@ RUN apk update && apk upgrade
 WORKDIR /app
 
 COPY --from=builder /app/bin/* /app/
-COPY --from=builder /app/server/internal/infrastructure/db/sqlite/migration/* /app/
 
 ENV PATH="/app:${PATH}"
 ENV ARK_DATADIR=/app/data
 ENV ARK_WALLET_DATADIR=/app/wallet-data
-ENV ARK_DB_MIGRATION_PATH=file://
 
 # Expose volume containing all 'arkd' data
 VOLUME /app/data

--- a/server/cmd/arkd/main.go
+++ b/server/cmd/arkd/main.go
@@ -78,7 +78,6 @@ func mainAction(_ *cli.Context) error {
 		EventDbType:             cfg.EventDbType,
 		DbType:                  cfg.DbType,
 		DbDir:                   cfg.DbDir,
-		DbMigrationPath:         cfg.DbMigrationPath,
 		EventDbDir:              cfg.DbDir,
 		RoundInterval:           cfg.RoundInterval,
 		Network:                 cfg.Network,

--- a/server/internal/app-config/config.go
+++ b/server/internal/app-config/config.go
@@ -59,7 +59,6 @@ type Config struct {
 	DbType                  string
 	EventDbType             string
 	DbDir                   string
-	DbMigrationPath         string
 	EventDbDir              string
 	RoundInterval           int64
 	Network                 common.Network
@@ -241,7 +240,7 @@ func (c *Config) repoManager() error {
 	case "badger":
 		dataStoreConfig = []interface{}{c.DbDir, logger}
 	case "sqlite":
-		dataStoreConfig = []interface{}{c.DbDir, c.DbMigrationPath}
+		dataStoreConfig = []interface{}{c.DbDir}
 	default:
 		return fmt.Errorf("unknown db type")
 	}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -57,7 +57,6 @@ var (
 	Port                = "PORT"
 	EventDbType         = "EVENT_DB_TYPE"
 	DbType              = "DB_TYPE"
-	DbMigrationPath     = "DB_MIGRATION_PATH"
 	SchedulerType       = "SCHEDULER_TYPE"
 	TxBuilderType       = "TX_BUILDER_TYPE"
 	LogLevel            = "LOG_LEVEL"
@@ -94,7 +93,6 @@ var (
 	DefaultPort                = 7070
 	defaultDbType              = "sqlite"
 	defaultEventDbType         = "badger"
-	defaultDbMigrationPath     = "file://internal/infrastructure/db/sqlite/migration"
 	defaultSchedulerType       = "gocron"
 	defaultTxBuilderType       = "covenantless"
 	defaultNetwork             = "bitcoin"
@@ -119,7 +117,6 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault(Datadir, defaultDatadir)
 	viper.SetDefault(Port, DefaultPort)
 	viper.SetDefault(DbType, defaultDbType)
-	viper.SetDefault(DbMigrationPath, defaultDbMigrationPath)
 	viper.SetDefault(NoTLS, defaultNoTLS)
 	viper.SetDefault(LogLevel, defaultLogLevel)
 	viper.SetDefault(Network, defaultNetwork)
@@ -154,7 +151,6 @@ func LoadConfig() (*Config, error) {
 		Port:                    viper.GetUint32(Port),
 		EventDbType:             viper.GetString(EventDbType),
 		DbType:                  viper.GetString(DbType),
-		DbMigrationPath:         viper.GetString(DbMigrationPath),
 		SchedulerType:           viper.GetString(SchedulerType),
 		TxBuilderType:           viper.GetString(TxBuilderType),
 		NoTLS:                   viper.GetBool(NoTLS),

--- a/server/internal/infrastructure/db/service_test.go
+++ b/server/internal/infrastructure/db/service_test.go
@@ -96,7 +96,7 @@ func TestService(t *testing.T) {
 				EventStoreType:   "badger",
 				DataStoreType:    "sqlite",
 				EventStoreConfig: []interface{}{"", nil},
-				DataStoreConfig:  []interface{}{dbDir, "file://sqlite/migration"},
+				DataStoreConfig:  []interface{}{dbDir},
 			},
 		},
 	}


### PR DESCRIPTION
With this, the migration files for server's sqlite db are embedded so that the env var ARK_DB_MIGRATION_PATH can be dropped.

Please @louisinger @sekulicd review