### PR TITLE
VtxoScript validation when spending a vtxo

### DIFF
--- a/common/bitcointree/pending.go
+++ b/common/bitcointree/pending.go
@@ -26,11 +26,18 @@ func BuildRedeemTx(
 	ins := make([]*wire.OutPoint, 0, len(vtxos))
 	sequences := make([]uint32, 0, len(vtxos))
 	witnessUtxos := make(map[int]*wire.TxOut)
-	tapscripts := make(map[int]*psbt.TaprootTapLeafScript)
+	signingTapLeaves := make(map[int]*psbt.TaprootTapLeafScript)
+	tapscripts := make(map[int][]string)
 
 	txLocktime := common.AbsoluteLocktime(0)
 
 	for index, vtxo := range vtxos {
+		if len(vtxo.RevealedTapscripts) == 0 {
+			return "", fmt.Errorf("missing tapscripts for input %d", index)
+		}
+
+		tapscripts[index] = vtxo.RevealedTapscripts
+
 		rootHash := vtxo.Tapscript.ControlBlock.RootHash(vtxo.Tapscript.RevealedScript)
 		taprootKey := txscript.ComputeTaprootOutputKey(UnspendableKey(), rootHash)
 
@@ -49,7 +56,7 @@ func BuildRedeemTx(
 			return "", err
 		}
 
-		tapscripts[index] = &psbt.TaprootTapLeafScript{
+		signingTapLeaves[index] = &psbt.TaprootTapLeafScript{
 			ControlBlock: ctrlBlockBytes,
 			Script:       vtxo.Tapscript.RevealedScript,
 			LeafVersion:  txscript.BaseLeafVersion,
@@ -97,7 +104,10 @@ func BuildRedeemTx(
 
 	for i := range redeemPtx.Inputs {
 		redeemPtx.Inputs[i].WitnessUtxo = witnessUtxos[i]
-		redeemPtx.Inputs[i].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapscripts[i]}
+		redeemPtx.Inputs[i].TaprootLeafScript = []*psbt.TaprootTapLeafScript{signingTapLeaves[i]}
+		if err := AddTapscripts(i, redeemPtx, tapscripts[i]); err != nil {
+			return "", err
+		}
 	}
 
 	redeemTx, err := redeemPtx.B64Encode()

--- a/common/bitcointree/pending.go
+++ b/common/bitcointree/pending.go
@@ -105,7 +105,7 @@ func BuildRedeemTx(
 	for i := range redeemPtx.Inputs {
 		redeemPtx.Inputs[i].WitnessUtxo = witnessUtxos[i]
 		redeemPtx.Inputs[i].TaprootLeafScript = []*psbt.TaprootTapLeafScript{signingTapLeaves[i]}
-		if err := AddTapscripts(i, redeemPtx, tapscripts[i]); err != nil {
+		if err := AddTaprootTree(i, redeemPtx, tapscripts[i]); err != nil {
 			return "", err
 		}
 	}

--- a/common/bitcointree/psbt_test.go
+++ b/common/bitcointree/psbt_test.go
@@ -131,11 +131,11 @@ func TestPsbtCustomUnknownFields(t *testing.T) {
 
 		for _, scripts := range testCases {
 			// Add tapscripts to input 0
-			err = bitcointree.AddTapscripts(0, ptx, scripts)
+			err = bitcointree.AddTaprootTree(0, ptx, scripts)
 			require.NoError(t, err)
 
 			// Get tapscripts back and verify
-			retrievedScripts, err := bitcointree.GetTapscripts(ptx.Inputs[0])
+			retrievedScripts, err := bitcointree.GetTaprootTree(ptx.Inputs[0])
 			require.NoError(t, err)
 			require.Equal(t, len(scripts), len(retrievedScripts))
 

--- a/common/bitcointree/psbt_test.go
+++ b/common/bitcointree/psbt_test.go
@@ -105,4 +105,46 @@ func TestPsbtCustomUnknownFields(t *testing.T) {
 			require.Equal(t, keys[i].SerializeCompressed(), retrievedKeys[i].SerializeCompressed())
 		}
 	})
+
+	t.Run("tapscripts", func(t *testing.T) {
+		// Create a new PSBT
+		ptx, err := psbt.New(nil, nil, 2, 0, nil)
+		require.NoError(t, err)
+
+		// Add an empty input
+		ptx.UnsignedTx.TxIn = []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{},
+			Sequence:         0,
+		}}
+		ptx.Inputs = []psbt.PInput{{}}
+
+		// Test cases with various tapscripts
+		testCases := [][]string{
+			{},
+			{"51201234567890abcdef"},
+			{
+				"51201234567890abcdef",
+				"522103deadbeef",
+				"76a914123456789012345678901234567890",
+			},
+		}
+
+		for _, scripts := range testCases {
+			// Add tapscripts to input 0
+			err = bitcointree.AddTapscripts(0, ptx, scripts)
+			require.NoError(t, err)
+
+			// Get tapscripts back and verify
+			retrievedScripts, err := bitcointree.GetTapscripts(ptx.Inputs[0])
+			require.NoError(t, err)
+			require.Equal(t, len(scripts), len(retrievedScripts))
+
+			for i := range scripts {
+				require.Equal(t, scripts[i], retrievedScripts[i])
+			}
+
+			// Clear the unknowns for next test case
+			ptx.Inputs[0].Unknowns = nil
+		}
+	})
 }

--- a/common/tree/vtxo.go
+++ b/common/tree/vtxo.go
@@ -75,14 +75,23 @@ func (v *TapscriptsVtxoScript) Decode(scripts []string) error {
 func (v *TapscriptsVtxoScript) Validate(server *secp256k1.PublicKey, minLocktime common.RelativeLocktime) error {
 	serverXonly := schnorr.SerializePubKey(server)
 	for _, forfeit := range v.ForfeitClosures() {
-		multisigClosure, ok := forfeit.(*MultisigClosure)
-		if !ok {
-			return fmt.Errorf("invalid forfeit closure, expected MultisigClosure")
+		keys := make([]*secp256k1.PublicKey, 0)
+		switch c := forfeit.(type) {
+		case *MultisigClosure:
+			keys = c.PubKeys
+		case *CLTVMultisigClosure:
+			keys = c.PubKeys
+		case *ConditionMultisigClosure:
+			keys = c.PubKeys
+		}
+
+		if len(keys) == 0 {
+			return fmt.Errorf("invalid forfeit closure, expected MultisigClosure, CLTVMultisigClosure or ConditionMultisigClosure")
 		}
 
 		// must contain server pubkey
 		found := false
-		for _, pubkey := range multisigClosure.PubKeys {
+		for _, pubkey := range keys {
 			if bytes.Equal(schnorr.SerializePubKey(pubkey), serverXonly) {
 				found = true
 				break

--- a/common/types.go
+++ b/common/types.go
@@ -6,8 +6,9 @@ import (
 )
 
 type VtxoInput struct {
-	Outpoint    *wire.OutPoint
-	Amount      int64
-	Tapscript   *waddrmgr.Tapscript
-	WitnessSize int
+	Outpoint           *wire.OutPoint
+	Amount             int64
+	Tapscript          *waddrmgr.Tapscript
+	WitnessSize        int
+	RevealedTapscripts []string
 }

--- a/pkg/client-sdk/covenantless_client.go
+++ b/pkg/client-sdk/covenantless_client.go
@@ -3137,10 +3137,11 @@ func buildRedeemTx(
 		}
 
 		ins = append(ins, common.VtxoInput{
-			Outpoint:    vtxoOutpoint,
-			Tapscript:   tapscript,
-			Amount:      int64(vtxo.Amount),
-			WitnessSize: closure.WitnessSize(extraWitnessSize),
+			Outpoint:           vtxoOutpoint,
+			Tapscript:          tapscript,
+			Amount:             int64(vtxo.Amount),
+			WitnessSize:        closure.WitnessSize(extraWitnessSize),
+			RevealedTapscripts: vtxo.Tapscripts,
 		})
 	}
 

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -276,7 +276,7 @@ func (s *covenantlessService) SubmitRedeemTx(
 			return "", "", fmt.Errorf("missing tapscript leaf")
 		}
 
-		tapscripts, err := bitcointree.GetTapscripts(input)
+		tapscripts, err := bitcointree.GetTaprootTree(input)
 		if err != nil {
 			return "", "", fmt.Errorf("missing tapscripts: %s", err)
 		}

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -276,10 +276,23 @@ func (s *covenantlessService) SubmitRedeemTx(
 			return "", "", fmt.Errorf("missing tapscript leaf")
 		}
 
-		tapscript := input.TaprootLeafScript[0]
+		tapscripts, err := bitcointree.GetTapscripts(input)
+		if err != nil {
+			return "", "", fmt.Errorf("missing tapscripts: %s", err)
+		}
 
 		if len(input.TaprootScriptSpendSig) == 0 {
 			return "", "", fmt.Errorf("missing tapscript spend sig")
+		}
+
+		if len(input.TaprootLeafScript) != 1 {
+			return "", "", fmt.Errorf("expected exactly one taproot leaf script")
+		}
+
+		signedTapscript := input.TaprootLeafScript[0]
+
+		if signedTapscript == nil {
+			return "", "", fmt.Errorf("no matching tapscript found")
 		}
 
 		outpoint := ptx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint
@@ -302,6 +315,41 @@ func (s *covenantlessService) SubmitRedeemTx(
 
 		if vtxo.Swept {
 			return "", "", fmt.Errorf("vtxo already swept")
+		}
+
+		vtxoScript, err := bitcointree.ParseVtxoScript(tapscripts)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse vtxo script: %s", err)
+		}
+
+		// validate the vtxo script
+		if err := vtxoScript.Validate(s.pubkey, s.unilateralExitDelay); err != nil {
+			return "", "", fmt.Errorf("invalid vtxo script: %s", err)
+		}
+
+		// verify the witnessUtxo script
+		if input.WitnessUtxo == nil {
+			return "", "", fmt.Errorf("missing witness utxo")
+		}
+
+		witnessUtxoScript := input.WitnessUtxo.PkScript
+
+		tapKeyFromTapscripts, _, err := vtxoScript.TapTree()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get taproot key from vtxo script: %s", err)
+		}
+
+		if vtxo.PubKey != hex.EncodeToString(schnorr.SerializePubKey(tapKeyFromTapscripts)) {
+			return "", "", fmt.Errorf("vtxo pubkey mismatch")
+		}
+
+		pkScriptFromTapscripts, err := common.P2TRScript(tapKeyFromTapscripts)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get pkscript from taproot key: %s", err)
+		}
+
+		if !bytes.Equal(witnessUtxoScript, pkScriptFromTapscripts) {
+			return "", "", fmt.Errorf("witness utxo script mismatch")
 		}
 
 		sumOfInputs += input.WitnessUtxo.Value
@@ -356,7 +404,7 @@ func (s *covenantlessService) SubmitRedeemTx(
 		}
 
 		// verify forfeit closure script
-		closure, err := tree.DecodeClosure(tapscript.Script)
+		closure, err := tree.DecodeClosure(signedTapscript.Script)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to decode forfeit closure: %s", err)
 		}
@@ -368,7 +416,7 @@ func (s *covenantlessService) SubmitRedeemTx(
 			locktime = &c.Locktime
 		case *tree.MultisigClosure, *tree.ConditionMultisigClosure:
 		default:
-			return "", "", fmt.Errorf("invalid forfeit closure script")
+			return "", "", fmt.Errorf("invalid forfeit closure script %x, cannot verify redeem tx", signedTapscript.Script)
 		}
 
 		if locktime != nil {
@@ -387,7 +435,7 @@ func (s *covenantlessService) SubmitRedeemTx(
 			}
 		}
 
-		ctrlBlock, err := txscript.ParseControlBlock(tapscript.ControlBlock)
+		ctrlBlock, err := txscript.ParseControlBlock(signedTapscript.ControlBlock)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to parse control block: %s", err)
 		}
@@ -396,8 +444,9 @@ func (s *covenantlessService) SubmitRedeemTx(
 			Outpoint: &outpoint,
 			Tapscript: &waddrmgr.Tapscript{
 				ControlBlock:   ctrlBlock,
-				RevealedScript: tapscript.Script,
+				RevealedScript: signedTapscript.Script,
 			},
+			RevealedTapscripts: tapscripts,
 		})
 	}
 
@@ -636,6 +685,15 @@ func (s *covenantlessService) SpendVtxos(ctx context.Context, inputs []ports.Inp
 					return "", fmt.Errorf("failed to parse boarding descriptor: %s", err)
 				}
 
+				// validate the vtxo script
+				// TODO: fix in PR #501
+				if err := vtxoScript.Validate(s.pubkey, common.RelativeLocktime{
+					Type:  s.unilateralExitDelay.Type,
+					Value: s.unilateralExitDelay.Value * 2,
+				}); err != nil {
+					return "", fmt.Errorf("invalid vtxo script: %s", err)
+				}
+
 				exitDelay, err := vtxoScript.SmallestExitDelay()
 				if err != nil {
 					return "", fmt.Errorf("failed to get exit delay: %s", err)
@@ -684,6 +742,11 @@ func (s *covenantlessService) SpendVtxos(ctx context.Context, inputs []ports.Inp
 		vtxoScript, err := bitcointree.ParseVtxoScript(input.Tapscripts)
 		if err != nil {
 			return "", fmt.Errorf("failed to parse boarding descriptor: %s", err)
+		}
+
+		// validate the vtxo script
+		if err := vtxoScript.Validate(s.pubkey, s.unilateralExitDelay); err != nil {
+			return "", fmt.Errorf("invalid vtxo script: %s", err)
 		}
 
 		tapKey, _, err := vtxoScript.TapTree()

--- a/server/internal/infrastructure/tx-builder/covenant/builder.go
+++ b/server/internal/infrastructure/tx-builder/covenant/builder.go
@@ -229,7 +229,7 @@ func (b *txBuilder) VerifyForfeitTxs(
 			locktime = &c.Locktime
 		case *tree.MultisigClosure, *tree.ConditionMultisigClosure:
 		default:
-			return nil, fmt.Errorf("invalid forfeit closure script")
+			return nil, fmt.Errorf("invalid forfeit closure script %x, cannot verify forfeit tx", vtxoTapscript.Script)
 		}
 
 		if locktime != nil {

--- a/server/test/e2e/covenantless/e2e_test.go
+++ b/server/test/e2e/covenantless/e2e_test.go
@@ -446,7 +446,7 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 					&tree.CLTVMultisigClosure{
 						Locktime: cltvLocktime,
 						MultisigClosure: tree.MultisigClosure{
-							PubKeys: []*secp256k1.PublicKey{bobPubKey},
+							PubKeys: []*secp256k1.PublicKey{bobPubKey, aliceAddr.Server},
 						},
 					},
 				},
@@ -518,6 +518,14 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
 		require.NoError(t, err)
 
+		tapscripts := make([]string, 0, len(vtxoScript.Closures))
+		for _, closure := range vtxoScript.Closures {
+			script, err := closure.Script()
+			require.NoError(t, err)
+
+			tapscripts = append(tapscripts, hex.EncodeToString(script))
+		}
+
 		ptx, err := bitcointree.BuildRedeemTx(
 			[]common.VtxoInput{
 				{
@@ -525,9 +533,10 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 						Hash:  redeemPtx.UnsignedTx.TxHash(),
 						Index: bobOutputIndex,
 					},
-					Tapscript:   tapscript,
-					WitnessSize: closure.WitnessSize(),
-					Amount:      bobOutput.Value,
+					Tapscript:          tapscript,
+					WitnessSize:        closure.WitnessSize(),
+					Amount:             bobOutput.Value,
+					RevealedTapscripts: tapscripts,
 				},
 			},
 			[]*wire.TxOut{
@@ -788,7 +797,7 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 				&tree.CLTVMultisigClosure{
 					Locktime: common.AbsoluteLocktime(currentHeight + cltvBlocks),
 					MultisigClosure: tree.MultisigClosure{
-						PubKeys: []*secp256k1.PublicKey{bobPubKey},
+						PubKeys: []*secp256k1.PublicKey{bobPubKey, aliceAddr.Server},
 					},
 				},
 			},
@@ -859,6 +868,14 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 	alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
 	require.NoError(t, err)
 
+	tapscripts := make([]string, 0, len(vtxoScript.Closures))
+	for _, closure := range vtxoScript.Closures {
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		tapscripts = append(tapscripts, hex.EncodeToString(script))
+	}
+
 	ptx, err := bitcointree.BuildRedeemTx(
 		[]common.VtxoInput{
 			{
@@ -866,9 +883,10 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 					Hash:  redeemPtx.UnsignedTx.TxHash(),
 					Index: bobOutputIndex,
 				},
-				Tapscript:   tapscript,
-				WitnessSize: closure.WitnessSize(),
-				Amount:      bobOutput.Value,
+				Tapscript:          tapscript,
+				WitnessSize:        closure.WitnessSize(),
+				Amount:             bobOutput.Value,
+				RevealedTapscripts: tapscripts,
 			},
 		},
 		[]*wire.TxOut{
@@ -968,7 +986,7 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 				&tree.ConditionMultisigClosure{
 					Condition: conditionScript,
 					MultisigClosure: tree.MultisigClosure{
-						PubKeys: []*secp256k1.PublicKey{bobPubKey},
+						PubKeys: []*secp256k1.PublicKey{bobPubKey, aliceAddr.Server},
 					},
 				},
 			},
@@ -1039,6 +1057,14 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 	alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
 	require.NoError(t, err)
 
+	tapscripts := make([]string, 0, len(vtxoScript.Closures))
+	for _, closure := range vtxoScript.Closures {
+		script, err := closure.Script()
+		require.NoError(t, err)
+
+		tapscripts = append(tapscripts, hex.EncodeToString(script))
+	}
+
 	ptx, err := bitcointree.BuildRedeemTx(
 		[]common.VtxoInput{
 			{
@@ -1046,9 +1072,10 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 					Hash:  redeemPtx.UnsignedTx.TxHash(),
 					Index: bobOutputIndex,
 				},
-				Tapscript:   tapscript,
-				WitnessSize: closure.WitnessSize(),
-				Amount:      bobOutput.Value,
+				Tapscript:          tapscript,
+				WitnessSize:        closure.WitnessSize(),
+				Amount:             bobOutput.Value,
+				RevealedTapscripts: tapscripts,
 			},
 		},
 		[]*wire.TxOut{


### PR DESCRIPTION
_This PR add robust checks on `SubmitRedeemTx` and `RegisterInputsForNextRound` RPCs. The idea is to validate the revealed tapscripts of every spent VTXO in order to prevent a malicious user to inject a "backdoor" tapscript._

### Settlement

The current `RegisterInputsForNextRoundRequest` has `Tapscripts` field on inputs. This PR only validates the scripts.

### Redeem tx

This PR introduces a **breaking change** for client, because now redeem PSBTs must reveal the inputs tapscripts using an unknown PSBT field "tapscripts".

_Why unknown field instead of TaprootLeafScript PSBT field ?_

We are using this field to signal the leaf used to sign, like most wallets do. Revealing the taproot tree using this field implies a lot of change on critical signing code (both clients and servers). Unknown field seems more adapted because the scripts are only used for validation. Also, it reduces the size of the PSBT.

@Kukks @altafan please review