### PR TITLE
Improve TestCollaborativeExit coverage

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1215,7 +1215,7 @@ func (s *service) RegisterIntent(
 
 			// reject if intent specifies onchain outputs and boarding inputs
 			if len(message.OnchainOutputIndexes) > 0 {
-				return "", errors.INVALID_INTENT_PROOF.New("boarding inputs can't be specified with onchain outputs").
+				return "", errors.INVALID_INTENT_PROOF.New("cannot include onchain inputs and outputs").
 					WithMetadata(errors.InvalidIntentProofMetadata{Proof: encodedProof, Message: encodedMessage})
 			}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -412,11 +412,17 @@ func TestCollaborativeExit(t *testing.T) {
 		err = json.Unmarshal([]byte(receiveStr), &receive)
 		require.NoError(t, err)
 
+		_, err = runCommand("nigiri", "faucet", receive.Boarding, "0.00010000")
+		require.NoError(t, err)
+
+		time.Sleep(5 * time.Second)
+
 		_, err = runArkCommand(
 			"redeem",
 			"--amount", "10000", "--address", onchainAddress, "--password", password,
 		)
 		require.Error(t, err)
+		require.ErrorContains(t, err, "include onchain inputs and outputs")
 	})
 }
 


### PR DESCRIPTION
@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that verifies an error is raised when attempting to use onchain address inputs in a redeem flow.

* **Bug Fixes**
  * Clarified validation error message when onchain inputs and onchain outputs are specified together to make the conflict clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->