### PR TITLE
[SDK]: Broadcast tx when complete unilateral exit

### DIFF
--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -1321,7 +1321,18 @@ func (a *covenantlessArkClient) completeUnilateralExit(
 		}
 	}
 
-	return ptx.B64Encode()
+	tx, err := psbt.Extract(ptx)
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := tx.Serialize(buf); err != nil {
+		return "", err
+	}
+
+	txHex := hex.EncodeToString(buf.Bytes())
+	return a.explorer.Broadcast(txHex)
 }
 
 func (a *covenantlessArkClient) selectFunds(


### PR DESCRIPTION
This fixes the `CompleteUnilateralExit` api of the client SDK by broadcasting the tx instead of just returning the base64 (psbt).

Please @tiero review