### PR TITLE
Fix collaborative path intent signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/arkade-os/arkd/pkg/errors v0.0.0-00010101000000-000000000000
 	github.com/arkade-os/arkd/pkg/kvdb v0.0.0-20250606113434-241d3e1ec7cb
 	github.com/arkade-os/arkd/pkg/macaroons v0.0.0-00010101000000-000000000000
-	github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb
+	github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/docker/docker v27.1.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSi
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb h1:qGq3QP3URnJmR3CYKn/yGCWxwGsVXj6BYLGeGGQRMcA=
-github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb/go.mod h1:iA0oSdi+/qNhEZxuEYxt6Dl1aBRgEdr0Br6KmRyWq4c=
+github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6 h1:nzaIrm4dxWkPtCqB2DndXbsnJq/oBWpITG4W1YZeT5o=
+github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6/go.mod h1:iA0oSdi+/qNhEZxuEYxt6Dl1aBRgEdr0Br6KmRyWq4c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1284,7 +1284,7 @@ func (s *service) RegisterIntent(
 			WithMetadata(errors.PsbtMetadata{Tx: proof.UnsignedTx.TxID()})
 	}
 
-	signedProof, err := s.wallet.SignTransactionTapscript(ctx, encodedProof, nil)
+	signedProof, err := s.signer.SignTransactionTapscript(ctx, encodedProof, nil)
 	if err != nil {
 		return "", errors.INTERNAL_ERROR.New("failed to sign proof: %w", err).
 			WithMetadata(map[string]any{
@@ -1685,7 +1685,7 @@ func (s *service) DeleteIntentsByProof(
 			WithMetadata(errors.PsbtMetadata{Tx: proof.UnsignedTx.TxID()})
 	}
 
-	signedProof, err := s.wallet.SignTransactionTapscript(ctx, encodedProof, nil)
+	signedProof, err := s.signer.SignTransactionTapscript(ctx, encodedProof, nil)
 	if err != nil {
 		return errors.INTERNAL_ERROR.New("failed to sign proof: %w", err).
 			WithMetadata(map[string]any{

--- a/pkg/ark-cli/go.mod
+++ b/pkg/ark-cli/go.mod
@@ -8,7 +8,7 @@ replace github.com/arkade-os/arkd/pkg/ark-lib => ../ark-lib
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.7.2-0.20251008210147-277c5d4229bb
-	github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb
+	github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6
 	github.com/urfave/cli/v2 v2.27.4
 	golang.org/x/term v0.35.0
 )

--- a/pkg/ark-cli/go.sum
+++ b/pkg/ark-cli/go.sum
@@ -16,8 +16,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb h1:qGq3QP3URnJmR3CYKn/yGCWxwGsVXj6BYLGeGGQRMcA=
-github.com/arkade-os/go-sdk v0.7.2-0.20251008210548-f35e9755b2cb/go.mod h1:iA0oSdi+/qNhEZxuEYxt6Dl1aBRgEdr0Br6KmRyWq4c=
+github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6 h1:nzaIrm4dxWkPtCqB2DndXbsnJq/oBWpITG4W1YZeT5o=
+github.com/arkade-os/go-sdk v0.7.2-0.20251010070236-d7b93df619b6/go.mod h1:iA0oSdi+/qNhEZxuEYxt6Dl1aBRgEdr0Br6KmRyWq4c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=


### PR DESCRIPTION
In `RegisterIntent` and `DeleteIntent` RPCs, the `signer` should be the counter-signer, not the `wallet` (liquidity provider).

@Kukks @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated underlying SDK to the latest patch version for compatibility and stability.
- Refactor
  - Consolidated transaction proof signing through a dedicated signer service to improve consistency and maintainability; no user-facing behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->