### PR TITLE
handle collaborative exit without vtxo change

### DIFF
--- a/pkg/client-sdk/covenantless_client.go
+++ b/pkg/client-sdk/covenantless_client.go
@@ -1523,6 +1523,18 @@ func (a *covenantlessArkClient) handleRoundStream(
 	)
 
 	step := start
+	hasOffchainOutput := false
+	for _, receiver := range receivers {
+		if _, err := common.DecodeAddress(receiver.Address); err == nil {
+			hasOffchainOutput = true
+			break
+		}
+	}
+
+	if !hasOffchainOutput {
+		// if none of the outputs are offchain, we should skip the vtxo tree signing steps
+		step = roundSigningNoncesGenerated
+	}
 
 	for {
 		select {

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1193,12 +1193,14 @@ func (s *covenantlessService) startFinalization(roundEndTime time.Time) {
 	uniqueSignerPubkeys := make(map[string]struct{})
 	serverPubKeyHex := hex.EncodeToString(s.serverSigningPubKey.SerializeCompressed())
 	for _, data := range musig2data {
+		if data == nil {
+			continue
+		}
 		for _, pubkey := range data.CosignersPublicKeys {
 			uniqueSignerPubkeys[pubkey] = struct{}{}
 		}
 		data.CosignersPublicKeys = append(data.CosignersPublicKeys, serverPubKeyHex)
 	}
-
 	log.Debugf("building tx for round %s", round.Id)
 	unsignedRoundTx, vtxoTree, connectorAddress, connectors, err := s.builder.BuildRoundTx(
 		s.pubkey, requests, boardingInputs, connectorAddresses, musig2data,


### PR DESCRIPTION
_This PR fixes collaborative exit payment where there is no change (exit all)._

it includes 2 different fixes:
* server : handle `nil` musig2data.
* client : if onchain outputs only, skip musig2 signing steps.

@altafan please review