### PR TITLE
OffchainTx: set vtxo.CreatedAt to StartingTimestamp

### DIFF
--- a/internal/core/application/utils.go
+++ b/internal/core/application/utils.go
@@ -134,7 +134,7 @@ func decodeTx(offchainTx domain.OffchainTx) (string, []domain.Outpoint, []domain
 			CommitmentTxids:    offchainTx.CommitmentTxidsList(),
 			RootCommitmentTxid: offchainTx.RootCommitmentTxId,
 			Preconfirmed:       true,
-			CreatedAt:          offchainTx.EndingTimestamp,
+			CreatedAt:          offchainTx.StartingTimestamp,
 		})
 	}
 

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -463,7 +463,7 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 				CommitmentTxids:    offchainTx.CommitmentTxidsList(),
 				RootCommitmentTxid: offchainTx.RootCommitmentTxId,
 				Preconfirmed:       true,
-				CreatedAt:          offchainTx.EndingTimestamp,
+				CreatedAt:          offchainTx.StartingTimestamp,
 				// mark the vtxo as "swept" if it is below dust limit to prevent it from being spent again in a future offchain tx
 				// the only way to spend a swept vtxo is by collecting enough dust to cover the minSettlementVtxoAmount and then settle.
 				// because sub-dust vtxos are using OP_RETURN output script, they can't be unilaterally exited.


### PR DESCRIPTION
For precomfirmed vtxos, set CreatedAt timestamp to `StartingTimestamp` (time of `SubmitOffchainTx`) instead of `EndingTimestamp` (time of `FinalizeOffchainTx`).

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timestamps for newly created outputs from off‑chain transactions to reflect the transaction start time, improving accuracy in activity logs and details.
  * Ensures consistent ordering and display of recent activity based on when a transaction began.

* **Chores**
  * Internal consistency improvements to timestamp handling for off‑chain transaction outputs, with no changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->