### PR TITLE
HotFix: vtxo min amount returned in GetInfo

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1617,7 +1617,7 @@ func (s *service) GetInfo(ctx context.Context) (*ServiceInfo, errors.Error) {
 		NextScheduledSession: nextScheduledSession,
 		UtxoMinAmount:        s.utxoMinAmount,
 		UtxoMaxAmount:        s.utxoMaxAmount,
-		VtxoMinAmount:        s.vtxoMinSettlementAmount,
+		VtxoMinAmount:        s.vtxoMinOffchainTxAmount,
 		VtxoMaxAmount:        s.vtxoMaxAmount,
 		CheckpointTapscript:  hex.EncodeToString(s.checkpointTapscript),
 	}, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the minimum VTXO amount calculation in service information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->