### PR TITLE
ardk-wallet: better withdrawal fee estimation

### DIFF
--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -783,7 +783,13 @@ func (w *wallet) withdrawAll(ctx context.Context, feeRate chainfee.SatPerKVByte,
 	}
 
 	estimatedFee := w.estimateWithdrawFee(feeRate, len(availableUtxos), destPkScript)
+	if amount < estimatedFee {
+		return nil, fmt.Errorf("amount is too small to be withdrawn (estimated fee: %d)", estimatedFee)
+	}
 	amount -= estimatedFee
+	if amount < w.GetDustAmount(ctx) {
+		return nil, fmt.Errorf("amount is too small to be withdrawn (dust amount: %d)", w.GetDustAmount(ctx))
+	}
 
 	inputs := make([]*wire.OutPoint, 0)
 	outputs := make([]*wire.TxOut, 0, 1)


### PR DESCRIPTION
This PR reworks the `estimateWithdrawFee` private function used to compute withdrawal tx fees: 
* compute the exact lenght of the destination address
* estimate with change type = P2TR (instead of P2WPKH)

@altafan please review





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Withdrawals now produce PSBTs for external signing and support pre-validating destination scripts; separate full-balance and partial withdrawal paths.
  * Added signer key management and a graceful shutdown helper for resource cleanup.

* **Bug Fixes**
  * Improved fee estimation, dust handling, and clearer signing/broadcast error messages to reduce failed withdrawals.

* **Refactor**
  * Transaction assembly and fee estimator updated to account for modern input types and real destination outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->