### PR TITLE
`pkg/client-sdk` store default explorer URL

### DIFF
--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -309,7 +309,7 @@ func (a *arkClient) init(
 		UnilateralExitDelay:        common.RelativeLocktime{Type: unilateralExitDelayType, Value: uint32(info.UnilateralExitDelay)},
 		Dust:                       info.Dust,
 		BoardingDescriptorTemplate: info.BoardingDescriptorTemplate,
-		ExplorerURL:                args.ExplorerURL,
+		ExplorerURL:                explorerSvc.BaseUrl(),
 		ForfeitAddress:             info.ForfeitAddress,
 		WithTransactionFeed:        args.WithTransactionFeed,
 		MarketHourStartTime:        info.MarketHourStartTime,

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -234,6 +234,7 @@ func (a *arkClient) initWithWallet(
 		MarketHourEndTime:          info.MarketHourEndTime,
 		MarketHourPeriod:           info.MarketHourPeriod,
 		MarketHourRoundInterval:    info.MarketHourRoundInterval,
+		ExplorerURL:                explorerSvc.BaseUrl(),
 	}
 	if err := a.store.ConfigStore().AddData(ctx, storeData); err != nil {
 		return err


### PR DESCRIPTION
This PR makes sure the wallet's `explorerURL` is set in case we are using default explorer URLs.

@altafan please review