### PR TITLE
SubmitOffchainTx: use expireAt to check swept status

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -582,8 +582,7 @@ func (s *service) SubmitOffchainTx(
 			return nil, "", "", errors.VTXO_ALREADY_UNROLLED.New("%s already unrolled", vtxo.Outpoint).
 				WithMetadata(errors.VtxoMetadata{VtxoOutpoint: vtxoOutpoint})
 		}
-
-		if vtxo.Swept {
+		if vtxo.Swept || !s.sweeper.scheduler.AfterNow(vtxo.ExpiresAt) {
 			// if we reach this point, it means vtxo.Spent = false so the vtxo is recoverable
 			return nil, "", "", errors.VTXO_RECOVERABLE.New("%s is recoverable", vtxo.Outpoint).
 				WithMetadata(errors.VtxoMetadata{VtxoOutpoint: vtxoOutpoint})


### PR DESCRIPTION
Disallow spending vtxo with `ExpiresAt` < now.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved off-chain transaction recovery handling. Time-limited outputs are now correctly recognized as recoverable in more scenarios, including when already swept or before expiry. This reduces false “unrecoverable” outcomes, lowers failed submission rates, and makes recovery workflows more reliable and predictable for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->