### PR TITLE
[application] delete outdated tx requests

### DIFF
--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ark-network/ark/server/internal/core/ports"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip19"
+	log "github.com/sirupsen/logrus"
 )
 
 type timedTxRequest struct {
@@ -118,6 +119,8 @@ func (m *txRequestsQueue) pop(num int64) ([]domain.TxRequest, []ports.BoardingIn
 		}
 		// Skip tx requests for which users didn't notify to be online in the last minute.
 		if p.pingTimestamp.IsZero() || time.Since(p.pingTimestamp).Minutes() > 1 {
+			log.Debugf("delete tx request %s because it didn't ping in the last minute", p.Id)
+			delete(m.requests, p.Id) // cleanup the request from the map
 			continue
 		}
 		requestsByTime = append(requestsByTime, *p)

--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	pingGapMinutes = float64(5)
+	selectGapMinutes = float64(1)
+	deleteGapMinutes = float64(5)
 )
 
 type timedTxRequest struct {
@@ -107,7 +108,8 @@ func (m *txRequestsQueue) push(
 		}
 	}
 
-	m.requests[request.Id] = &timedTxRequest{request, boardingInputs, make([]note.Note, 0), time.Now(), time.Time{}, nil}
+	now := time.Now()
+	m.requests[request.Id] = &timedTxRequest{request, boardingInputs, make([]note.Note, 0), now, now, nil}
 	return nil
 }
 
@@ -121,14 +123,21 @@ func (m *txRequestsQueue) pop(num int64) ([]domain.TxRequest, []ports.BoardingIn
 		if len(p.Receivers) <= 0 {
 			continue
 		}
+
+		sinceLastPing := time.Since(p.pingTimestamp).Minutes()
+
 		// Skip tx requests for which users didn't notify to be online in the last minute.
-		if p.pingTimestamp.IsZero() || time.Since(p.pingTimestamp).Minutes() > pingGapMinutes {
-			log.Debugf("delete tx request %s : we didn't receive a ping in the last %d minutes", p.Id, int(pingGapMinutes))
-			// cleanup the request from the map
+		if sinceLastPing > selectGapMinutes {
+			// Cleanup the request from the map if greater than deleteGapMinutes
 			// TODO move to dedicated function
-			delete(m.requests, p.Id)
+			if sinceLastPing > deleteGapMinutes {
+				log.Debugf("delete tx request %s : we didn't receive a ping in the last %d minutes", p.Id, int(deleteGapMinutes))
+				delete(m.requests, p.Id)
+			}
+
 			continue
 		}
+
 		requestsByTime = append(requestsByTime, *p)
 	}
 	sort.SliceStable(requestsByTime, func(i, j int) bool {


### PR DESCRIPTION
This PR cleans the requests map from outdated request. A request is outdated if the user didn't ping for at least 1 minute. It prevents `duplicated input` errors in case the client stops pinging and then retry with the same inputs.

@altafan please review