### PR TITLE
Tx & Address notifications: return the latest `spentVtxos` state 

### DIFF
--- a/server/internal/core/application/covenant.go
+++ b/server/internal/core/application/covenant.go
@@ -1080,7 +1080,7 @@ func (s *covenantService) updateVtxoSet(round *domain.Round) {
 	spentVtxos := getSpentVtxos(round.TxRequests)
 	if len(spentVtxos) > 0 {
 		for {
-			if err := repo.SpendVtxos(ctx, spentVtxos, round.Txid); err != nil {
+			if _, err := repo.SpendVtxos(ctx, spentVtxos, round.Txid); err != nil {
 				log.WithError(err).Warn("failed to add new vtxos, retrying soon")
 				time.Sleep(100 * time.Millisecond)
 				continue

--- a/server/internal/core/domain/round_repo.go
+++ b/server/internal/core/domain/round_repo.go
@@ -26,7 +26,7 @@ type RoundRepository interface {
 
 type VtxoRepository interface {
 	AddVtxos(ctx context.Context, vtxos []Vtxo) error
-	SpendVtxos(ctx context.Context, vtxos []VtxoKey, txid string) error
+	SpendVtxos(ctx context.Context, vtxos []VtxoKey, txid string) ([]Vtxo, error)
 	RedeemVtxos(ctx context.Context, vtxos []VtxoKey) error
 	GetVtxos(ctx context.Context, vtxos []VtxoKey) ([]Vtxo, error)
 	GetVtxosForRound(ctx context.Context, txid string) ([]Vtxo, error)

--- a/server/internal/infrastructure/db/service_test.go
+++ b/server/internal/infrastructure/db/service_test.go
@@ -444,10 +444,7 @@ func testVtxoRepository(t *testing.T, svc ports.RepoManager) {
 		require.NoError(t, err)
 		require.Len(t, append(spendableVtxos, spentVtxos...), numberOfVtxos+len(newVtxos))
 
-		err = svc.Vtxos().SpendVtxos(ctx, vtxoKeys[:1], randomString(32))
-		require.NoError(t, err)
-
-		spentVtxos, err = svc.Vtxos().GetVtxos(ctx, vtxoKeys[:1])
+		spentVtxos, err = svc.Vtxos().SpendVtxos(ctx, vtxoKeys[:1], randomString(32))
 		require.NoError(t, err)
 		require.Len(t, spentVtxos, len(vtxoKeys[:1]))
 		for _, v := range spentVtxos {

--- a/server/internal/infrastructure/db/sqlite/vtxo_repo.go
+++ b/server/internal/infrastructure/db/sqlite/vtxo_repo.go
@@ -182,7 +182,7 @@ func (v *vxtoRepository) RedeemVtxos(ctx context.Context, vtxos []domain.VtxoKey
 	return execTx(ctx, v.db, txBody)
 }
 
-func (v *vxtoRepository) SpendVtxos(ctx context.Context, vtxos []domain.VtxoKey, txid string) error {
+func (v *vxtoRepository) SpendVtxos(ctx context.Context, vtxos []domain.VtxoKey, txid string) ([]domain.Vtxo, error) {
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, vtxo := range vtxos {
 			if err := querierWithTx.MarkVtxoAsSpent(
@@ -200,7 +200,11 @@ func (v *vxtoRepository) SpendVtxos(ctx context.Context, vtxos []domain.VtxoKey,
 		return nil
 	}
 
-	return execTx(ctx, v.db, txBody)
+	if err := execTx(ctx, v.db, txBody); err != nil {
+		return nil, err
+	}
+
+	return v.GetVtxos(ctx, vtxos)
 }
 
 func (v *vxtoRepository) SweepVtxos(ctx context.Context, vtxos []domain.VtxoKey) error {


### PR DESCRIPTION
This PR ensures that the `spentVtxos` fields in tx events and address subscriptions are populated with the latest DB state (= with `spentBy` populated).

@altafan please review