### PR TITLE
add `ExpireAt` member when adding new vtxos created by settlement

### DIFF
--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1917,7 +1917,9 @@ func (s *covenantlessService) getNewVtxos(round *domain.Round) []domain.Vtxo {
 		return nil
 	}
 
-	createdAt := time.Now().Unix()
+	now := time.Now()
+	createdAt := now.Unix()
+	expireAt := now.Add(time.Duration(s.vtxoTreeExpiry.Seconds()) * time.Second).Unix()
 
 	leaves := round.VtxoTree.Leaves()
 	vtxos := make([]domain.Vtxo, 0)
@@ -1941,7 +1943,7 @@ func (s *covenantlessService) getNewVtxos(round *domain.Round) []domain.Vtxo {
 				Amount:    uint64(out.Value),
 				RoundTxid: round.Txid,
 				CreatedAt: createdAt,
-				ExpireAt:  createdAt + s.vtxoTreeExpiry.Seconds(),
+				ExpireAt:  expireAt,
 			})
 		}
 	}

--- a/server/internal/core/application/covenantless.go
+++ b/server/internal/core/application/covenantless.go
@@ -1941,6 +1941,7 @@ func (s *covenantlessService) getNewVtxos(round *domain.Round) []domain.Vtxo {
 				Amount:    uint64(out.Value),
 				RoundTxid: round.Txid,
 				CreatedAt: createdAt,
+				ExpireAt:  createdAt + s.vtxoTreeExpiry.Seconds(),
 			})
 		}
 	}


### PR DESCRIPTION
The sweeper is responsible for watching and updating expiration timestamps. However, with the new SubscribeForAddress stream, it happens that the `ExpireAt` member is not updated when the notification hits the client. This PR fixes.

@altafan please reveiw

