### PR TITLE
arkd-wallet: send ready update immediatly if wallet is unlocked

### DIFF
--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -65,6 +65,19 @@ func New(opts WalletOptions) application.WalletService {
 }
 
 func (w *wallet) GetReadyUpdate(ctx context.Context) <-chan struct{} {
+	isUnlocked := w.keyMgr != nil
+
+	if isUnlocked {
+		go func() {
+			select {
+			case <-ctx.Done():
+				return
+			case w.isReady <- struct{}{}:
+				return
+			}
+		}()
+	}
+
 	return w.isReady
 }
 


### PR DESCRIPTION
@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet readiness signal to properly account for unlock state, ensuring reliable detection of when the wallet is ready for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->