### PR TITLE
[SDK] Add GetVtxoEventChannel API

### DIFF
--- a/pkg/client-sdk/ark_sdk.go
+++ b/pkg/client-sdk/ark_sdk.go
@@ -34,8 +34,8 @@ type ArkClient interface {
 	ListVtxos(ctx context.Context) (spendable, spent []client.Vtxo, err error)
 	Dump(ctx context.Context) (seed string, err error)
 	GetTransactionHistory(ctx context.Context) ([]types.Transaction, error)
-	GetTransactionEventChannel() chan types.TransactionEvent
-	GetVtxoEventChannel() chan types.VtxoEvent
+	GetTransactionEventChannel(ctx context.Context) chan types.TransactionEvent
+	GetVtxoEventChannel(ctx context.Context) chan types.VtxoEvent
 	RedeemNotes(ctx context.Context, notes []string, opts ...Option) (string, error)
 	SetNostrNotificationRecipient(ctx context.Context, nostrRecipient string) error
 	SignTransaction(ctx context.Context, tx string) (string, error)

--- a/pkg/client-sdk/ark_sdk.go
+++ b/pkg/client-sdk/ark_sdk.go
@@ -34,7 +34,8 @@ type ArkClient interface {
 	ListVtxos(ctx context.Context) (spendable, spent []client.Vtxo, err error)
 	Dump(ctx context.Context) (seed string, err error)
 	GetTransactionHistory(ctx context.Context) ([]types.Transaction, error)
-	GetTransactionChannel() chan types.Transaction
+	GetTransactionEventChannel() chan types.TransactionEvent
+	GetVtxoEventChannel() chan types.VtxoEvent
 	RedeemNotes(ctx context.Context, notes []string, opts ...Option) (string, error)
 	SetNostrNotificationRecipient(ctx context.Context, nostrRecipient string) error
 	SignTransaction(ctx context.Context, tx string) (string, error)

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -99,11 +99,11 @@ func (a *arkClient) Receive(ctx context.Context) (string, string, error) {
 	return offchainAddr.Address, boardingAddr.Address, nil
 }
 
-func (a *arkClient) GetTransactionEventChannel() chan types.TransactionEvent {
+func (a *arkClient) GetTransactionEventChannel(_ context.Context) chan types.TransactionEvent {
 	return a.store.TransactionStore().GetEventChannel()
 }
 
-func (a *arkClient) GetVtxoEventChannel() chan types.VtxoEvent {
+func (a *arkClient) GetVtxoEventChannel(_ context.Context) chan types.VtxoEvent {
 	return a.store.VtxoStore().GetEventChannel()
 }
 

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -99,8 +99,12 @@ func (a *arkClient) Receive(ctx context.Context) (string, string, error) {
 	return offchainAddr.Address, boardingAddr.Address, nil
 }
 
-func (a *arkClient) GetTransactionChannel() chan types.Transaction {
+func (a *arkClient) GetTransactionEventChannel() chan types.TransactionEvent {
 	return a.store.TransactionStore().GetEventChannel()
+}
+
+func (a *arkClient) GetVtxoEventChannel() chan types.VtxoEvent {
+	return a.store.VtxoStore().GetEventChannel()
 }
 
 func (a *arkClient) SignTransaction(ctx context.Context, tx string) (string, error) {

--- a/pkg/client-sdk/covenantless_client.go
+++ b/pkg/client-sdk/covenantless_client.go
@@ -2667,11 +2667,6 @@ func (a *covenantlessArkClient) handleRoundTx(
 		}
 	}
 
-	fmt.Println("TXS TO ADD", len(txsToAdd))
-	fmt.Println("TXS TO SETTLE", len(txsToSettle))
-	fmt.Println("VTXOS TO ADD", len(vtxosToAdd))
-	fmt.Println("VTXOS TO SPEND", len(vtxosToSpend))
-
 	if len(txsToAdd) > 0 {
 		count, err := a.store.TransactionStore().AddTransactions(ctx, txsToAdd)
 		if err != nil {

--- a/pkg/client-sdk/example/covenantless/alice_to_bob.go
+++ b/pkg/client-sdk/example/covenantless/alice_to_bob.go
@@ -270,7 +270,7 @@ func generateBlock() error {
 }
 
 func logTxEvents(wallet string, client arksdk.ArkClient) {
-	txsChan := client.GetTransactionEventChannel()
+	txsChan := client.GetTransactionEventChannel(context.Background())
 	go func() {
 		for txEvent := range txsChan {
 			for _, tx := range txEvent.Txs {

--- a/pkg/client-sdk/example/covenantless/alice_to_bob.go
+++ b/pkg/client-sdk/example/covenantless/alice_to_bob.go
@@ -270,14 +270,16 @@ func generateBlock() error {
 }
 
 func logTxEvents(wallet string, client arksdk.ArkClient) {
-	txsChan := client.GetTransactionChannel()
+	txsChan := client.GetTransactionEventChannel()
 	go func() {
 		for txEvent := range txsChan {
-			msg := fmt.Sprintf("[EVENT]%s: tx event: %s, %d", wallet, txEvent.Type, txEvent.Amount)
-			if txEvent.IsBoarding() {
-				msg += fmt.Sprintf(", boarding tx: %s", txEvent.BoardingTxid)
+			for _, tx := range txEvent.Txs {
+				msg := fmt.Sprintf(
+					"[EVENT]%s: tx %s type: %s, amount: %d",
+					wallet, tx.TransactionKey.String(), tx.Type, tx.Amount,
+				)
+				log.Infoln(msg)
 			}
-			log.Infoln(msg)
 		}
 	}()
 	log.Infof("%s tx event listener started", wallet)

--- a/pkg/client-sdk/store/kv/transaction_repository.go
+++ b/pkg/client-sdk/store/kv/transaction_repository.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/ark-network/ark/pkg/client-sdk/types"
 	"github.com/dgraph-io/badger/v4"
@@ -21,7 +22,7 @@ const (
 type txStore struct {
 	db      *badgerhold.Store
 	lock    *sync.Mutex
-	eventCh chan types.Transaction
+	eventCh chan types.TransactionEvent
 }
 
 func NewTransactionStore(
@@ -34,7 +35,7 @@ func NewTransactionStore(
 	return &txStore{
 		db:      badgerDb,
 		lock:    &sync.Mutex{},
-		eventCh: make(chan types.Transaction),
+		eventCh: make(chan types.TransactionEvent),
 	}, nil
 }
 
@@ -51,26 +52,49 @@ func (s *txStore) AddTransactions(
 		}
 		count++
 		go func(tx types.Transaction) {
-			s.sendEvent(tx)
+			s.sendEvent(types.TransactionEvent{
+				Type: types.TxsAdded,
+				Txs:  []types.Transaction{tx},
+			})
 		}(tx)
 	}
 	return count, nil
 }
 
-func (s *txStore) UpdateTransactions(
-	_ context.Context, txs []types.Transaction,
+func (s *txStore) SettleTransactions(
+	ctx context.Context, txids []string,
 ) (int, error) {
-	count := 0
+	txs, err := s.GetTransactions(ctx, txids)
+	if err != nil {
+		return -1, err
+	}
+
 	for _, tx := range txs {
+		tx.Settled = true
 		if err := s.db.Upsert(tx.TransactionKey.String(), &tx); err != nil {
 			return -1, err
 		}
-		count++
-		go func(tx types.Transaction) {
-			s.sendEvent(tx)
-		}(tx)
 	}
-	return count, nil
+	s.sendEvent(types.TransactionEvent{Type: types.TxsSettled, Txs: txs})
+	return len(txs), nil
+}
+
+func (s *txStore) ConfirmTransactions(
+	ctx context.Context, txids []string, timestamp time.Time,
+) (int, error) {
+	txs, err := s.GetTransactions(ctx, txids)
+	if err != nil {
+		return -1, err
+	}
+
+	for _, tx := range txs {
+		tx.CreatedAt = timestamp
+		if err := s.db.Upsert(tx.TransactionKey.String(), &tx); err != nil {
+			return -1, err
+		}
+	}
+	s.sendEvent(types.TransactionEvent{Type: types.TxsConfirmed, Txs: txs})
+	return len(txs), nil
 }
 
 func (s *txStore) GetAllTransactions(
@@ -109,7 +133,7 @@ func (s *txStore) GetTransactions(
 	return txs, nil
 }
 
-func (s *txStore) GetEventChannel() chan types.Transaction {
+func (s *txStore) GetEventChannel() chan types.TransactionEvent {
 	return s.eventCh
 }
 
@@ -120,7 +144,7 @@ func (s *txStore) Close() {
 	close(s.eventCh)
 }
 
-func (s *txStore) sendEvent(event types.Transaction) {
+func (s *txStore) sendEvent(event types.TransactionEvent) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/pkg/client-sdk/store/service_test.go
+++ b/pkg/client-sdk/store/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ark-network/ark/pkg/client-sdk/store"
 	filedb "github.com/ark-network/ark/pkg/client-sdk/store/file"
 	inmemorydb "github.com/ark-network/ark/pkg/client-sdk/store/inmemory"
+	"github.com/ark-network/ark/pkg/client-sdk/types"
 	sdktypes "github.com/ark-network/ark/pkg/client-sdk/types"
 	"github.com/ark-network/ark/pkg/client-sdk/wallet"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -111,8 +112,9 @@ func TestNewService(t *testing.T) {
 
 	go func() {
 		eventCh := service.TransactionStore().GetEventChannel()
-		for tx := range eventCh {
-			log.Infof("Tx inserted: %d %v", tx.Amount, tx.Type)
+		for event := range eventCh {
+			log.Infof("Tx inserted: %d %v", event.Txs[0].Amount, event.Txs[0].Type)
+			require.Equal(t, types.TxsAdded, event.Type)
 		}
 	}()
 

--- a/pkg/client-sdk/types/interfaces.go
+++ b/pkg/client-sdk/types/interfaces.go
@@ -1,6 +1,9 @@
 package types
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type Store interface {
 	ConfigStore() ConfigStore
@@ -20,18 +23,19 @@ type ConfigStore interface {
 
 type TransactionStore interface {
 	AddTransactions(ctx context.Context, txs []Transaction) (int, error)
-	UpdateTransactions(ctx context.Context, txs []Transaction) (int, error)
+	SettleTransactions(ctx context.Context, txids []string) (int, error)
+	ConfirmTransactions(ctx context.Context, txids []string, timestamp time.Time) (int, error)
 	GetAllTransactions(ctx context.Context) ([]Transaction, error)
 	GetTransactions(ctx context.Context, txids []string) ([]Transaction, error)
-	GetEventChannel() chan Transaction
+	GetEventChannel() chan TransactionEvent
 	Close()
 }
 
 type VtxoStore interface {
 	AddVtxos(ctx context.Context, vtxos []Vtxo) (int, error)
-	UpdateVtxos(ctx context.Context, vtxos []Vtxo) (int, error)
 	SpendVtxos(ctx context.Context, vtxos []VtxoKey, spentBy string) (int, error)
 	GetAllVtxos(ctx context.Context) (spendable []Vtxo, spent []Vtxo, err error)
 	GetVtxos(ctx context.Context, keys []VtxoKey) ([]Vtxo, error)
+	GetEventChannel() chan VtxoEvent
 	Close()
 }

--- a/pkg/client-sdk/types/types.go
+++ b/pkg/client-sdk/types/types.go
@@ -54,6 +54,25 @@ type Vtxo struct {
 	Spent     bool
 }
 
+type VtxoEventType int
+
+const (
+	VtxosAdded VtxoEventType = iota
+	VtxosSpent
+)
+
+func (e VtxoEventType) String() string {
+	return map[VtxoEventType]string{
+		VtxosAdded: "VTXOS_ADDED",
+		VtxosSpent: "VTXOS_SPENT",
+	}[e]
+}
+
+type VtxoEvent struct {
+	Type  VtxoEventType
+	Vtxos []Vtxo
+}
+
 const (
 	TxSent     TxType = "SENT"
 	TxReceived TxType = "RECEIVED"
@@ -94,6 +113,27 @@ func (t Transaction) IsOOR() bool {
 func (t Transaction) String() string {
 	buf, _ := json.MarshalIndent(t, "", "  ")
 	return string(buf)
+}
+
+type TxEventType int
+
+const (
+	TxsAdded TxEventType = iota
+	TxsSettled
+	TxsConfirmed
+)
+
+func (e TxEventType) String() string {
+	return map[TxEventType]string{
+		TxsAdded:     "TXS_ADDED",
+		TxsSettled:   "TXS_SETTLED",
+		TxsConfirmed: "TXS_CONFIRMED",
+	}[e]
+}
+
+type TransactionEvent struct {
+	Type TxEventType
+	Txs  []Transaction
 }
 
 type Utxo struct {


### PR DESCRIPTION
This adds a new GetVtxoEventChannel API to the sdk client so that consumers can get notified whenever a list of vtxos is either added to the vtxo set or updated to spent.

This also adds changes so that GetTransactionEventChannel returns events for transactions that are added to the history, or updated to confirmed (onchain txs) or settled (offchain txs).

Please @bordalix @louisinger review this.