### PR TITLE
fix forfeit transaction size estimation

### DIFF
--- a/common/fees.go
+++ b/common/fees.go
@@ -34,7 +34,7 @@ func ComputeForfeitTxFee(
 ) (uint64, error) {
 	txWeightEstimator := &input.TxWeightEstimator{}
 
-	txWeightEstimator.AddP2PKHInput() // connector input
+	txWeightEstimator.AddTaprootKeySpendInput(txscript.SigHashDefault) // connector input
 	txWeightEstimator.AddTapscriptInput(
 		lntypes.WeightUnit(witnessSize),
 		tapscript,


### PR DESCRIPTION
Use  `AddTaprootKeySpendInput`  instead of `AddP2PKHInput` when estimating the weight of the forfeit transactions.

@altafan please review