### PR TITLE
arkd-wallet: increase minRelayFee rate

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -112,7 +112,7 @@ func (n *nbxplorer) GetBitcoinStatus(ctx context.Context) (*ports.BitcoinStatus,
 		return nil, fmt.Errorf("failed to unmarshal blockchain info: %w", err)
 	}
 
-	minRelayTxFee := resp.BitcoinStatus.MinRelayTxFee * 1_100
+	minRelayTxFee := resp.BitcoinStatus.MinRelayTxFee * 1000
 	// add 10% margin to avoid min-relay-fee-not-met errors
 	increasedMinRelayTxFee := minRelayTxFee + (minRelayTxFee * 0.1)
 


### PR DESCRIPTION
add 10% to minRelayFee rate to avoid min-relay-fee-not-met errors.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied a 10% margin buffer to minimum relay transaction fee calculations to improve reliability and ensure transactions consistently meet network requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->