### PR TITLE
Move sweeper.start in go routine

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -337,9 +337,10 @@ func NewService(
 	return svc, nil
 }
 
-func (s *service) Start(ctx context.Context) errors.Error {
+func (s *service) Start() errors.Error {
 	log.Debug("starting sweeper service...")
-	_, s.sweeperCancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.sweeperCancel = cancel
 	go func() {
 		if err := s.sweeper.start(ctx); err != nil {
 			log.WithError(err).Warn("failed to start sweeper")

--- a/internal/core/application/types.go
+++ b/internal/core/application/types.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Service interface {
-	Start(ctx context.Context) errors.Error
+	Start() errors.Error
 	Stop()
 	RegisterIntent(
 		ctx context.Context, proof intent.Proof, message intent.RegisterMessage,

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -142,8 +142,7 @@ func (s *service) start(withAppSvc bool) error {
 
 	if withAppSvc {
 		appSvc, _ := s.appConfig.AppService()
-		ctx := context.Background()
-		if err := appSvc.Start(ctx); err != nil {
+		if err := appSvc.Start(); err != nil {
 			return fmt.Errorf("failed to start app service: %s", err)
 		}
 		log.Info("started app service")


### PR DESCRIPTION
this PR moves the restore startup process in background to prevent blocking the main application service in case something went wrong in sweeper.

it needs https://github.com/arkade-os/arkd/pull/761 to avoid conflcting offchain txs.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sweeper service lifecycle management to ensure reliable shutdown and proper cancellation handling during application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->