### PR TITLE
[Server] Optmization of embedded wallet and forfeit tx validation

### DIFF
--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -707,6 +707,21 @@ func (s *covenantService) finalizeRound() {
 		return
 	}
 
+	// TODO: make this concurrent and ensure all forfeits are verified before returning error
+	for _, tx := range forfeitTxs {
+		ok, txid, err := s.builder.VerifyTapscriptPartialSigs(tx)
+		if err != nil {
+			changes = round.Fail(fmt.Errorf("failed to validate forfeit tx %s: %s", txid, err))
+			log.WithError(err).Warnf("failed to validate forfeit tx %s: %s", txid, err)
+			return
+		}
+		if !ok {
+			changes = round.Fail(fmt.Errorf("invalid signature for forfeit tx %s", txid))
+			log.Warnf("invalid signature for forfeit tx %s", txid)
+			return
+		}
+	}
+
 	log.Debugf("signing round transaction %s\n", round.Id)
 
 	boardingInputs := make([]int, 0)

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -750,6 +750,11 @@ func (s *covenantlessService) UpdateTxRequestStatus(_ context.Context, id string
 }
 
 func (s *covenantlessService) SignVtxos(ctx context.Context, forfeitTxs []string) error {
+	start := time.Now()
+	defer func() {
+		end := time.Since(start)
+		fmt.Printf("SUBMIt FORFEIT TXS TOOK: %dµs", end.Microseconds())
+	}()
 	return s.forfeitTxs.sign(forfeitTxs)
 }
 
@@ -1402,6 +1407,7 @@ func (s *covenantlessService) finalizeRound(notes []note.Note) {
 	}
 
 	// TODO: make this concurrent and ensure all forfeits are verified before returning error
+	start := time.Now()
 	for _, tx := range forfeitTxs {
 		ok, txid, err := s.builder.VerifyTapscriptPartialSigs(tx)
 		if err != nil {
@@ -1415,6 +1421,8 @@ func (s *covenantlessService) finalizeRound(notes []note.Note) {
 			return
 		}
 	}
+	end := time.Since(start)
+	fmt.Printf("FORFEIT TXS SIGS VERIFICATION TOOK %dµs\n", end.Microseconds())
 
 	log.Debugf("signing round transaction %s\n", round.Id)
 

--- a/server/internal/core/ports/tx_builder.go
+++ b/server/internal/core/ports/tx_builder.go
@@ -52,7 +52,7 @@ type TxBuilder interface {
 	BuildSweepTx(inputs []SweepInput) (signedSweepTx string, err error)
 	GetSweepInput(node tree.Node) (vtxoTreeExpiry *common.RelativeLocktime, sweepInput SweepInput, err error)
 	FinalizeAndExtract(tx string) (txhex string, err error)
-	VerifyTapscriptPartialSigs(tx string) (valid bool, err error)
+	VerifyTapscriptPartialSigs(tx string) (valid bool, txid string, err error)
 	// FindLeaves returns all the leaves txs that are reachable from the given outpoint
 	FindLeaves(vtxoTree tree.VtxoTree, fromtxid string, vout uint32) (leaves []tree.Node, err error)
 	VerifyAndCombinePartialTx(dest string, src string) (string, error)

--- a/server/internal/infrastructure/wallet/btc-embedded/wallet.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/wallet.go
@@ -118,9 +118,8 @@ type service struct {
 	// holds the data related to the server key used in Vtxo scripts
 	serverKeyAddr waddrmgr.ManagedPubKeyAddress
 
-	// cached forfeit address
-	forfeitAddrLock sync.RWMutex
-	forfeitAddr     string
+	// cached forfeit addres
+	forfeitAddr string
 
 	isSynced bool
 	syncedCh chan struct{}
@@ -418,44 +417,18 @@ func (s *service) Unlock(_ context.Context, password string) error {
 			return fmt.Errorf("failed to start wallet: %s", err)
 		}
 
-		addrs, err := wallet.ListAddresses(string(serverKeyAccount), false)
+		serverAddr, err := s.loadServerAddress(wallet)
 		if err != nil {
 			return err
 		}
-		for info, addrs := range addrs {
-			if info.AccountName != string(serverKeyAccount) {
-				continue
-			}
 
-			for _, addr := range addrs {
-				if addr.Internal {
-					continue
-				}
-
-				splittedPath := strings.Split(addr.DerivationPath, "/")
-				last := splittedPath[len(splittedPath)-1]
-				if last == "0" {
-					decoded, err := btcutil.DecodeAddress(addr.Address, s.cfg.chainParams())
-					if err != nil {
-						return err
-					}
-
-					infos, err := wallet.AddressInfo(decoded)
-					if err != nil {
-						return err
-					}
-
-					managedPubkeyAddr, ok := infos.(waddrmgr.ManagedPubKeyAddress)
-					if !ok {
-						return fmt.Errorf("failed to cast address to managed pubkey address")
-					}
-
-					s.serverKeyAddr = managedPubkeyAddr
-					break
-				}
-			}
+		forfeitAddr, err := s.loadForfeitAddress(wallet)
+		if err != nil {
+			return err
 		}
 
+		s.serverKeyAddr = serverAddr
+		s.forfeitAddr = forfeitAddr
 		s.wallet = wallet
 
 		go s.listenToSynced()
@@ -571,63 +544,7 @@ func (s *service) GetForfeitAddress(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	s.forfeitAddrLock.RLock()
-	if s.forfeitAddr != "" {
-		addr := s.forfeitAddr
-		s.forfeitAddrLock.RUnlock()
-		return addr, nil
-	}
-	s.forfeitAddrLock.RUnlock()
-
-	addrs, err := s.wallet.ListAddresses(string(mainAccount), false)
-	if err != nil {
-		return "", err
-	}
-
-	var forfeitAddr string
-	if len(addrs) == 0 {
-		addr, err := s.deriveNextAddress()
-		if err != nil {
-			return "", err
-		}
-		forfeitAddr = addr.EncodeAddress()
-	} else {
-		for info, addrs := range addrs {
-			if info.KeyScope != p2wpkhKeyScope {
-				continue
-			}
-
-			if info.AccountName != string(mainAccount) {
-				continue
-			}
-
-			for _, addr := range addrs {
-				if addr.Internal {
-					continue
-				}
-
-				splittedPath := strings.Split(addr.DerivationPath, "/")
-				last := splittedPath[len(splittedPath)-1]
-				if last == "0" {
-					forfeitAddr = addr.Address
-					break
-				}
-			}
-			if forfeitAddr != "" {
-				break
-			}
-		}
-	}
-
-	if forfeitAddr == "" {
-		return "", fmt.Errorf("forfeit address not found")
-	}
-
-	s.forfeitAddrLock.Lock()
-	s.forfeitAddr = forfeitAddr
-	s.forfeitAddrLock.Unlock()
-
-	return forfeitAddr, nil
+	return s.forfeitAddr, nil
 }
 
 func (s *service) ListConnectorUtxos(ctx context.Context, connectorAddress string) ([]ports.TxInput, error) {
@@ -1302,10 +1219,12 @@ func (s *service) create(mnemonic, password string, addrGap uint32) error {
 		return fmt.Errorf("failed to start wallet: %s", err)
 	}
 
-	if err := s.initServerKeyAddress(wallet); err != nil {
+	serverAddr, err := s.loadServerAddress(wallet)
+	if err != nil {
 		return err
 	}
 
+	s.serverKeyAddr = serverAddr
 	s.wallet = wallet
 
 	go s.listenToSynced()
@@ -1391,68 +1310,100 @@ func (s *service) initServerKeyAccount(wallet *btcwallet.BtcWallet) error {
 	return nil
 }
 
-// initServerKeyAddress generates the server key address if it doesn't exist
-// it also cache the address in s.serverKeyAddr field
-func (s *service) initServerKeyAddress(wallet *btcwallet.BtcWallet) error {
+func (s *service) loadServerAddress(
+	wallet *btcwallet.BtcWallet,
+) (waddrmgr.ManagedPubKeyAddress, error) {
 	addrs, err := wallet.ListAddresses(string(serverKeyAccount), false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if len(addrs) == 0 {
-		serverKeyAddr, err := wallet.NewAddress(lnwallet.TaprootPubkey, false, string(serverKeyAccount))
-		if err != nil {
-			return err
+	for info, addrs := range addrs {
+		if info.AccountName != string(serverKeyAccount) {
+			continue
 		}
 
-		addrInfos, err := wallet.AddressInfo(serverKeyAddr)
-		if err != nil {
-			return err
-		}
-
-		managedAddr, ok := addrInfos.(waddrmgr.ManagedPubKeyAddress)
-		if !ok {
-			return fmt.Errorf("failed to cast address to managed pubkey address")
-		}
-
-		s.serverKeyAddr = managedAddr
-	} else {
-		for info, addrs := range addrs {
-			if info.AccountName != string(serverKeyAccount) {
+		for _, addr := range addrs {
+			if addr.Internal {
 				continue
 			}
 
-			for _, addr := range addrs {
-				if addr.Internal {
-					continue
+			splittedPath := strings.Split(addr.DerivationPath, "/")
+			last := splittedPath[len(splittedPath)-1]
+			if last == "0" {
+				decoded, err := btcutil.DecodeAddress(addr.Address, s.cfg.chainParams())
+				if err != nil {
+					return nil, err
 				}
 
-				splittedPath := strings.Split(addr.DerivationPath, "/")
-				last := splittedPath[len(splittedPath)-1]
-				if last == "0" {
-					decoded, err := btcutil.DecodeAddress(addr.Address, s.cfg.chainParams())
-					if err != nil {
-						return err
-					}
-
-					infos, err := wallet.AddressInfo(decoded)
-					if err != nil {
-						return err
-					}
-
-					managedPubkeyAddr, ok := infos.(waddrmgr.ManagedPubKeyAddress)
-					if !ok {
-						return fmt.Errorf("failed to cast address to managed pubkey address")
-					}
-
-					s.serverKeyAddr = managedPubkeyAddr
-					break
+				info, err := wallet.AddressInfo(decoded)
+				if err != nil {
+					return nil, err
 				}
+
+				managedPubkeyAddr, ok := info.(waddrmgr.ManagedPubKeyAddress)
+				if !ok {
+					return nil, fmt.Errorf("failed to cast address to managed pubkey address")
+				}
+
+				return managedPubkeyAddr, nil
 			}
 		}
 	}
 
-	return nil
+	serverKeyAddr, err := wallet.NewAddress(lnwallet.TaprootPubkey, false, string(serverKeyAccount))
+	if err != nil {
+		return nil, err
+	}
+
+	addrInfos, err := wallet.AddressInfo(serverKeyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	managedAddr, ok := addrInfos.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast address to managed pubkey address")
+	}
+
+	return managedAddr, nil
+}
+
+func (s *service) loadForfeitAddress(
+	wallet *btcwallet.BtcWallet,
+) (string, error) {
+	addrs, err := wallet.ListAddresses(string(mainAccount), false)
+	if err != nil {
+		return "", err
+	}
+
+	for info, addrs := range addrs {
+		if info.KeyScope != p2wpkhKeyScope {
+			continue
+		}
+
+		if info.AccountName != string(mainAccount) {
+			continue
+		}
+
+		for _, addr := range addrs {
+			if addr.Internal {
+				continue
+			}
+
+			splittedPath := strings.Split(addr.DerivationPath, "/")
+			last := splittedPath[len(splittedPath)-1]
+			if last == "0" {
+				return addr.Address, nil
+			}
+		}
+	}
+
+	addr, err := s.deriveNextAddress()
+	if err != nil {
+		return "", fmt.Errorf("failed to derive forfeit address: %s", err)
+	}
+	return addr.EncodeAddress(), nil
 }
 
 func (s *service) deriveNextAddress() (btcutil.Address, error) {


### PR DESCRIPTION
The purpose of this is to optimize the flow of finalizing a round. In particular:
- Embedded bitcoin wallet: cache forfeit address at creation/unlocking instead of doing so the very first time the relative API is called. Contains also some renaming for consistency.
- SubmitForfeitTxs API: move validation of txs signatures at round finalization to prevent clients to have wait for their calls to succeed (if a lot of clients join the same round)

Please @louisinger @sekulicd review.