### PR TITLE
[SDK] Fix closing server-side streams & Polish NotifyIncomingFunds

### DIFF
--- a/pkg/client-sdk/client/client.go
+++ b/pkg/client-sdk/client/client.go
@@ -19,6 +19,10 @@ const (
 	RestClient = "rest"
 )
 
+var (
+	ErrConnectionClosedByServer = fmt.Errorf("connection closed by server")
+)
+
 type RoundEvent interface {
 	isRoundEvent()
 }


### PR DESCRIPTION
This pr fixes the close of the server-side streams in both rest and grpc client used by the SDK.

This also cleans the `NotifyIncomingFunds` API as there was no need for wait groups.

@louisinger please review.