### PR TITLE
musig2: hotfix aggregate nonces

### DIFF
--- a/pkg/ark-lib/tree/musig2.go
+++ b/pkg/ark-lib/tree/musig2.go
@@ -373,8 +373,6 @@ func (t *treeSignerSession) AggregateNonces(txid string, pubkeyNonces map[string
 	}
 
 	// set our nonce to ensure server didn't overwrite it
-	pubkey := schnorr.SerializePubKey(nonce.Pub.X)
-	pubkeyNonces[string(pubkey)] = nonce.R
 	xonlyPubkey := hex.EncodeToString(schnorr.SerializePubKey(t.secretKey.PubKey()))
 	pubkeyNonces[xonlyPubkey] = &Musig2Nonce{myNonce.PubNonce}
 


### PR DESCRIPTION
Before aggregating nonce, set the xonly pubkey to the map instead of compressed format.
 
@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nonce storage updated: each signer’s nonce is now recorded under the x-only public key (previous full-key storage removed), preventing collisions and incorrect overwrites.

* **Security**
  * Improved multi-party signing robustness by standardizing nonce representation to x-only public keys, reducing risk of nonce misuse and improving aggregated signature integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->