### PR TITLE
fix marketHour on /v1/info

### DIFF
--- a/server/internal/interface/grpc/handlers/arkservice.go
+++ b/server/internal/interface/grpc/handlers/arkservice.go
@@ -80,8 +80,8 @@ func (h *handler) GetInfo(
 		MarketHour: &arkv1.MarketHour{
 			NextStartTime: info.NextMarketHour.StartTime.Unix(),
 			NextEndTime:   info.NextMarketHour.EndTime.Unix(),
-			Period:        int64(info.NextMarketHour.Period),
-			RoundInterval: int64(info.NextMarketHour.RoundInterval),
+			Period:        int64(info.NextMarketHour.Period.Seconds()),
+			RoundInterval: int64(info.NextMarketHour.RoundInterval.Seconds()),
 		},
 		Version: h.version,
 	}, nil


### PR DESCRIPTION
Instead of this

![Screenshot 2025-02-26 at 10 56 29](https://github.com/user-attachments/assets/0bbbb2f3-9c36-4612-a7ce-ed1828b2e18c)

we get the correct values 86400 and 15

@altafan please review