### PR TITLE
add `ALLOW_ZERO_FEES` flag

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -113,6 +113,12 @@ var (
 		Name:  "amount",
 		Usage: "amount to send in sats",
 	}
+	zeroFeesFlag = &cli.BoolFlag{
+		Name:    "zero-fees",
+		Aliases: []string{"z"},
+		Usage:   "UNSAFE: allow sending offchain transactions with zero fees, disable unilateral exit",
+		Value:   false,
+	}
 	enableExpiryCoinselectFlag = &cli.BoolFlag{
 		Name:  "enable-expiry-coinselect",
 		Usage: "select VTXOs about to expire first",
@@ -200,7 +206,7 @@ var (
 		Action: func(ctx *cli.Context) error {
 			return send(ctx)
 		},
-		Flags: []cli.Flag{receiversFlag, toFlag, amountFlag, enableExpiryCoinselectFlag, passwordFlag},
+		Flags: []cli.Flag{receiversFlag, toFlag, amountFlag, enableExpiryCoinselectFlag, passwordFlag, zeroFeesFlag},
 	}
 	redeemCommand = cli.Command{
 		Name:  "redeem",
@@ -327,6 +333,7 @@ func send(ctx *cli.Context) error {
 	receiversJSON := ctx.String(receiversFlag.Name)
 	to := ctx.String(toFlag.Name)
 	amount := ctx.Uint64(amountFlag.Name)
+	zeroFees := ctx.Bool(zeroFeesFlag.Name)
 	if receiversJSON == "" && to == "" && amount == 0 {
 		return fmt.Errorf("missing destination, use --to and --amount or --receivers")
 	}
@@ -366,7 +373,7 @@ func send(ctx *cli.Context) error {
 	}
 
 	if isBitcoin {
-		return sendCovenantLess(ctx, receivers)
+		return sendCovenantLess(ctx, receivers, zeroFees)
 	}
 	return sendCovenant(ctx, receivers)
 }
@@ -526,7 +533,7 @@ func parseReceivers(receveirsJSON string, isBitcoin bool) ([]arksdk.Receiver, er
 	return receivers, nil
 }
 
-func sendCovenantLess(ctx *cli.Context, receivers []arksdk.Receiver) error {
+func sendCovenantLess(ctx *cli.Context, receivers []arksdk.Receiver, withZeroFees bool) error {
 	var onchainReceivers, offchainReceivers []arksdk.Receiver
 
 	for _, receiver := range receivers {
@@ -547,7 +554,7 @@ func sendCovenantLess(ctx *cli.Context, receivers []arksdk.Receiver) error {
 
 	computeExpiration := ctx.Bool(enableExpiryCoinselectFlag.Name)
 	redeemTx, err := arkSdkClient.SendOffChain(
-		ctx.Context, computeExpiration, offchainReceivers,
+		ctx.Context, computeExpiration, offchainReceivers, withZeroFees,
 	)
 	if err != nil {
 		return err
@@ -581,7 +588,7 @@ func sendCovenant(ctx *cli.Context, receivers []arksdk.Receiver) error {
 
 	computeExpiration := ctx.Bool(enableExpiryCoinselectFlag.Name)
 	txid, err := arkSdkClient.SendOffChain(
-		ctx.Context, computeExpiration, offchainReceivers,
+		ctx.Context, computeExpiration, offchainReceivers, false,
 	)
 	if err != nil {
 		return err

--- a/pkg/client-sdk/ark_sdk.go
+++ b/pkg/client-sdk/ark_sdk.go
@@ -19,6 +19,7 @@ type ArkClient interface {
 	SendOnChain(ctx context.Context, receivers []Receiver) (string, error)
 	SendOffChain(
 		ctx context.Context, withExpiryCoinselect bool, receivers []Receiver,
+		withZeroFees bool,
 	) (string, error)
 	UnilateralRedeem(ctx context.Context) error
 	CollaborativeRedeem(

--- a/pkg/client-sdk/covenant_client.go
+++ b/pkg/client-sdk/covenant_client.go
@@ -420,6 +420,7 @@ func (a *covenantArkClient) SendOnChain(
 func (a *covenantArkClient) SendOffChain(
 	ctx context.Context,
 	withExpiryCoinselect bool, receivers []Receiver,
+	_ bool,
 ) (string, error) {
 	for _, receiver := range receivers {
 		if receiver.IsOnchain() {

--- a/pkg/client-sdk/example/covenant/alice_to_bob.go
+++ b/pkg/client-sdk/example/covenant/alice_to_bob.go
@@ -105,7 +105,7 @@ func main() {
 	fmt.Println("")
 	log.Infof("alice is sending %d sats to bob offchain...", amount)
 
-	txid, err = aliceArkClient.SendOffChain(ctx, false, receivers)
+	txid, err = aliceArkClient.SendOffChain(ctx, false, receivers, false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/client-sdk/example/covenantless/alice_to_bob.go
+++ b/pkg/client-sdk/example/covenantless/alice_to_bob.go
@@ -128,7 +128,7 @@ func main() {
 	fmt.Println("")
 	log.Infof("alice is sending %d sats to bob offchain...", amount)
 
-	if _, err = aliceArkClient.SendOffChain(ctx, false, receivers, false); err != nil {
+	if _, err = aliceArkClient.SendOffChain(ctx, false, receivers, true); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/client-sdk/example/covenantless/alice_to_bob.go
+++ b/pkg/client-sdk/example/covenantless/alice_to_bob.go
@@ -128,7 +128,7 @@ func main() {
 	fmt.Println("")
 	log.Infof("alice is sending %d sats to bob offchain...", amount)
 
-	if _, err = aliceArkClient.SendOffChain(ctx, false, receivers); err != nil {
+	if _, err = aliceArkClient.SendOffChain(ctx, false, receivers, false); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/client-sdk/wasm/browser/wrappers.go
+++ b/pkg/client-sdk/wasm/browser/wrappers.go
@@ -228,7 +228,7 @@ func SendOnChainWrapper() js.Func {
 
 func SendOffChainWrapper() js.Func {
 	return JSPromise(func(args []js.Value) (interface{}, error) {
-		if len(args) != 2 {
+		if len(args) != 2 && len(args) != 3 {
 			return nil, errors.New("invalid number of args")
 		}
 
@@ -238,8 +238,13 @@ func SendOffChainWrapper() js.Func {
 			return nil, err
 		}
 
+		withZeroFees := false
+		if len(args) == 3 {
+			withZeroFees = args[2].Bool()
+		}
+
 		txID, err := arkSdkClient.SendOffChain(
-			context.Background(), withExpiryCoinselect, receivers,
+			context.Background(), withExpiryCoinselect, receivers, withZeroFees,
 		)
 		if err != nil {
 			return nil, err

--- a/server/Makefile
+++ b/server/Makefile
@@ -62,6 +62,7 @@ run-neutrino: clean
 	export ARK_ESPLORA_URL=http://localhost:3000; \
 	export ARK_NEUTRINO_PEER=localhost:18444; \
 	export ARK_DATADIR=./data/regtest; \
+	export ARK_ALLOW_ZERO_FEES=true; \
 	go run ./cmd/arkd
 
 ## run-neutrino-mutinynet: run in signet mode

--- a/server/cmd/arkd/main.go
+++ b/server/cmd/arkd/main.go
@@ -104,7 +104,13 @@ func mainAction(_ *cli.Context) error {
 		MarketHourPeriod:        cfg.MarketHourPeriod,
 		MarketHourRoundInterval: cfg.MarketHourRoundInterval,
 		OtelCollectorEndpoint:   cfg.OtelCollectorEndpoint,
+		AllowZeroFees:           cfg.AllowZeroFees,
 	}
+
+	if cfg.AllowZeroFees {
+		log.Warn("WARNING: AllowZeroFees is enabled")
+	}
+
 	svc, err := grpcservice.NewService(svcConfig, appConfig)
 	if err != nil {
 		return err

--- a/server/internal/app-config/config.go
+++ b/server/internal/app-config/config.go
@@ -76,6 +76,8 @@ type Config struct {
 	MarketHourRoundInterval time.Duration
 	OtelCollectorEndpoint   string
 
+	AllowZeroFees bool
+
 	EsploraURL       string
 	NeutrinoPeer     string
 	BitcoindRpcUser  string
@@ -374,6 +376,7 @@ func (c *Config) appService() error {
 		c.Network, c.RoundInterval, c.VtxoTreeExpiry, c.UnilateralExitDelay, c.BoardingExitDelay, c.NostrDefaultRelays,
 		c.wallet, c.repo, c.txBuilder, c.scanner, c.scheduler, c.NoteUriPrefix,
 		c.MarketHourStartTime, c.MarketHourEndTime, c.MarketHourPeriod, c.MarketHourRoundInterval,
+		c.AllowZeroFees,
 	)
 	if err != nil {
 		return err

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	MarketHourPeriod        time.Duration
 	MarketHourRoundInterval time.Duration
 	OtelCollectorEndpoint   string
+
+	// TODO remove with transactions version 3
+	AllowZeroFees bool
 }
 
 var (
@@ -88,6 +91,8 @@ var (
 	MarketHourRoundInterval = "MARKET_HOUR_ROUND_INTERVAL"
 	OtelCollectorEndpoint   = "OTEL_COLLECTOR_ENDPOINT"
 
+	AllowZeroFees = "ALLOW_ZERO_FEES"
+
 	defaultDatadir             = common.AppDataDir("arkd", false)
 	defaultRoundInterval       = 15
 	DefaultPort                = 7070
@@ -108,6 +113,8 @@ var (
 	defaultMarketHourEndTime   = defaultMarketHourStartTime.Add(time.Duration(defaultRoundInterval) * time.Second)
 	defaultMarketHourPeriod    = time.Duration(24) * time.Hour
 	defaultMarketHourInterval  = time.Duration(defaultRoundInterval) * time.Second
+
+	defaultAllowZeroFees = false
 )
 
 func LoadConfig() (*Config, error) {
@@ -134,7 +141,7 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault(MarketHourEndTime, defaultMarketHourEndTime)
 	viper.SetDefault(MarketHourPeriod, defaultMarketHourPeriod)
 	viper.SetDefault(MarketHourRoundInterval, defaultMarketHourInterval)
-
+	viper.SetDefault(AllowZeroFees, defaultAllowZeroFees)
 	net, err := getNetwork()
 	if err != nil {
 		return nil, fmt.Errorf("error while getting network: %s", err)
@@ -180,6 +187,7 @@ func LoadConfig() (*Config, error) {
 		MarketHourPeriod:        viper.GetDuration(MarketHourPeriod),
 		MarketHourRoundInterval: viper.GetDuration(MarketHourRoundInterval),
 		OtelCollectorEndpoint:   viper.GetString(OtelCollectorEndpoint),
+		AllowZeroFees:           viper.GetBool(AllowZeroFees),
 	}, nil
 }
 

--- a/server/test/e2e/covenant/e2e_test.go
+++ b/server/test/e2e/covenant/e2e_test.go
@@ -175,7 +175,7 @@ func TestReactToSpentVtxosRedemption(t *testing.T) {
 
 	vtxo := spendable[0]
 
-	_, err = client.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewLiquidReceiver(offchainAddress, 1000)})
+	_, err = client.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewLiquidReceiver(offchainAddress, 1000)}, false)
 	require.NoError(t, err)
 
 	round, err := grpcClient.GetRound(ctx, vtxo.RoundTxid)

--- a/server/test/e2e/covenantless/e2e_test.go
+++ b/server/test/e2e/covenantless/e2e_test.go
@@ -248,7 +248,7 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		err = utils.GenerateBlock()
 		require.NoError(t, err)
 
-		_, err = sdkClient.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(offchainAddress, 1000)})
+		_, err = sdkClient.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(offchainAddress, 1000)}, false)
 		require.NoError(t, err)
 
 		_, err = sdkClient.Settle(ctx)
@@ -395,7 +395,7 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		bobAddrStr, err := bobAddr.Encode()
 		require.NoError(t, err)
 
-		txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)})
+		txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)}, false)
 		require.NoError(t, err)
 		require.NotEmpty(t, txid)
 
@@ -574,7 +574,7 @@ func TestAliceSendsSeveralTimesToBob(t *testing.T) {
 	bobAddress, _, err := bob.Receive(ctx)
 	require.NoError(t, err)
 
-	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 1000)})
+	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 1000)}, false)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
@@ -583,7 +583,7 @@ func TestAliceSendsSeveralTimesToBob(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bobVtxos, 1)
 
-	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)})
+	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)}, false)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
@@ -592,7 +592,7 @@ func TestAliceSendsSeveralTimesToBob(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bobVtxos, 2)
 
-	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)})
+	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)}, false)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
@@ -601,7 +601,7 @@ func TestAliceSendsSeveralTimesToBob(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, bobVtxos, 3)
 
-	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)})
+	_, err = alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddress, 10000)}, false)
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)
@@ -738,7 +738,7 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 	bobAddrStr, err := bobAddr.Encode()
 	require.NoError(t, err)
 
-	txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)})
+	txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)}, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, txid)
 
@@ -919,7 +919,7 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 	bobAddrStr, err := bobAddr.Encode()
 	require.NoError(t, err)
 
-	txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)})
+	txid, err := alice.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddrStr, sendAmount)}, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, txid)
 


### PR DESCRIPTION
This PR adds an `ALLOW_ZERO_FEES` flag for redeem transactions. It allows to submit redeem psbt with a zero fee value. It must be removed when we migrate to transaction V3 (https://github.com/ark-network/ark/pull/328). It's not ideal cause it makes the transaction not being relayed by full node from the onchain point of view, thus it's not possible to unilateral exit a zero-fee pending VTXO. 

It also adds a `withZeroFee` flag to covenantless `SendOffchain` method. It prevents the transaction builder to deduct min-relay-fee amount from the last output.

@tiero @bordalix @altafan please review