### PR TITLE
[SDK] add `WithEventsCh` settle option

### DIFF
--- a/nak.Dockerfile
+++ b/nak.Dockerfile
@@ -1,5 +1,5 @@
 # Use official Go image as base
-FROM golang:1.23.1-alpine
+FROM golang:1.23.3-alpine
 
 # Install git (needed for go install)
 RUN apk add --no-cache git

--- a/pkg/client-sdk/covenantless_client.go
+++ b/pkg/client-sdk/covenantless_client.go
@@ -36,9 +36,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// SetleOptions is only available for covenantless clients
+// SettleOptions is only available for covenantless clients
 // it allows to customize the vtxo signing process
-type SetleOptions struct {
+type SettleOptions struct {
 	ExtraSignerSessions  []bitcointree.SignerSession
 	SigningType          *tree.SigningType
 	WalletSignerDisabled bool
@@ -48,7 +48,7 @@ type SetleOptions struct {
 
 func WithEventsCh(ch chan<- client.RoundEvent) Option {
 	return func(o interface{}) error {
-		opts, ok := o.(*SetleOptions)
+		opts, ok := o.(*SettleOptions)
 		if !ok {
 			return fmt.Errorf("invalid options type")
 		}
@@ -60,7 +60,7 @@ func WithEventsCh(ch chan<- client.RoundEvent) Option {
 
 // WithoutWalletSigner disables the wallet signer
 func WithoutWalletSigner(o interface{}) error {
-	opts, ok := o.(*SetleOptions)
+	opts, ok := o.(*SettleOptions)
 	if !ok {
 		return fmt.Errorf("invalid options type")
 	}
@@ -71,7 +71,7 @@ func WithoutWalletSigner(o interface{}) error {
 
 // WithSignAll sets the signing type to ALL instead of the default BRANCH
 func WithSignAll(o interface{}) error {
-	opts, ok := o.(*SetleOptions)
+	opts, ok := o.(*SettleOptions)
 	if !ok {
 		return fmt.Errorf("invalid options type")
 	}
@@ -84,7 +84,7 @@ func WithSignAll(o interface{}) error {
 // WithExtraSigner allows to use a set of custom signer for the vtxo tree signing process
 func WithExtraSigner(signerSessions ...bitcointree.SignerSession) Option {
 	return func(o interface{}) error {
-		opts, ok := o.(*SetleOptions)
+		opts, ok := o.(*SettleOptions)
 		if !ok {
 			return fmt.Errorf("invalid options type")
 		}
@@ -898,7 +898,7 @@ func (a *covenantlessArkClient) SendOffChain(
 func (a *covenantlessArkClient) RedeemNotes(ctx context.Context, notes []string, opts ...Option) (string, error) {
 	amount := uint64(0)
 
-	options := &SetleOptions{}
+	options := &SettleOptions{}
 	for _, opt := range opts {
 		if err := opt(options); err != nil {
 			return "", err
@@ -1026,7 +1026,7 @@ func (a *covenantlessArkClient) CollaborativeRedeem(
 	addr string, amount uint64, withExpiryCoinselect bool,
 	opts ...Option,
 ) (string, error) {
-	options := &SetleOptions{}
+	options := &SettleOptions{}
 	for _, opt := range opts {
 		if err := opt(options); err != nil {
 			return "", err
@@ -1431,7 +1431,7 @@ func (a *covenantlessArkClient) sendOffchain(
 	settleOpts ...Option,
 ) (string, error) {
 
-	options := &SetleOptions{}
+	options := &SettleOptions{}
 	for _, opt := range settleOpts {
 		if err := opt(options); err != nil {
 			return "", err
@@ -2942,7 +2942,7 @@ func buildRedeemTx(
 	return bitcointree.BuildRedeemTx(ins, outs)
 }
 
-func (a *covenantlessArkClient) handleOptions(options *SetleOptions, inputs []client.Input, notesInputs []string) ([]bitcointree.SignerSession, []string, tree.SigningType, error) {
+func (a *covenantlessArkClient) handleOptions(options *SettleOptions, inputs []client.Input, notesInputs []string) ([]bitcointree.SignerSession, []string, tree.SigningType, error) {
 	var signingType tree.SigningType
 	if options.SigningType != nil {
 		signingType = *options.SigningType

--- a/pkg/client-sdk/test/wasm/wasm_test.go
+++ b/pkg/client-sdk/test/wasm/wasm_test.go
@@ -325,7 +325,7 @@ func settle(page playwright.Page) (string, error) {
 	result, err := page.Evaluate(`async () => { 
         try {
             await unlock("pass");
-            return await settle();
+            return await settle((e) => console.log(JSON.parse(e)));
         } catch (err) {
             console.error("Error:", err);
             throw err;


### PR DESCRIPTION
_This PR adds a way to inspect the settlement process by replaying the`RoundEvent` received from the server to a custom channel created by the client. It also allow to do the same with JS using a callback function._

**Golang**

```go
eventsCh := make(chan client.RoundEvent)
defer close(eventsCh)
go func() {
	for event := range eventsCh {
		fmt.Println(event)
	}
}()

resp, err := arkSdkClient.Settle(context.Background(), arksdk.WithEventsCh(eventsCh))
if err != nil {
	return nil, err
}
```

**WASM JS wrapper**

```js
await settle((e) => console.log(JSON.parse(e)));
```

@tiero @bordalix @altafan @sekulicd  please review