### PR TITLE
add start sub-command

### DIFF
--- a/cmd/arkd/commands.go
+++ b/cmd/arkd/commands.go
@@ -17,6 +17,12 @@ const ONE_BTC = float64(1_00_000_000)
 
 // commands
 var (
+	startCmd = &cli.Command{
+		Name:   "start",
+		Usage:  "Starts the arkd server",
+		Action: startAction,
+	}
+
 	walletCmd = &cli.Command{
 		Name:  "wallet",
 		Usage: "Manage the Ark Server wallet",

--- a/cmd/arkd/main.go
+++ b/cmd/arkd/main.go
@@ -23,7 +23,7 @@ const (
 	tlsCertFile  = "cert.pem"
 )
 
-func mainAction(_ *cli.Context) error {
+func startAction(_ *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		return fmt.Errorf("invalid config: %s", err)
@@ -77,6 +77,7 @@ func main() {
 	app.UsageText = "Run the Ark Server with:\n\tarkd\nManage the Ark Server with:\n\tarkd [global options] command [command options]"
 	app.Commands = append(
 		app.Commands,
+		startCmd,
 		versionCmd,
 		walletCmd,
 		signerCmd,
@@ -90,7 +91,8 @@ func main() {
 		revokeAuthCmd,
 		convictionsCmd,
 	)
-	app.Action = mainAction
+
+	app.DefaultCommand = startCmd.Name
 	app.Flags = append(app.Flags, urlFlag, datadirFlag, macaroonFlag)
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Moving the main command to a sub-command paves the way to #782 (Improve main action flag visibility).
With this in-place, the next step is to move the ENV flag definition to the cli/v2 flag field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "start" command to launch the arkd server

* **Refactor**
  * Restructured application entry point to use the start command as the default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->