### PR TITLE
Changed 'withoutAppSvc' to 'withAppSvc'.

### DIFF
--- a/server/internal/interface/grpc/service.go
+++ b/server/internal/interface/grpc/service.go
@@ -101,8 +101,8 @@ func NewService(
 }
 
 func (s *service) Start() error {
-	withoutAppSvc := false
-	if err := s.start(withoutAppSvc); err != nil {
+	withAppSvc := true
+	if err := s.start(withAppSvc); err != nil {
 		return err
 	}
 	if s.appConfig.UnlockerService() != nil {


### PR DESCRIPTION
The argument [`withoutAppSvc`](https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/server/internal/interface/grpc/service.go#L104) does not match the parameter name `withAppSvc` defined on [start](https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/server/internal/interface/grpc/service.go#L124). This has lead to an improper value being set for this variable. 

When this variable is `false` it prevents the app service from starting. This happens because `start` kicks off [`newServer`](https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/server/internal/interface/grpc/service.go#L168) which [calls RegisterArkServiceServer](https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/server/internal/interface/grpc/service.go#L209) only if [`withAppSvc` is true](https://github.com/ark-network/ark/blob/cba48925bcc836cc55f9bb482f2cd1b76d78953e/server/internal/interface/grpc/service.go#L197).

Addresses #550 

EDIT: Edits for clarity