### PR TITLE
fix marketHour on /v1/info

### DIFF
--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -519,8 +519,8 @@ func (s *covenantService) GetInfo(ctx context.Context) (*ServiceInfo, error) {
 		NextMarketHour: &NextMarketHour{
 			StartTime:     marketHourNextStart,
 			EndTime:       marketHourNextEnd,
-			Period:        marketHourConfig.Period,
-			RoundInterval: marketHourConfig.RoundInterval,
+			Period:        marketHourConfig.Period.Seconds(),
+			RoundInterval: marketHourConfig.RoundInterval.Seconds(),
 		},
 	}, nil
 }

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -893,8 +893,8 @@ func (s *covenantlessService) GetInfo(ctx context.Context) (*ServiceInfo, error)
 		NextMarketHour: &NextMarketHour{
 			StartTime:     marketHourNextStart,
 			EndTime:       marketHourNextEnd,
-			Period:        marketHourConfig.Period,
-			RoundInterval: marketHourConfig.RoundInterval,
+			Period:        marketHourConfig.Period.Seconds(),
+			RoundInterval: marketHourConfig.RoundInterval.Seconds(),
 		},
 	}, nil
 }

--- a/server/internal/core/application/types.go
+++ b/server/internal/core/application/types.go
@@ -68,8 +68,8 @@ type ServiceInfo struct {
 type NextMarketHour struct {
 	StartTime     time.Time
 	EndTime       time.Time
-	Period        time.Duration
-	RoundInterval time.Duration
+	Period        float64
+	RoundInterval float64
 }
 
 type WalletStatus struct {


### PR DESCRIPTION
Instead of this

![Screenshot 2025-02-26 at 10 56 29](https://github.com/user-attachments/assets/c3f5cb48-f52c-400a-9d27-81134a8caa7d)

we get the correct values 86400 and 15

@altafan please review