### PR TITLE
Telemetry - Go runtime metrics

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.34.0
+	go.opentelemetry.io/otel/metric v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
 	go.opentelemetry.io/otel/sdk/metric v1.34.0
 	google.golang.org/grpc v1.69.4
@@ -164,7 +165,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.28.0 // indirect
-	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/server/internal/interface/grpc/otel.go
+++ b/server/internal/interface/grpc/otel.go
@@ -19,8 +19,6 @@ import (
 )
 
 var arkRuntimeMetrics = []string{
-	//Counts how many calls Go made into C code (via cgo). Useful for diagnosing heavy cgo overhead
-	"/cgo/go-to-c-calls:calls",
 	//CPU time in user Go code (not GC or idle). Compare with GC CPU to see if GC is dominating.
 	"/cpu/classes/user:cpu-seconds",
 	//CPU time spent in garbage collection. Helps detect if GC overhead is large.

--- a/server/internal/interface/grpc/otel.go
+++ b/server/internal/interface/grpc/otel.go
@@ -175,7 +175,6 @@ const (
 )
 
 var typeMap = map[string]metricType{
-	"/cgo/go-to-c-calls:calls":          asCounter,
 	"/cpu/classes/user:cpu-seconds":     asCounter,
 	"/cpu/classes/gc/total:cpu-seconds": asCounter,
 	"/gc/cycles/total:gc-cycles":        asCounter,

--- a/server/internal/interface/grpc/otel.go
+++ b/server/internal/interface/grpc/otel.go
@@ -1,0 +1,252 @@
+package grpcservice
+
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	metricExport "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	traceExport "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"runtime/metrics"
+	"strings"
+	"sync"
+	"time"
+)
+
+var arkRuntimeMetrics = []string{
+	//Counts how many calls Go made into C code (via cgo). Useful for diagnosing heavy cgo overhead
+	"/cgo/go-to-c-calls:calls",
+	//CPU time in user Go code (not GC or idle). Compare with GC CPU to see if GC is dominating.
+	"/cpu/classes/user:cpu-seconds",
+	//CPU time spent in garbage collection. Helps detect if GC overhead is large.
+	"/cpu/classes/gc/total:cpu-seconds",
+	//Total number of completed GC cycles. A high rate may indicate excessive allocation or small heaps.
+	"/gc/cycles/total:gc-cycles",
+	//Heap memory used by live objects after the last GC cycle. Great for spotting leaks.
+	"/gc/heap/live:bytes",
+	//Current number of live goroutines. Rises if there's a goroutine leak or concurrency spikes.
+	"/sched/goroutines:goroutines",
+	//Total memory mapped by the Go runtime. Good for overall runtime footprint.
+	"/memory/classes/total:bytes",
+	//Approximate total time goroutines have spent blocked on locks. Spikes show contention.
+	"/sync/mutex/wait/total:seconds",
+	//Cumulative bytes allocated by Go on the heap since process start. Helps gauge allocation rate.
+	"/gc/heap/allocs:bytes",
+	//Cumulative bytes freed by the garbage collector. Compare with allocs to see net usage.
+	"/gc/heap/frees:bytes",
+}
+
+func initOtelSDK(ctx context.Context, otelCollectorUrl string) (func(context.Context) error, error) {
+	otelCollectorUrl = strings.TrimSuffix(otelCollectorUrl, "/")
+	traceExp, err := traceExport.New(
+		ctx,
+		traceExport.WithEndpoint(strings.TrimPrefix(otelCollectorUrl, "http://")),
+		traceExport.WithInsecure(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("arkd"),
+	)
+	tp := trace.NewTracerProvider(
+		trace.WithBatcher(traceExp),
+		trace.WithResource(res),
+	)
+
+	metricExp, err := metricExport.New(
+		ctx,
+		metricExport.WithEndpoint(strings.TrimPrefix(otelCollectorUrl, "http://")),
+		metricExport.WithInsecure(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := sdkmetric.NewPeriodicReader(
+		metricExp,
+		sdkmetric.WithInterval(5*time.Second),
+	)
+
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
+
+	go collectGoRuntimeMetrics(context.Background())
+
+	shutdown := func(ctx context.Context) error {
+		err1 := tp.Shutdown(ctx)
+		err2 := mp.Shutdown(ctx)
+		if err1 != nil {
+			return err1
+		}
+		return err2
+	}
+
+	log.Info("otel sdk initialized")
+
+	return shutdown, nil
+}
+
+// collectGoRuntimeMetrics is the main function that sets up the OTEL callback
+// to read runtime/metrics and publish them as OTel metrics.
+func collectGoRuntimeMetrics(ctx context.Context) {
+	m := otel.Meter("ark.runtime")
+	inst, err := initArkRuntimeInstruments(m)
+	if err != nil {
+		return
+	}
+
+	samples := make([]metrics.Sample, 0, len(arkRuntimeMetrics))
+	for _, n := range arkRuntimeMetrics {
+		samples = append(samples, metrics.Sample{Name: n})
+	}
+
+	_, err = m.RegisterCallback(
+		func(ctx context.Context, obs metric.Observer) error {
+			metrics.Read(samples)
+			mu.Lock()
+			defer mu.Unlock()
+
+			for _, sample := range samples {
+				rName := sample.Name
+				val := sample.Value
+				mType := typeMap[rName]
+
+				switch mType {
+				case asCounter:
+					switch val.Kind() {
+					case metrics.KindUint64:
+						obs.ObserveInt64(
+							inst.counters[rName],
+							int64(val.Uint64()),
+							metric.WithAttributes(attribute.String("rt.name", rName)),
+						)
+					case metrics.KindFloat64:
+						obs.ObserveInt64(
+							inst.counters[rName],
+							int64(val.Float64()),
+							metric.WithAttributes(attribute.String("rt.name", rName)),
+						)
+					}
+
+				case asGauge:
+					switch val.Kind() {
+					case metrics.KindUint64:
+						obs.ObserveInt64(
+							inst.gauges[rName],
+							int64(val.Uint64()),
+							metric.WithAttributes(attribute.String("rt.name", rName)),
+						)
+					case metrics.KindFloat64:
+						obs.ObserveInt64(
+							inst.gauges[rName],
+							int64(val.Float64()),
+							metric.WithAttributes(attribute.String("rt.name", rName)),
+						)
+					}
+				}
+			}
+			return nil
+		},
+		collectInstruments(inst)...,
+	)
+	if err != nil {
+		return
+	}
+
+	log.Info("otel started collecting runtime metrics")
+}
+
+type metricType int
+
+const (
+	asGauge metricType = iota
+	asCounter
+)
+
+var typeMap = map[string]metricType{
+	"/cgo/go-to-c-calls:calls":          asCounter,
+	"/cpu/classes/user:cpu-seconds":     asCounter,
+	"/cpu/classes/gc/total:cpu-seconds": asCounter,
+	"/gc/cycles/total:gc-cycles":        asCounter,
+	"/gc/heap/live:bytes":               asGauge,
+	"/sched/goroutines:goroutines":      asGauge,
+	"/memory/classes/total:bytes":       asGauge,
+	"/sync/mutex/wait/total:seconds":    asCounter,
+	"/gc/heap/allocs:bytes":             asCounter,
+	"/gc/heap/frees:bytes":              asCounter,
+}
+
+var mu sync.Mutex
+
+// arkMetricName converts e.g. "/cpu/classes/user:cpu-seconds" to "ark_cpu_classes_user_cpu-seconds"
+func arkMetricName(name string) string {
+	clean := strings.ReplaceAll(name, "/", "_")
+	clean = strings.ReplaceAll(clean, ":", "_")
+	for strings.HasPrefix(clean, "_") {
+		clean = clean[1:]
+	}
+	return "ark_" + clean
+}
+
+type arkInstruments struct {
+	counters map[string]metric.Int64ObservableCounter
+	gauges   map[string]metric.Int64ObservableGauge
+}
+
+func initArkRuntimeInstruments(m metric.Meter) (*arkInstruments, error) {
+	inst := &arkInstruments{
+		counters: make(map[string]metric.Int64ObservableCounter),
+		gauges:   make(map[string]metric.Int64ObservableGauge),
+	}
+	for _, rName := range arkRuntimeMetrics {
+		mType := typeMap[rName]
+		mName := arkMetricName(rName)
+
+		switch mType {
+		case asCounter:
+			ctr, err := m.Int64ObservableCounter(
+				mName,
+				metric.WithDescription("runtime metric for "+rName),
+			)
+			if err != nil {
+				return nil, err
+			}
+			inst.counters[rName] = ctr
+
+		case asGauge:
+			g, err := m.Int64ObservableGauge(
+				mName,
+				metric.WithDescription("runtime metric for "+rName),
+			)
+			if err != nil {
+				return nil, err
+			}
+			inst.gauges[rName] = g
+		}
+	}
+	return inst, nil
+}
+
+func collectInstruments(inst *arkInstruments) []metric.Observable {
+	var list []metric.Observable
+	for _, c := range inst.counters {
+		list = append(list, c)
+	}
+	for _, g := range inst.gauges {
+		list = append(list, g)
+	}
+	return list
+}

--- a/server/internal/interface/grpc/service.go
+++ b/server/internal/interface/grpc/service.go
@@ -4,24 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"net/http"
-	"path/filepath"
-	"runtime/metrics"
-	"sort"
-	"strings"
-	"time"
-
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	metricExport "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	traceExport "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/metric"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/resource"
-	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-
 	arkv1 "github.com/ark-network/ark/api-spec/protobuf/gen/ark/v1"
 	"github.com/ark-network/ark/server/internal/config"
 	"github.com/ark-network/ark/server/internal/core/application"
@@ -32,6 +14,8 @@ import (
 	"github.com/ark-network/ark/server/pkg/macaroons"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
@@ -39,6 +23,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/encoding/protojson"
+	"net/http"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -179,7 +166,7 @@ func (s *service) stop(withAppSvc bool) {
 
 func (s *service) newServer(tlsConfig *tls.Config, withAppSvc bool) error {
 	if s.appConfig.OtelCollectorEndpoint != "" {
-		otelShutdown, err := initOpenTelemetry(context.Background(), s.appConfig.OtelCollectorEndpoint)
+		otelShutdown, err := initOtelSDK(context.Background(), s.appConfig.OtelCollectorEndpoint)
 		if err != nil {
 			return err
 		}
@@ -425,268 +412,4 @@ func isOptionRequest(req *http.Request) bool {
 func isHttpRequest(req *http.Request) bool {
 	return req.Method == http.MethodGet ||
 		strings.Contains(req.Header.Get("Content-Type"), "application/json")
-}
-
-func initOpenTelemetry(ctx context.Context, otelCollectorUrl string) (func(context.Context) error, error) {
-	// Remove trailing slash if present
-	otelCollectorUrl = strings.TrimSuffix(otelCollectorUrl, "/")
-
-	traceExp, err := traceExport.New(
-		ctx,
-		traceExport.WithEndpoint(strings.TrimPrefix(otelCollectorUrl, "http://")), //TODO double check
-		traceExport.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create trace exporter: %w", err)
-	}
-
-	res := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceName("arkd"),
-	)
-	tp := trace.NewTracerProvider(
-		trace.WithBatcher(traceExp),
-		trace.WithResource(res),
-	)
-
-	metricExp, err := metricExport.New(
-		ctx,
-		metricExport.WithEndpoint(strings.TrimPrefix(otelCollectorUrl, "http://")), // Remove http:// prefix
-		metricExport.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
-	}
-
-	reader := sdkmetric.NewPeriodicReader(
-		metricExp,
-		sdkmetric.WithInterval(5*time.Second),
-	)
-
-	mp := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(reader),
-		sdkmetric.WithResource(res),
-	)
-
-	otel.SetTracerProvider(tp)
-	otel.SetMeterProvider(mp)
-
-	// Start collecting runtime metrics
-	go collectRuntimeMetrics(ctx)
-
-	log.Info("initialized opentelemetry")
-
-	shutdown := func(ctx context.Context) error {
-		err1 := tp.Shutdown(ctx)
-		err2 := mp.Shutdown(ctx)
-		if err1 != nil {
-			return err1
-		}
-		return err2
-	}
-	return shutdown, nil
-}
-
-func collectRuntimeMetrics(ctx context.Context) {
-	meter := otel.Meter("runtime.metrics")
-
-	// Define our metrics by their semantic type
-	gaugeMetrics := map[string]bool{
-		// Memory metrics (gauges)
-		"/memory/classes/heap/objects:bytes":  true,
-		"/memory/classes/heap/free:bytes":     true,
-		"/memory/classes/heap/released:bytes": true,
-		"/memory/classes/heap/stacks:bytes":   true,
-		"/memory/classes/total:bytes":         true,
-
-		// GC gauges
-		"/gc/heap/objects:objects": true,
-		"/gc/heap/goal:bytes":      true,
-
-		// Scheduler gauges
-		"/sched/goroutines:goroutines": true,
-		"/sched/gomaxprocs:threads":    true,
-
-		// Histogram metrics (will extract gauge-like statistics)
-		"/gc/pauses:seconds": true,
-	}
-
-	metrics.All()
-
-	counterMetrics := map[string]bool{
-		// Counters (monotonically increasing)
-		"/gc/cycles/total:gc-cycles":     true,
-		"/sync/mutex/wait/total:seconds": true,
-	}
-
-	// Combine all metrics for tracking
-	allMetrics := make(map[string]bool)
-	for k, v := range gaugeMetrics {
-		allMetrics[k] = v
-	}
-	for k, v := range counterMetrics {
-		allMetrics[k] = v
-	}
-
-	// Create sample slice
-	var samples []metrics.Sample
-	for name := range allMetrics {
-		samples = append(samples, metrics.Sample{Name: name})
-	}
-
-	// Helper function to format the metric name for OpenTelemetry
-	formatMetricName := func(rawName string) string {
-		// Replace slashes and colons with underscores
-		name := strings.ReplaceAll(rawName, "/", "_")
-		name = strings.ReplaceAll(name, ":", "_")
-		// Add the ark_ prefix
-		return "ark" + name
-	}
-
-	// Register all metrics with their individual names
-	_, err := meter.Int64ObservableGauge(
-		"ark_runtime_metrics_gauge",
-		metric.WithDescription("Ark runtime gauge metrics"),
-		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
-			// Read all metric values
-			metrics.Read(samples)
-
-			// Process all samples
-			for _, sample := range samples {
-				if sample.Value.Kind() == metrics.KindBad {
-					continue
-				}
-
-				// Format the metric name
-				metricName := formatMetricName(sample.Name)
-
-				// Handle gauge metrics
-				if gaugeMetrics[sample.Name] {
-					switch sample.Value.Kind() {
-					case metrics.KindUint64:
-						o.Observe(int64(sample.Value.Uint64()), metric.WithAttributes(
-							attribute.String("metric_name", metricName),
-						))
-					case metrics.KindFloat64:
-						o.Observe(int64(sample.Value.Float64()), metric.WithAttributes(
-							attribute.String("metric_name", metricName),
-						))
-					case metrics.KindFloat64Histogram:
-						// For histograms, extract statistics
-						hist := sample.Value.Float64Histogram()
-						if len(hist.Counts) > 0 {
-							// Calculate mean
-							var sum, count float64
-							for i, c := range hist.Counts {
-								if i+1 < len(hist.Buckets) {
-									midpoint := (hist.Buckets[i] + hist.Buckets[i+1]) / 2
-									sum += midpoint * float64(c)
-									count += float64(c)
-								}
-							}
-
-							if count > 0 {
-								// Report mean
-								o.Observe(int64(sum/count*1e9), metric.WithAttributes( // Convert to nanoseconds
-									attribute.String("metric_name", metricName+"_mean"),
-									attribute.String("statistic", "mean"),
-								))
-
-								// For GC pauses, also report p50, p90, p99 if we have enough data
-								if count >= 10 && sample.Name == "/gc/pauses:seconds" {
-									// This is a simplified percentile calculation
-									var values []float64
-									for i, c := range hist.Counts {
-										if i+1 < len(hist.Buckets) {
-											midpoint := (hist.Buckets[i] + hist.Buckets[i+1]) / 2
-											for j := 0; j < int(c); j++ {
-												values = append(values, midpoint)
-											}
-										}
-									}
-
-									// Sort for percentile calculation
-									sort.Float64s(values)
-
-									// Calculate percentiles
-									if len(values) > 0 {
-										p50idx := int(float64(len(values)) * 0.5)
-										p90idx := int(float64(len(values)) * 0.9)
-										p99idx := int(float64(len(values)) * 0.99)
-
-										if p50idx < len(values) {
-											o.Observe(int64(values[p50idx]*1e9), metric.WithAttributes(
-												attribute.String("metric_name", metricName+"_p50"),
-												attribute.String("statistic", "p50"),
-											))
-										}
-
-										if p90idx < len(values) {
-											o.Observe(int64(values[p90idx]*1e9), metric.WithAttributes(
-												attribute.String("metric_name", metricName+"_p90"),
-												attribute.String("statistic", "p90"),
-											))
-										}
-
-										if p99idx < len(values) {
-											o.Observe(int64(values[p99idx]*1e9), metric.WithAttributes(
-												attribute.String("metric_name", metricName+"_p99"),
-												attribute.String("statistic", "p99"),
-											))
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-
-			return nil
-		}),
-	)
-
-	if err != nil {
-		log.Error(fmt.Sprintf("failed to register gauge metrics: %v", err))
-		return
-	}
-
-	// Register counter metrics
-	_, err = meter.Int64ObservableCounter(
-		"ark_runtime_metrics_counter",
-		metric.WithDescription("Ark runtime counter metrics"),
-		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
-			// Read all metrics again
-			metrics.Read(samples)
-
-			// Process counter metrics
-			for _, sample := range samples {
-				if !counterMetrics[sample.Name] || sample.Value.Kind() == metrics.KindBad {
-					continue
-				}
-
-				// Format the metric name
-				metricName := formatMetricName(sample.Name)
-
-				switch sample.Value.Kind() {
-				case metrics.KindUint64:
-					o.Observe(int64(sample.Value.Uint64()), metric.WithAttributes(
-						attribute.String("metric_name", metricName),
-					))
-				case metrics.KindFloat64:
-					o.Observe(int64(sample.Value.Float64()), metric.WithAttributes(
-						attribute.String("metric_name", metricName),
-					))
-				}
-			}
-
-			return nil
-		}),
-	)
-
-	if err != nil {
-		log.Error(fmt.Sprintf("failed to register counter metrics: %v", err))
-	}
-
-	log.Info("Started collecting Ark Go runtime metrics with metric_name attribute")
 }

--- a/server/internal/interface/grpc/service.go
+++ b/server/internal/interface/grpc/service.go
@@ -6,14 +6,18 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime/metrics"
+	"sort"
 	"strings"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	metricExport "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	traceExport "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -454,18 +458,21 @@ func initOpenTelemetry(ctx context.Context, otelCollectorUrl string) (func(conte
 		return nil, fmt.Errorf("failed to create metric exporter: %w", err)
 	}
 
-	reader := metric.NewPeriodicReader(
+	reader := sdkmetric.NewPeriodicReader(
 		metricExp,
-		metric.WithInterval(5*time.Second),
+		sdkmetric.WithInterval(5*time.Second),
 	)
 
-	mp := metric.NewMeterProvider(
-		metric.WithReader(reader),
-		metric.WithResource(res),
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(res),
 	)
 
 	otel.SetTracerProvider(tp)
 	otel.SetMeterProvider(mp)
+
+	// Start collecting runtime metrics
+	go collectRuntimeMetrics(ctx)
 
 	log.Info("initialized opentelemetry")
 
@@ -478,4 +485,208 @@ func initOpenTelemetry(ctx context.Context, otelCollectorUrl string) (func(conte
 		return err2
 	}
 	return shutdown, nil
+}
+
+func collectRuntimeMetrics(ctx context.Context) {
+	meter := otel.Meter("runtime.metrics")
+
+	// Define our metrics by their semantic type
+	gaugeMetrics := map[string]bool{
+		// Memory metrics (gauges)
+		"/memory/classes/heap/objects:bytes":  true,
+		"/memory/classes/heap/free:bytes":     true,
+		"/memory/classes/heap/released:bytes": true,
+		"/memory/classes/heap/stacks:bytes":   true,
+		"/memory/classes/total:bytes":         true,
+
+		// GC gauges
+		"/gc/heap/objects:objects": true,
+		"/gc/heap/goal:bytes":      true,
+
+		// Scheduler gauges
+		"/sched/goroutines:goroutines": true,
+		"/sched/gomaxprocs:threads":    true,
+
+		// Histogram metrics (will extract gauge-like statistics)
+		"/gc/pauses:seconds": true,
+	}
+
+	metrics.All()
+
+	counterMetrics := map[string]bool{
+		// Counters (monotonically increasing)
+		"/gc/cycles/total:gc-cycles":     true,
+		"/sync/mutex/wait/total:seconds": true,
+	}
+
+	// Combine all metrics for tracking
+	allMetrics := make(map[string]bool)
+	for k, v := range gaugeMetrics {
+		allMetrics[k] = v
+	}
+	for k, v := range counterMetrics {
+		allMetrics[k] = v
+	}
+
+	// Create sample slice
+	var samples []metrics.Sample
+	for name := range allMetrics {
+		samples = append(samples, metrics.Sample{Name: name})
+	}
+
+	// Helper function to format the metric name for OpenTelemetry
+	formatMetricName := func(rawName string) string {
+		// Replace slashes and colons with underscores
+		name := strings.ReplaceAll(rawName, "/", "_")
+		name = strings.ReplaceAll(name, ":", "_")
+		// Add the ark_ prefix
+		return "ark" + name
+	}
+
+	// Register all metrics with their individual names
+	_, err := meter.Int64ObservableGauge(
+		"ark_runtime_metrics_gauge",
+		metric.WithDescription("Ark runtime gauge metrics"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			// Read all metric values
+			metrics.Read(samples)
+
+			// Process all samples
+			for _, sample := range samples {
+				if sample.Value.Kind() == metrics.KindBad {
+					continue
+				}
+
+				// Format the metric name
+				metricName := formatMetricName(sample.Name)
+
+				// Handle gauge metrics
+				if gaugeMetrics[sample.Name] {
+					switch sample.Value.Kind() {
+					case metrics.KindUint64:
+						o.Observe(int64(sample.Value.Uint64()), metric.WithAttributes(
+							attribute.String("metric_name", metricName),
+						))
+					case metrics.KindFloat64:
+						o.Observe(int64(sample.Value.Float64()), metric.WithAttributes(
+							attribute.String("metric_name", metricName),
+						))
+					case metrics.KindFloat64Histogram:
+						// For histograms, extract statistics
+						hist := sample.Value.Float64Histogram()
+						if len(hist.Counts) > 0 {
+							// Calculate mean
+							var sum, count float64
+							for i, c := range hist.Counts {
+								if i+1 < len(hist.Buckets) {
+									midpoint := (hist.Buckets[i] + hist.Buckets[i+1]) / 2
+									sum += midpoint * float64(c)
+									count += float64(c)
+								}
+							}
+
+							if count > 0 {
+								// Report mean
+								o.Observe(int64(sum/count*1e9), metric.WithAttributes( // Convert to nanoseconds
+									attribute.String("metric_name", metricName+"_mean"),
+									attribute.String("statistic", "mean"),
+								))
+
+								// For GC pauses, also report p50, p90, p99 if we have enough data
+								if count >= 10 && sample.Name == "/gc/pauses:seconds" {
+									// This is a simplified percentile calculation
+									var values []float64
+									for i, c := range hist.Counts {
+										if i+1 < len(hist.Buckets) {
+											midpoint := (hist.Buckets[i] + hist.Buckets[i+1]) / 2
+											for j := 0; j < int(c); j++ {
+												values = append(values, midpoint)
+											}
+										}
+									}
+
+									// Sort for percentile calculation
+									sort.Float64s(values)
+
+									// Calculate percentiles
+									if len(values) > 0 {
+										p50idx := int(float64(len(values)) * 0.5)
+										p90idx := int(float64(len(values)) * 0.9)
+										p99idx := int(float64(len(values)) * 0.99)
+
+										if p50idx < len(values) {
+											o.Observe(int64(values[p50idx]*1e9), metric.WithAttributes(
+												attribute.String("metric_name", metricName+"_p50"),
+												attribute.String("statistic", "p50"),
+											))
+										}
+
+										if p90idx < len(values) {
+											o.Observe(int64(values[p90idx]*1e9), metric.WithAttributes(
+												attribute.String("metric_name", metricName+"_p90"),
+												attribute.String("statistic", "p90"),
+											))
+										}
+
+										if p99idx < len(values) {
+											o.Observe(int64(values[p99idx]*1e9), metric.WithAttributes(
+												attribute.String("metric_name", metricName+"_p99"),
+												attribute.String("statistic", "p99"),
+											))
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			return nil
+		}),
+	)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("failed to register gauge metrics: %v", err))
+		return
+	}
+
+	// Register counter metrics
+	_, err = meter.Int64ObservableCounter(
+		"ark_runtime_metrics_counter",
+		metric.WithDescription("Ark runtime counter metrics"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			// Read all metrics again
+			metrics.Read(samples)
+
+			// Process counter metrics
+			for _, sample := range samples {
+				if !counterMetrics[sample.Name] || sample.Value.Kind() == metrics.KindBad {
+					continue
+				}
+
+				// Format the metric name
+				metricName := formatMetricName(sample.Name)
+
+				switch sample.Value.Kind() {
+				case metrics.KindUint64:
+					o.Observe(int64(sample.Value.Uint64()), metric.WithAttributes(
+						attribute.String("metric_name", metricName),
+					))
+				case metrics.KindFloat64:
+					o.Observe(int64(sample.Value.Float64()), metric.WithAttributes(
+						attribute.String("metric_name", metricName),
+					))
+				}
+			}
+
+			return nil
+		}),
+	)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("failed to register counter metrics: %v", err))
+	}
+
+	log.Info("Started collecting Ark Go runtime metrics with metric_name attribute")
 }


### PR DESCRIPTION
This adds another ‘telemetry’ layer that will help us have better observability of arkd process it self.
We already have next metrics/dashboards: hostmetrics which gathers metrics for whole machine(cpu, RAM/Disc memory, Network/Disc I/O), we have arkd GPRC latency, count, request size, recently i added Cadvisor that tracks stats for each docker container running in machine separately and now I added metrics that will give us better insight into arkd go process it self. Check [here](https://github.com/sekulicd/ark/blob/7108217930ffe837cedf262d1fa3ad161747cc62/server/internal/interface/grpc/otel.go#L21) metrics i decided to track after investigation, goal is to inspect possible memory, go routines leaks, does gc behaves problematic, there is also metric tracking lock time for mutexes and num of cgo calls that could maybe indicate some places for future optimizations.

@altafan @tiero please take a look.