### PR TITLE
show market hour on sdk config

### DIFF
--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -200,6 +200,10 @@ func (a *arkClient) initWithWallet(
 		BoardingDescriptorTemplate: info.BoardingDescriptorTemplate,
 		ForfeitAddress:             info.ForfeitAddress,
 		WithTransactionFeed:        args.WithTransactionFeed,
+		MarketHourStartTime:        info.MarketHourStartTime,
+		MarketHourEndTime:          info.MarketHourEndTime,
+		MarketHourPeriod:           info.MarketHourPeriod,
+		MarketHourRoundInterval:    info.MarketHourRoundInterval,
 	}
 	if err := a.store.ConfigStore().AddData(ctx, storeData); err != nil {
 		return err
@@ -278,6 +282,10 @@ func (a *arkClient) init(
 		ExplorerURL:                args.ExplorerURL,
 		ForfeitAddress:             info.ForfeitAddress,
 		WithTransactionFeed:        args.WithTransactionFeed,
+		MarketHourStartTime:        info.MarketHourStartTime,
+		MarketHourEndTime:          info.MarketHourEndTime,
+		MarketHourPeriod:           info.MarketHourPeriod,
+		MarketHourRoundInterval:    info.MarketHourRoundInterval,
 	}
 	walletSvc, err := getWallet(a.store.ConfigStore(), &cfgData, supportedWallets)
 	if err != nil {

--- a/pkg/client-sdk/client/client.go
+++ b/pkg/client-sdk/client/client.go
@@ -69,6 +69,10 @@ type Info struct {
 	Dust                       uint64
 	BoardingDescriptorTemplate string
 	ForfeitAddress             string
+	MarketHourStartTime        string
+	MarketHourEndTime          string
+	MarketHourPeriod           string
+	MarketHourRoundInterval    string
 }
 
 type RoundEventChannel struct {

--- a/pkg/client-sdk/client/client.go
+++ b/pkg/client-sdk/client/client.go
@@ -69,10 +69,10 @@ type Info struct {
 	Dust                       uint64
 	BoardingDescriptorTemplate string
 	ForfeitAddress             string
-	MarketHourStartTime        string
-	MarketHourEndTime          string
-	MarketHourPeriod           string
-	MarketHourRoundInterval    string
+	MarketHourStartTime        int64
+	MarketHourEndTime          int64
+	MarketHourPeriod           int64
+	MarketHourRoundInterval    int64
 }
 
 type RoundEventChannel struct {

--- a/pkg/client-sdk/client/grpc/client.go
+++ b/pkg/client-sdk/client/grpc/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 
@@ -75,10 +74,10 @@ func (a *grpcClient) GetInfo(ctx context.Context) (*client.Info, error) {
 		BoardingDescriptorTemplate: resp.GetBoardingDescriptorTemplate(),
 		ForfeitAddress:             resp.GetForfeitAddress(),
 		Version:                    resp.GetVersion(),
-		MarketHourStartTime:        strconv.FormatInt(resp.GetMarketHour().GetNextStartTime(), 10),
-		MarketHourEndTime:          strconv.FormatInt(resp.GetMarketHour().GetNextEndTime(), 10),
-		MarketHourPeriod:           strconv.FormatInt(resp.GetMarketHour().GetPeriod(), 10),
-		MarketHourRoundInterval:    strconv.FormatInt(resp.GetMarketHour().GetRoundInterval(), 10),
+		MarketHourStartTime:        resp.GetMarketHour().GetNextStartTime(),
+		MarketHourEndTime:          resp.GetMarketHour().GetNextEndTime(),
+		MarketHourPeriod:           resp.GetMarketHour().GetPeriod(),
+		MarketHourRoundInterval:    resp.GetMarketHour().GetRoundInterval(),
 	}, nil
 }
 

--- a/pkg/client-sdk/client/grpc/client.go
+++ b/pkg/client-sdk/client/grpc/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,6 +75,10 @@ func (a *grpcClient) GetInfo(ctx context.Context) (*client.Info, error) {
 		BoardingDescriptorTemplate: resp.GetBoardingDescriptorTemplate(),
 		ForfeitAddress:             resp.GetForfeitAddress(),
 		Version:                    resp.GetVersion(),
+		MarketHourStartTime:        strconv.FormatInt(resp.GetMarketHour().GetNextStartTime(), 10),
+		MarketHourEndTime:          strconv.FormatInt(resp.GetMarketHour().GetNextEndTime(), 10),
+		MarketHourPeriod:           strconv.FormatInt(resp.GetMarketHour().GetPeriod(), 10),
+		MarketHourRoundInterval:    strconv.FormatInt(resp.GetMarketHour().GetRoundInterval(), 10),
 	}, nil
 }
 

--- a/pkg/client-sdk/client/rest/client.go
+++ b/pkg/client-sdk/client/rest/client.go
@@ -68,18 +68,31 @@ func (a *restClient) GetInfo(
 	if err != nil {
 		return nil, err
 	}
-
 	unilateralExitDelay, err := strconv.Atoi(resp.Payload.UnilateralExitDelay)
 	if err != nil {
 		return nil, err
 	}
-
 	roundInterval, err := strconv.Atoi(resp.Payload.RoundInterval)
 	if err != nil {
 		return nil, err
 	}
-
 	dust, err := strconv.Atoi(resp.Payload.Dust)
+	if err != nil {
+		return nil, err
+	}
+	nextStartTime, err := strconv.Atoi(resp.Payload.MarketHour.NextStartTime)
+	if err != nil {
+		return nil, err
+	}
+	nextEndTime, err := strconv.Atoi(resp.Payload.MarketHour.NextEndTime)
+	if err != nil {
+		return nil, err
+	}
+	period, err := strconv.Atoi(resp.Payload.MarketHour.Period)
+	if err != nil {
+		return nil, err
+	}
+	mhRoundInterval, err := strconv.Atoi(resp.Payload.MarketHour.RoundInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -94,10 +107,10 @@ func (a *restClient) GetInfo(
 		BoardingDescriptorTemplate: resp.Payload.BoardingDescriptorTemplate,
 		ForfeitAddress:             resp.Payload.ForfeitAddress,
 		Version:                    resp.Payload.Version,
-		MarketHourStartTime:        resp.Payload.MarketHour.NextStartTime,
-		MarketHourEndTime:          resp.Payload.MarketHour.NextEndTime,
-		MarketHourPeriod:           resp.Payload.MarketHour.Period,
-		MarketHourRoundInterval:    resp.Payload.MarketHour.RoundInterval,
+		MarketHourStartTime:        int64(nextStartTime),
+		MarketHourEndTime:          int64(nextEndTime),
+		MarketHourPeriod:           int64(period),
+		MarketHourRoundInterval:    int64(mhRoundInterval),
 	}, nil
 }
 

--- a/pkg/client-sdk/client/rest/client.go
+++ b/pkg/client-sdk/client/rest/client.go
@@ -94,6 +94,10 @@ func (a *restClient) GetInfo(
 		BoardingDescriptorTemplate: resp.Payload.BoardingDescriptorTemplate,
 		ForfeitAddress:             resp.Payload.ForfeitAddress,
 		Version:                    resp.Payload.Version,
+		MarketHourStartTime:        resp.Payload.MarketHour.NextStartTime,
+		MarketHourEndTime:          resp.Payload.MarketHour.NextEndTime,
+		MarketHourPeriod:           resp.Payload.MarketHour.Period,
+		MarketHourRoundInterval:    resp.Payload.MarketHour.RoundInterval,
 	}, nil
 }
 

--- a/pkg/client-sdk/store/file/config_store.go
+++ b/pkg/client-sdk/store/file/config_store.go
@@ -65,10 +65,10 @@ func (s *configStore) AddData(ctx context.Context, data types.Config) error {
 		ExplorerURL:                data.ExplorerURL,
 		ForfeitAddress:             data.ForfeitAddress,
 		WithTransactionFeed:        strconv.FormatBool(data.WithTransactionFeed),
-		MarketHourStartTime:        data.MarketHourStartTime,
-		MarketHourEndTime:          data.MarketHourEndTime,
-		MarketHourPeriod:           data.MarketHourPeriod,
-		MarketHourRoundInterval:    data.MarketHourRoundInterval,
+		MarketHourStartTime:        fmt.Sprintf("%d", data.MarketHourStartTime),
+		MarketHourEndTime:          fmt.Sprintf("%d", data.MarketHourEndTime),
+		MarketHourPeriod:           fmt.Sprintf("%d", data.MarketHourPeriod),
+		MarketHourRoundInterval:    fmt.Sprintf("%d", data.MarketHourRoundInterval),
 	}
 
 	if err := s.write(sd); err != nil {

--- a/pkg/client-sdk/store/file/config_store.go
+++ b/pkg/client-sdk/store/file/config_store.go
@@ -65,6 +65,10 @@ func (s *configStore) AddData(ctx context.Context, data types.Config) error {
 		ExplorerURL:                data.ExplorerURL,
 		ForfeitAddress:             data.ForfeitAddress,
 		WithTransactionFeed:        strconv.FormatBool(data.WithTransactionFeed),
+		MarketHourStartTime:        data.MarketHourStartTime,
+		MarketHourEndTime:          data.MarketHourEndTime,
+		MarketHourPeriod:           data.MarketHourPeriod,
+		MarketHourRoundInterval:    data.MarketHourRoundInterval,
 	}
 
 	if err := s.write(sd); err != nil {

--- a/pkg/client-sdk/store/file/types.go
+++ b/pkg/client-sdk/store/file/types.go
@@ -49,6 +49,10 @@ func (d storeData) decode() types.Config {
 	buf, _ := hex.DecodeString(d.ServerPubKey)
 	serverPubkey, _ := secp256k1.ParsePubKey(buf)
 	explorerURL := d.ExplorerURL
+	nextStartTime, _ := strconv.Atoi(d.MarketHourStartTime)
+	nextEndTime, _ := strconv.Atoi(d.MarketHourEndTime)
+	period, _ := strconv.Atoi(d.MarketHourPeriod)
+	mhRoundInterval, _ := strconv.Atoi(d.MarketHourRoundInterval)
 
 	vtxoTreeExpiryType := common.LocktimeTypeBlock
 	if vtxoTreeExpiry >= 512 {
@@ -74,6 +78,10 @@ func (d storeData) decode() types.Config {
 		ExplorerURL:                explorerURL,
 		ForfeitAddress:             d.ForfeitAddress,
 		WithTransactionFeed:        withTransactionFeed,
+		MarketHourStartTime:        int64(nextStartTime),
+		MarketHourEndTime:          int64(nextEndTime),
+		MarketHourPeriod:           int64(period),
+		MarketHourRoundInterval:    int64(mhRoundInterval),
 	}
 }
 

--- a/pkg/client-sdk/store/file/types.go
+++ b/pkg/client-sdk/store/file/types.go
@@ -24,6 +24,10 @@ type storeData struct {
 	ExplorerURL                string `json:"explorer_url"`
 	ForfeitAddress             string `json:"forfeit_address"`
 	WithTransactionFeed        string `json:"with_transaction_feed"`
+	MarketHourStartTime        string `json:"market_hour_start_time"`
+	MarketHourEndTime          string `json:"market_hour_end_time"`
+	MarketHourPeriod           string `json:"market_hour_period"`
+	MarketHourRoundInterval    string `json:"market_hour_round_interval"`
 }
 
 func (d storeData) isEmpty() bool {

--- a/pkg/client-sdk/store/file/types.go
+++ b/pkg/client-sdk/store/file/types.go
@@ -100,5 +100,9 @@ func (d storeData) asMap() map[string]string {
 		"explorer_url":                 d.ExplorerURL,
 		"forfeit_address":              d.ForfeitAddress,
 		"with_transaction_feed":        d.WithTransactionFeed,
+		"market_hour_start_time":       d.MarketHourStartTime,
+		"market_hour_end_time":         d.MarketHourEndTime,
+		"market_hour_period":           d.MarketHourPeriod,
+		"market_hour_round_interval":   d.MarketHourRoundInterval,
 	}
 }

--- a/pkg/client-sdk/types/types.go
+++ b/pkg/client-sdk/types/types.go
@@ -30,10 +30,10 @@ type Config struct {
 	ExplorerURL                string
 	ForfeitAddress             string
 	WithTransactionFeed        bool
-	MarketHourStartTime        string
-	MarketHourEndTime          string
-	MarketHourPeriod           string
-	MarketHourRoundInterval    string
+	MarketHourStartTime        int64
+	MarketHourEndTime          int64
+	MarketHourPeriod           int64
+	MarketHourRoundInterval    int64
 }
 
 type VtxoKey struct {

--- a/pkg/client-sdk/types/types.go
+++ b/pkg/client-sdk/types/types.go
@@ -30,6 +30,10 @@ type Config struct {
 	ExplorerURL                string
 	ForfeitAddress             string
 	WithTransactionFeed        bool
+	MarketHourStartTime        string
+	MarketHourEndTime          string
+	MarketHourPeriod           string
+	MarketHourRoundInterval    string
 }
 
 type VtxoKey struct {


### PR DESCRIPTION
In order for clients to calculate the best market hour for future claims, its helpful to know when the server is expecting to run a happy hour. The server already gives that info on /v1/info. This PR makes that information visible in the SDK.

@altafan please review