### PR TITLE
[FIX] GetVtxoChain - prevent infinite loop

### DIFF
--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -231,7 +231,7 @@ func (i *indexerService) GetVtxoChain(
 
 		newNextVtxos := make([]domain.Outpoint, 0)
 		for _, vtxo := range vtxos {
-			key := fmt.Sprintf("%s:%d", vtxo.Txid, vtxo.VOut)
+			key := vtxo.Outpoint.String()
 			if visited[key] {
 				continue
 			}
@@ -272,8 +272,7 @@ func (i *indexerService) GetVtxoChain(
 
 					// populate newNextVtxos with checkpoints inputs
 					for _, in := range ptx.UnsignedTx.TxIn {
-						childKey := fmt.Sprintf("%s:%d", in.PreviousOutPoint.Hash.String(), in.PreviousOutPoint.Index)
-						if !visited[childKey] {
+						if !visited[in.PreviousOutPoint.String()] {
 							newNextVtxos = append(newNextVtxos, domain.Outpoint{
 								Txid: in.PreviousOutPoint.Hash.String(),
 								VOut: in.PreviousOutPoint.Index,


### PR DESCRIPTION
This adds fix, at least temporarily, so that GetVtxoChain doesnt run infinitely.
This prevents traversing already visited Vtxo, i didnt find exact reason why some vtxo are traversed multiple times which creates infinite cycle while traversing chain graph.

Possible future schema enhancement:
1. decode tx from checkpoint_tx and create table so we dont need to decode psbt all the time and we could possible get chain directly with sql(complex recursive) query
2. dont store tree txs children in jsonb column but have additional table 

In attachment i sending script that visualize chain for the vtxo from the issue.
````
# save as vtxo_chain_to_dot.py, run:  python vtxo_chain_to_dot.py < chain.txt
import re, sys, hashlib

text = sys.stdin.read()

items = re.findall(
    r"\{Txid:([0-9a-f]+)\s+ExpiresAt:\d+\s+Type:([a-z]+)\s+Spends:\[([^\]]*)\]\}",
    text
)

nodes = {}          # key: (type, txid) -> idx
edges = set()       # (src_idx, dst_idx)
type_style = {
    'ark':        ('box',       'black'),
    'checkpoint': ('ellipse',   'gray30'),
    'tree':       ('diamond',   'gray50'),
    'commitment': ('octagon',   'gray10'),
}

def node_id(t, x):
    if (t,x) not in nodes:
        nodes[(t,x)] = len(nodes)
    return nodes[(t,x)]

for txid, typ, spends_str in items:
    src = node_id(typ, txid)
    spends = [s for s in spends_str.strip().split() if s]
    for s in spends:
        # checkpoints list "hash:index", others list a txid
        dst_txid = s.split(':',1)[0]
        # We don't know the dst type from this line; link by txid to any known type(s).
        # Build provisional edges to all nodes we later see with that txid, otherwise keep a placeholder.
        edges.add((src, dst_txid))

# Resolve edges to concrete node indices by matching any node with txid == dst_txid (any type)
resolved_edges = set()
tx_to_types = {}
for (typ, txid), idx in nodes.items():
    tx_to_types.setdefault(txid, []).append((typ, idx))

for src_idx, dst_txid in edges:
    for typ, dst_idx in tx_to_types.get(dst_txid, []):
        resolved_edges.add((src_idx, dst_idx))

# Emit DOT
def short(x): return x[:8] + '…'
print('digraph G {')
print('  rankdir=LR; overlap=false; splines=true;')
for (typ, txid), idx in nodes.items():
    shape, color = type_style.get(typ, ('box','black'))
    label = f"{typ}\\n{short(txid)}"
    print(f'  n{idx} [label="{label}", shape={shape}, style=filled, fillcolor=white, color="{color}", fontname="Helvetica"];')
for a,b in sorted(resolved_edges):
    print(f'  n{a} -> n{b};')
print('}')


````
[chain.txt](https://github.com/user-attachments/files/21857056/chain.txt)
<img width="25503" height="1044" alt="chain" src="https://github.com/user-attachments/assets/cfabf831-0bbc-41a4-aa42-36c556802180" />

@louisinger @Kukks @tiero please review.

This closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminates duplicate entries during transaction-chain traversal, ensuring each output is processed once.
  * Prevents repeated off-chain checkpoints from reappearing, improving consistency of results and downstream calculations.
  * Enhances reliability across edge cases that previously caused redundant entries.

* **Performance**
  * Reduces redundant processing in complex transaction histories, improving responsiveness.
  * Lowers the chance of stalls from re-processing the same data, leading to smoother operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->