### PR TITLE
add sleep time to TestUnilateralExit

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -332,6 +332,8 @@ func TestUnilateralExit(t *testing.T) {
 		err = generateBlocks(5)
 		require.NoError(t, err)
 
+		time.Sleep(5 * time.Second)
+
 		_, err = runArkCommand("redeem", "--force", "--password", password)
 		require.NoError(t, err)
 


### PR DESCRIPTION
in CI, it happens that randomly, the redeem command fails with "waiting for confirmation, please retry later" error. It is due to nigiri generate block taking time to be replied by esplora (used by the CLI).

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of the unilateral exit end-to-end scenario by introducing a brief wait after block generation before redemption.
  * Reduces race conditions and flakiness in CI, leading to more reliable and consistent test runs.
  * No impact on runtime behavior or performance of the product; this change only affects test execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->