### PR TITLE
Skip waiting for signed boarding ins/forfeit txs if none is required

### DIFF
--- a/nak.Dockerfile
+++ b/nak.Dockerfile
@@ -1,5 +1,5 @@
 # Use official Go image as base
-FROM golang:1.23.3-alpine
+FROM golang:1.24.1-alpine
 
 # Install git (needed for go install)
 RUN apk add --no-cache git

--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -401,9 +401,14 @@ func (s *covenantService) SignRoundTx(ctx context.Context, signedRoundTx string)
 	defer s.currentRoundLock.Unlock()
 	currentRound := s.currentRound
 
-	combined, err := s.builder.VerifyAndCombinePartialTx(currentRound.UnsignedTx, signedRoundTx)
+	numSignedInputs, combined, err := s.builder.VerifyAndCombinePartialTx(
+		currentRound.UnsignedTx, signedRoundTx,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to verify and combine partial tx: %s", err)
+	}
+	if numSignedInputs == 0 {
+		return nil
 	}
 
 	s.currentRound.UnsignedTx = combined

--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -397,18 +397,21 @@ func (s *covenantService) SignVtxos(ctx context.Context, forfeitTxs []string) er
 }
 
 func (s *covenantService) SignRoundTx(ctx context.Context, signedRoundTx string) error {
+	numSignedInputs, err := s.builder.CountSignedTaprootInputs(signedRoundTx)
+	if err != nil {
+		return fmt.Errorf("failed to count number of signed boarding inputs: %s", err)
+	}
+	if numSignedInputs == 0 {
+		return nil
+	}
+
 	s.currentRoundLock.Lock()
 	defer s.currentRoundLock.Unlock()
 	currentRound := s.currentRound
 
-	numSignedInputs, combined, err := s.builder.VerifyAndCombinePartialTx(
-		currentRound.UnsignedTx, signedRoundTx,
-	)
+	combined, err := s.builder.VerifyAndCombinePartialTx(currentRound.UnsignedTx, signedRoundTx)
 	if err != nil {
 		return fmt.Errorf("failed to verify and combine partial tx: %s", err)
-	}
-	if numSignedInputs == 0 {
-		return nil
 	}
 
 	s.currentRound.UnsignedTx = combined

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1490,6 +1490,9 @@ func (s *covenantlessService) finalizeRound(notes []note.Note, roundEndTime time
 	}
 	includesBoardingInputs := false
 	for _, in := range roundTx.Inputs {
+		// TODO: this is ok as long as the server doesn't use taproot address too!
+		// We need to find a better way to understand if an in input is ours or if
+		// it's a boarding one.
 		scriptType := txscript.GetScriptClass(in.WitnessUtxo.PkScript)
 		if scriptType == txscript.WitnessV1TaprootTy {
 			includesBoardingInputs = true

--- a/server/internal/core/ports/tx_builder.go
+++ b/server/internal/core/ports/tx_builder.go
@@ -56,6 +56,6 @@ type TxBuilder interface {
 	VerifyTapscriptPartialSigs(tx string) (valid bool, txid string, err error)
 	// FindLeaves returns all the leaves txs that are reachable from the given outpoint
 	FindLeaves(vtxoTree tree.TxTree, fromtxid string, vout uint32) (leaves []tree.Node, err error)
-	VerifyAndCombinePartialTx(dest string, src string) (string, error)
+	VerifyAndCombinePartialTx(dest string, src string) (int, string, error)
 	GetTxID(tx string) (string, error)
 }

--- a/server/internal/core/ports/tx_builder.go
+++ b/server/internal/core/ports/tx_builder.go
@@ -56,6 +56,7 @@ type TxBuilder interface {
 	VerifyTapscriptPartialSigs(tx string) (valid bool, txid string, err error)
 	// FindLeaves returns all the leaves txs that are reachable from the given outpoint
 	FindLeaves(vtxoTree tree.TxTree, fromtxid string, vout uint32) (leaves []tree.Node, err error)
-	VerifyAndCombinePartialTx(dest string, src string) (int, string, error)
+	VerifyAndCombinePartialTx(dest string, src string) (string, error)
+	CountSignedTaprootInputs(tx string) (int, error)
 	GetTxID(tx string) (string, error)
 }

--- a/server/internal/infrastructure/tx-builder/covenant/builder.go
+++ b/server/internal/infrastructure/tx-builder/covenant/builder.go
@@ -1087,11 +1087,7 @@ func (b *txBuilder) VerifyAndCombinePartialTx(dest string, src string) (string, 
 		}
 	}
 
-	b64, err := roundSigner.Pset.ToBase64()
-	if err != nil {
-		return "", err
-	}
-	return b64, nil
+	return roundSigner.Pset.ToBase64()
 }
 
 func (b *txBuilder) getTaprootPreimage(pset *psetv2.Pset, inputIndex int, leafHash *chainhash.Hash) ([]byte, error) {

--- a/server/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/server/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -1118,11 +1118,7 @@ func (b *txBuilder) VerifyAndCombinePartialTx(dest string, src string) (string, 
 		}
 	}
 
-	b64, err := roundTx.B64Encode()
-	if err != nil {
-		return "", err
-	}
-	return b64, nil
+	return roundTx.B64Encode()
 }
 
 func (b *txBuilder) minRelayFeeTreeTx() (uint64, error) {


### PR DESCRIPTION
This includes server-side optimization for the execution of the round:
- Do not wait for the execution timeout to expire when a round doesn't contain boarding inputs or forfeit txs to be signed: this is a very edge case in which a round includes only users that are redeeming notes. In this case, users just need to sign the VTXO tree to complete the round execution. Before this, in such case, the server would have waited for the timeout to expire because clients wouldn't submit any signed boarding input or forfeit tx.
- Add safe checks to [`SignRoundTx`](https://github.com/ark-network/ark/blob/master/server/internal/core/application/covenantless.go#L776) to prevent overriding a round tx if the user didn't submit any signed boarding input. Before this, a malicious client could have submitted an unsigned round tx to make the server loose all previous collected signed boarding inputs.

Closes #492.

Please @louisinger @sekulicd review.