### PR TITLE
Hotfix sweeper

### DIFF
--- a/server/internal/infrastructure/wallet/btc-embedded/esplora.go
+++ b/server/internal/infrastructure/wallet/btc-embedded/esplora.go
@@ -45,7 +45,7 @@ func (f *esploraClient) broadcast(txhex string) error {
 			return err
 		}
 
-		if strings.Contains(strings.ToLower(string(content)), "non-BIP68-final") {
+		if strings.Contains(strings.ToLower(string(content)), "non-bip68-final") {
 			return ports.ErrNonFinalBIP68
 		}
 


### PR DESCRIPTION
This fixes the check for bip68 non final tx when broadcasting so that the sweeper correctly retries broadcasting a sweep tx on bitcoin networks.

Please @sekulicd @louisinger review