### PR TITLE
hotfix: TapscriptsVtxoScript.Decode returns an error in case array is empty

### DIFF
--- a/common/bitcointree/vtxo.go
+++ b/common/bitcointree/vtxo.go
@@ -13,6 +13,10 @@ import (
 type VtxoScript common.VtxoScript[bitcoinTapTree, tree.Closure]
 
 func ParseVtxoScript(scripts []string) (VtxoScript, error) {
+	if len(scripts) == 0 {
+		return nil, fmt.Errorf("empty tapscripts array")
+	}
+
 	types := []VtxoScript{
 		&TapscriptsVtxoScript{},
 	}

--- a/common/tree/vtxo.go
+++ b/common/tree/vtxo.go
@@ -56,6 +56,10 @@ func (v *TapscriptsVtxoScript) Encode() ([]string, error) {
 }
 
 func (v *TapscriptsVtxoScript) Decode(scripts []string) error {
+	if len(scripts) == 0 {
+		return fmt.Errorf("empty scripts array")
+	}
+
 	v.Closures = make([]Closure, 0, len(scripts))
 	for _, script := range scripts {
 		scriptBytes, err := hex.DecodeString(script)
@@ -69,6 +73,11 @@ func (v *TapscriptsVtxoScript) Decode(scripts []string) error {
 		}
 		v.Closures = append(v.Closures, closure)
 	}
+
+	if len(v.Closures) == 0 {
+		return fmt.Errorf("no valid closures found in scripts")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add a check on `ParseVtxoScript` argument to prevent SubmitRedeemTx to panic in case a redeem tx does not reveal input's tapscripts.

Related to https://github.com/ark-network/ark/pull/505

@altafan please review