### PR TITLE
arkd-wallet: set autoTrack=true in GetNewUnusedAddress

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -347,6 +347,7 @@ func (n *nbxplorer) GetNewUnusedAddress(ctx context.Context, derivationScheme st
 	}
 
 	params := url.Values{}
+	params.Set("autoTrack", "true")
 	if change {
 		params.Set("feature", "Change")
 	} else {


### PR DESCRIPTION
When fetching a new unused address from nbxplorer, it may happen that the response is empty. to fix this, we must set autoTrack=true.

@Kukks @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly generated receiving addresses are now automatically tracked, enabling immediate detection of incoming transactions and faster balance updates without manual steps. This streamlines address management, improves reliability when requesting a fresh address, and enhances the experience for users generating multiple addresses in succession or setting up the wallet for the first time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->