### PR TITLE
Wait for forfeits until round ends

### DIFF
--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -602,14 +602,15 @@ func (s *covenantService) startRound() {
 	s.currentRound = round
 
 	defer func() {
-		time.Sleep(time.Duration(s.roundInterval/3) * time.Second)
-		s.startFinalization()
+		roundEndTime := time.Now().Add(time.Duration(s.roundInterval) * time.Second)
+		time.Sleep(time.Duration(s.roundInterval/6) * time.Second)
+		s.startFinalization(roundEndTime)
 	}()
 
 	log.Debugf("started registration stage for new round: %s", round.Id)
 }
 
-func (s *covenantService) startFinalization() {
+func (s *covenantService) startFinalization(roundEndTime time.Time) {
 	ctx := context.Background()
 	round := s.currentRound
 
@@ -629,7 +630,7 @@ func (s *covenantService) startFinalization() {
 			return
 		}
 		time.Sleep(time.Duration((s.roundInterval/3)-1) * time.Second)
-		s.finalizeRound()
+		s.finalizeRound(roundEndTime)
 	}()
 
 	if round.IsFailed() {
@@ -683,7 +684,7 @@ func (s *covenantService) startFinalization() {
 	log.Debugf("started finalization stage for round: %s", round.Id)
 }
 
-func (s *covenantService) finalizeRound() {
+func (s *covenantService) finalizeRound(roundEndTime time.Time) {
 	defer s.startRound()
 
 	ctx := context.Background()
@@ -699,6 +700,16 @@ func (s *covenantService) finalizeRound() {
 			return
 		}
 	}()
+
+	remainingTime := time.Until(roundEndTime)
+	// Wait for the remaining forfeit txs to be sent,
+	// but only wait until the round interval expires.
+	select {
+	case <-s.forfeitTxs.doneCh:
+		log.Debug("all forfeit txs have been sent")
+	case <-time.After(remainingTime):
+		log.Debug("timeout waiting for forfeit txs")
+	}
 
 	forfeitTxs, err := s.forfeitTxs.pop()
 	if err != nil {

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1130,7 +1130,7 @@ func (s *covenantlessService) startFinalization(roundEndTime time.Time) {
 	round := s.currentRound
 
 	roundRemainingDuration := time.Duration((s.roundInterval/3)*2-1) * time.Second
-	thirdOfRemainingDuration := time.Duration(roundRemainingDuration / 3)
+	thirdOfRemainingDuration := roundRemainingDuration / 3
 
 	var notes []note.Note
 	var roundAborted bool

--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -260,8 +260,7 @@ type forfeitTxsMap struct {
 	connectors []string
 	vtxos      []domain.Vtxo
 
-	doneCh   chan struct{}
-	doneOnce sync.Once
+	doneCh chan struct{}
 }
 
 func newForfeitTxsMap(txBuilder ports.TxBuilder) *forfeitTxsMap {
@@ -271,7 +270,7 @@ func newForfeitTxsMap(txBuilder ports.TxBuilder) *forfeitTxsMap {
 		forfeitTxs: make(map[domain.VtxoKey][]string),
 		connectors: nil,
 		vtxos:      nil,
-		doneCh:     make(chan struct{}),
+		doneCh:     make(chan struct{}, 1),
 	}
 }
 
@@ -314,9 +313,7 @@ func (m *forfeitTxsMap) sign(txs []string) error {
 	}
 
 	if m.allSigned() {
-		m.doneOnce.Do(func() {
-			close(m.doneCh)
-		})
+		m.doneCh <- struct{}{}
 	}
 
 	return nil

--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -337,7 +337,7 @@ func (m *forfeitTxsMap) pop() ([]string, error) {
 		m.lock.Unlock()
 		m.reset()
 	}()
-	
+
 	txs := make([]string, 0)
 	for vtxoKey, signed := range m.forfeitTxs {
 		if len(signed) == 0 {

--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -328,7 +328,6 @@ func (m *forfeitTxsMap) reset() {
 
 	m.forfeitTxs = make(map[domain.VtxoKey][]string)
 	m.connectors = nil
-	m.doneCh = make(chan struct{}, 1)
 }
 
 func (m *forfeitTxsMap) pop() ([]string, error) {
@@ -350,9 +349,6 @@ func (m *forfeitTxsMap) pop() ([]string, error) {
 }
 
 func (m *forfeitTxsMap) allSigned() bool {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
 	for _, txs := range m.forfeitTxs {
 		if len(txs) == 0 {
 			return false


### PR DESCRIPTION
This is attempt to improve on forfeits sync, before this after nonces & sigs were collected round would wait “third of remaining” and if forfeits were not sent after that time round would fail, with this round possibly extends this period, especially if gathering of nonces and sigs are fast, by waiting till round remaining time, it also saves time by lowering registration phase(currently in master roundInterval=60s, meaning reg phase were 20s in this phase where we testing we dont need more than few seconds i think).

```
roundRemainingDuration := time.Duration((s.roundInterval/3)*2-1) * time.Second
thirdOfRemainingDuration := time.Duration(roundRemainingDuration / 3)
```

@altafan 