### PR TITLE
sweeper: check if tx is onchain before broadcasting

### DIFF
--- a/server/internal/core/application/sweeper.go
+++ b/server/internal/core/application/sweeper.go
@@ -236,23 +236,19 @@ func (s *sweeper) createTask(
 		vtxosRepository := s.repoManager.Vtxos()
 		if len(sweepInputs) > 0 {
 			// build the sweep transaction with all the expired non-swept shared outputs
-			sweeptTxId, sweepTx, err := s.builder.BuildSweepTx(sweepInputs)
+			sweepTxId, sweepTx, err := s.builder.BuildSweepTx(sweepInputs)
 			if err != nil {
 				log.WithError(err).Error("error while building sweep tx")
 				return
 			}
 
 			// check if the transaction is already onchain
-			tx, err := s.wallet.GetTransaction(ctx, sweeptTxId)
-			if err != nil {
-				log.WithError(err).Error("error while getting transaction")
-				return
-			}
+			tx, _ := s.wallet.GetTransaction(ctx, sweepTxId)
 
 			txid := ""
 
 			if len(tx) > 0 {
-				txid = sweeptTxId
+				txid = sweepTxId
 			}
 
 			err = nil

--- a/server/internal/core/application/sweeper.go
+++ b/server/internal/core/application/sweeper.go
@@ -236,14 +236,26 @@ func (s *sweeper) createTask(
 		vtxosRepository := s.repoManager.Vtxos()
 		if len(sweepInputs) > 0 {
 			// build the sweep transaction with all the expired non-swept shared outputs
-			sweepTx, err := s.builder.BuildSweepTx(sweepInputs)
+			sweeptTxId, sweepTx, err := s.builder.BuildSweepTx(sweepInputs)
 			if err != nil {
 				log.WithError(err).Error("error while building sweep tx")
 				return
 			}
 
-			err = nil
+			// check if the transaction is already onchain
+			tx, err := s.wallet.GetTransaction(ctx, sweeptTxId)
+			if err != nil {
+				log.WithError(err).Error("error while getting transaction")
+				return
+			}
+
 			txid := ""
+
+			if len(tx) > 0 {
+				txid = sweeptTxId
+			}
+
+			err = nil
 			// retry until the tx is broadcasted or the error is not BIP68 final
 			for len(txid) == 0 && (err == nil || err == ports.ErrNonFinalBIP68) {
 				if err != nil {
@@ -253,11 +265,11 @@ func (s *sweeper) createTask(
 
 				txid, err = s.wallet.BroadcastTransaction(ctx, sweepTx)
 			}
-
 			if err != nil {
 				log.WithError(err).Error("error while broadcasting sweep tx")
 				return
 			}
+
 			if len(txid) > 0 {
 				log.Debugln("sweep tx broadcasted:", txid)
 

--- a/server/internal/core/ports/tx_builder.go
+++ b/server/internal/core/ports/tx_builder.go
@@ -49,7 +49,7 @@ type TxBuilder interface {
 	VerifyForfeitTxs(
 		vtxos []domain.Vtxo, connectors []string, txs []string,
 	) (valid map[domain.VtxoKey][]string, err error)
-	BuildSweepTx(inputs []SweepInput) (signedSweepTx string, err error)
+	BuildSweepTx(inputs []SweepInput) (txid string, signedSweepTx string, err error)
 	GetSweepInput(node tree.Node) (vtxoTreeExpiry *common.RelativeLocktime, sweepInput SweepInput, err error)
 	FinalizeAndExtract(tx string) (txhex string, err error)
 	VerifyTapscriptPartialSigs(tx string) (valid bool, txid string, err error)

--- a/server/internal/core/ports/wallet.go
+++ b/server/internal/core/ports/wallet.go
@@ -8,8 +8,10 @@ import (
 	"github.com/lightningnetwork/lnd/lnwallet/chainfee"
 )
 
-// ErrNonFinalBIP68 is returned when a transaction spending a CSV-locked output is not final.
-var ErrNonFinalBIP68 = errors.New("non-final BIP68 sequence")
+var (
+	// ErrNonFinalBIP68 is returned when a transaction spending a CSV-locked output is not final.
+	ErrNonFinalBIP68 = errors.New("non-final BIP68 sequence")
+)
 
 type WalletService interface {
 	BlockchainScanner


### PR DESCRIPTION
This PR adds a check in sweeper.go verifying that the tx is not already onchain before trying to broadcast it.

@altafan please review