### PR TITLE
sweeper: fix retry on non-bip68-final 

### DIFF
--- a/internal/core/application/sweeper.go
+++ b/internal/core/application/sweeper.go
@@ -3,6 +3,7 @@ package application
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -534,7 +535,7 @@ func (s *sweeper) createBatchSweepTask(commitmentTxid string, vtxoTree *tree.TxT
 
 		err = nil
 		// retry until the tx is broadcasted or the error is not BIP68 final
-		for len(txid) == 0 && (err == nil || err == ports.ErrNonFinalBIP68) {
+		for len(txid) == 0 && (err == nil || errors.Is(err, ports.ErrNonFinalBIP68)) {
 			if err != nil {
 				log.Debug("sweeper: sweep tx not BIP68 final, retrying in 5 seconds")
 				time.Sleep(5 * time.Second)

--- a/internal/infrastructure/wallet/wallet_client.go
+++ b/internal/infrastructure/wallet/wallet_client.go
@@ -302,6 +302,11 @@ func (w *walletDaemonClient) BroadcastTransaction(
 		ctx, &arkwalletv1.BroadcastTransactionRequest{Txs: txs},
 	)
 	if err != nil {
+		// handle non-final BIP68 error and return the appropriate error
+		if strings.Contains(
+			strings.ToLower(err.Error()), "non-bip68-final") {
+			return "", ports.ErrNonFinalBIP68
+		}
 		return "", err
 	}
 	return resp.GetTxid(), nil


### PR DESCRIPTION
This PR ensures we're handling "non-bip68-final" error properly. The logic was already here, but the wallet interface didn't map to the proper `ports.ErrNonFinalBIP68` error.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “non-final” (BIP68) transaction errors to trigger safe retries instead of failing outright.
  * Normalized wallet broadcast errors into a consistent, retryable condition, reducing spurious failures.
  * Increased robustness of batch sweep operations with more reliable error detection and retry logic, leading to fewer transient broadcast failures and smoother sweeps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->