### PR TITLE
fix: ConditionCSVMultisigClosure as exit closures

### DIFF
--- a/pkg/ark-lib/script/script_test.go
+++ b/pkg/ark-lib/script/script_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	common "github.com/arkade-os/arkd/pkg/ark-lib"
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -438,7 +438,7 @@ func TestRoundTripCSV(t *testing.T) {
 		MultisigClosure: script.MultisigClosure{
 			PubKeys: []*btcec.PublicKey{seckey.PubKey()},
 		},
-		Locktime: common.RelativeLocktime{Type: common.LocktimeTypeSecond, Value: 1024},
+		Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 1024},
 	}
 
 	leaf, err := csvSig.Script()
@@ -600,7 +600,7 @@ func TestCSVMultisigClosure(t *testing.T) {
 			MultisigClosure: script.MultisigClosure{
 				PubKeys: []*btcec.PublicKey{pubkey1},
 			},
-			Locktime: common.RelativeLocktime{Type: common.LocktimeTypeSecond, Value: 1024},
+			Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 1024},
 		}
 
 		scriptBytes, err := csvSig.Script()
@@ -623,8 +623,8 @@ func TestCSVMultisigClosure(t *testing.T) {
 			MultisigClosure: script.MultisigClosure{
 				PubKeys: []*btcec.PublicKey{pubkey1, pubkey2},
 			},
-			Locktime: common.RelativeLocktime{
-				Type:  common.LocktimeTypeSecond,
+			Locktime: arklib.RelativeLocktime{
+				Type:  arklib.LocktimeTypeSecond,
 				Value: 512 * 4,
 			}, // ~2 weeks
 		}
@@ -674,9 +674,9 @@ func TestCSVMultisigClosure(t *testing.T) {
 			MultisigClosure: script.MultisigClosure{
 				PubKeys: []*btcec.PublicKey{pubkey1},
 			},
-			Locktime: common.RelativeLocktime{
-				Type:  common.LocktimeTypeSecond,
-				Value: common.SECONDS_MAX,
+			Locktime: arklib.RelativeLocktime{
+				Type:  arklib.LocktimeTypeSecond,
+				Value: arklib.SECONDS_MAX,
 			}, // Maximum allowed value
 		}
 
@@ -687,7 +687,7 @@ func TestCSVMultisigClosure(t *testing.T) {
 		valid, err := decodedCSV.Decode(scriptBytes)
 		require.NoError(t, err)
 		require.True(t, valid)
-		require.Equal(t, uint32(common.SECONDS_MAX), decodedCSV.Locktime.Value)
+		require.Equal(t, uint32(arklib.SECONDS_MAX), decodedCSV.Locktime.Value)
 	})
 }
 
@@ -793,7 +793,7 @@ func TestCSVMultisigClosureWitness(t *testing.T) {
 		MultisigClosure: script.MultisigClosure{
 			PubKeys: []*btcec.PublicKey{pub1},
 		},
-		Locktime: common.RelativeLocktime{Type: common.LocktimeTypeBlock, Value: 144},
+		Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeBlock, Value: 144},
 	}
 
 	witness, err := closure.Witness(controlBlock, signatures)
@@ -868,7 +868,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1},
 				Type:    script.MultisigTypeChecksig,
 			},
-			Locktime: common.AbsoluteLocktime(time.Now().Unix()),
+			Locktime: arklib.AbsoluteLocktime(time.Now().Unix()),
 		}
 
 		scriptBytes, err := closure.Script()
@@ -893,7 +893,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1},
 				Type:    script.MultisigTypeChecksig,
 			},
-			Locktime: common.AbsoluteLocktime(3000),
+			Locktime: arklib.AbsoluteLocktime(3000),
 		}
 
 		scriptBytes, err := closure.Script()
@@ -918,7 +918,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1, pubkey2},
 				Type:    script.MultisigTypeChecksig,
 			},
-			Locktime: common.AbsoluteLocktime(time.Now().Unix()),
+			Locktime: arklib.AbsoluteLocktime(time.Now().Unix()),
 		}
 
 		scriptBytes, err := closure.Script()
@@ -938,7 +938,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1, pubkey2},
 				Type:    script.MultisigTypeChecksigAdd,
 			},
-			Locktime: common.AbsoluteLocktime(time.Now().Unix()),
+			Locktime: arklib.AbsoluteLocktime(time.Now().Unix()),
 		}
 
 		scriptBytes, err := closure.Script()
@@ -959,7 +959,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1, pubkey2},
 				Type:    script.MultisigTypeChecksig,
 			},
-			Locktime: common.AbsoluteLocktime(time.Now().Unix()),
+			Locktime: arklib.AbsoluteLocktime(time.Now().Unix()),
 		}
 
 		controlBlock := bytes.Repeat([]byte{0x00}, 32)
@@ -984,7 +984,7 @@ func TestCLTVMultisigClosure(t *testing.T) {
 				PubKeys: []*btcec.PublicKey{pubkey1},
 				Type:    script.MultisigTypeChecksig,
 			},
-			Locktime: common.AbsoluteLocktime(time.Now().Unix()),
+			Locktime: arklib.AbsoluteLocktime(time.Now().Unix()),
 		}
 		scriptBytes, err := validClosure.Script()
 		require.NoError(t, err)
@@ -1249,17 +1249,33 @@ func TestParseVtxoScript(t *testing.T) {
 			vtxoScript, err := script.ParseVtxoScript(fixture.Scripts)
 			require.NoError(t, err)
 
+			allClosures := append(vtxoScript.ExitClosures(), vtxoScript.ForfeitClosures()...)
+
+			require.Len(t, allClosures, len(fixture.Scripts))
+
 			tapkey, _, err := vtxoScript.TapTree()
 			require.NoError(t, err)
 			require.Equal(t, fixture.TaprootKey, hex.EncodeToString(schnorr.SerializePubKey(tapkey)))
+
+			for _, closure := range allClosures {
+				scriptBytes, err := closure.Script()
+				require.NoError(t, err)
+				require.Contains(t, fixture.Scripts, hex.EncodeToString(scriptBytes))
+			}
+
+			smallestExitDelay, err := vtxoScript.SmallestExitDelay()
+			require.NoError(t, err)
+			require.NotNil(t, smallestExitDelay)
+			require.Equal(t, fixture.SmallestExitDelay, *smallestExitDelay)
 		})
 	}
 }
 
 type vtxoScriptFixtures struct {
-	Name       string   `json:"name"`
-	Scripts    []string `json:"scripts"`
-	TaprootKey string   `json:"taprootKey"`
+	Name              string                  `json:"name"`
+	Scripts           []string                `json:"scripts"`
+	TaprootKey        string                  `json:"taprootKey"`
+	SmallestExitDelay arklib.RelativeLocktime `json:"smallestExitDelay"`
 }
 
 func parseVtxoScriptFixtures(t *testing.T) []vtxoScriptFixtures {

--- a/pkg/ark-lib/script/testdata/vtxoscript.json
+++ b/pkg/ark-lib/script/testdata/vtxoscript.json
@@ -10,7 +10,11 @@
             "03010040b275201ad0602183f84bf33205d574dbbbe1b2bfecfd35bf4ba9fed39852606ed62391ad20e106ad991696429bfdd602890800d275937b3b3858024774efc21fb5e8b75c30ac",
             "a91446a0f8ae0ca7bb8041c6759fc29837b667c279cd8769201ad0602183f84bf33205d574dbbbe1b2bfecfd35bf4ba9fed39852606ed62391ad20e106ad991696429bfdd602890800d275937b3b3858024774efc21fb5e8b75c30ad2061d8b7526b6d5a46a57a01fcab370acaad1bff309da342bf4acc9077db6b4ac2ad2056f810de93e500e745b7dabfcb2b798b216a70a99de7edee79bf1791379bf62dac"
         ],
-        "taprootKey": "44815a74de6ea3c04652544da00711cf702263b6952bd4222c00d7bdf6e59ec9"
+        "taprootKey": "44815a74de6ea3c04652544da00711cf702263b6952bd4222c00d7bdf6e59ec9",
+        "smallestExitDelay": {
+            "type": 0,
+            "value": 512
+        }
     },
     {
         "name": "vtxoScript from even number of tapscripts",
@@ -22,6 +26,35 @@
             "03010040b275201ad0602183f84bf33205d574dbbbe1b2bfecfd35bf4ba9fed39852606ed62391ad2061d8b7526b6d5a46a57a01fcab370acaad1bff309da342bf4acc9077db6b4ac2ac",
             "03010040b275201ad0602183f84bf33205d574dbbbe1b2bfecfd35bf4ba9fed39852606ed62391ad20e106ad991696429bfdd602890800d275937b3b3858024774efc21fb5e8b75c30ac"
         ],
-        "taprootKey": "5de945bb60e4c8c0cf5096f71f4707018d0a9879c76c9cf7a7996d8a555b812e"
+        "taprootKey": "5de945bb60e4c8c0cf5096f71f4707018d0a9879c76c9cf7a7996d8a555b812e",
+        "smallestExitDelay": {
+            "type": 0,
+            "value": 512
+        }
+    },
+    {
+        "name": "vtxoScript with condition CSV multisig closure",
+        "scripts": [
+            "516920002851fd1c7692e5ab649ce1a88bd8ba59e09401d78c4c8fe6ef93c405c4bbb8ad2008c65c69fb2bb155d81f914de7b0319a01f3ce89eaad8e212efaf835c58010a3ac",
+            "516903020040b27520002851fd1c7692e5ab649ce1a88bd8ba59e09401d78c4c8fe6ef93c405c4bbb8ad2008c65c69fb2bb155d81f914de7b0319a01f3ce89eaad8e212efaf835c58010a3ac"
+        ],
+        "taprootKey": "2e65d02c0d5a6f6a11cbf67692d0fc0c9f115661d945146511d3b6bf80825c1a",
+        "smallestExitDelay": {
+            "type": 0,
+            "value": 1024
+        }
+    },
+    {
+        "name": "vtxoScript with block exit delay",
+        "scripts": [
+            "516903020040b2752006cf59c1626cb6a9205d0f950bb4b4562adf1372e8719b3c0c4796b9a7870038ad20f97c6a02e7a3055cdb27afb51220efa99d93957a7218da17c665f183696da025ac",
+            "51692006cf59c1626cb6a9205d0f950bb4b4562adf1372e8719b3c0c4796b9a7870038ad20f97c6a02e7a3055cdb27afb51220efa99d93957a7218da17c665f183696da025ac",
+            "51b2752006cf59c1626cb6a9205d0f950bb4b4562adf1372e8719b3c0c4796b9a7870038ad20f97c6a02e7a3055cdb27afb51220efa99d93957a7218da17c665f183696da025ac"
+        ],
+        "taprootKey": "9fca3b709253880dab186fbe6bc014caa642c82d3e2f74c6c7591697c540107d",
+        "smallestExitDelay": {
+            "type": 1,
+            "value": 1
+        }
     }
 ]

--- a/pkg/ark-lib/script/vtxo_script.go
+++ b/pkg/ark-lib/script/vtxo_script.go
@@ -156,11 +156,22 @@ func (v *TapscriptsVtxoScript) Validate(
 func (v *TapscriptsVtxoScript) SmallestExitDelay() (*arklib.RelativeLocktime, error) {
 	var smallest *arklib.RelativeLocktime
 
-	for _, closure := range v.Closures {
-		if csvClosure, ok := closure.(*CSVMultisigClosure); ok {
-			if smallest == nil || csvClosure.Locktime.LessThan(*smallest) {
-				smallest = &csvClosure.Locktime
-			}
+	for _, closure := range v.ExitClosures() {
+		var closureExitLocktime *arklib.RelativeLocktime
+
+		switch c := closure.(type) {
+		case *CSVMultisigClosure:
+			closureExitLocktime = &c.Locktime
+		case *ConditionCSVMultisigClosure:
+			closureExitLocktime = &c.Locktime
+		}
+
+		if closureExitLocktime == nil {
+			return nil, fmt.Errorf("invalid exit closure, expected CSVMultisigClosure or ConditionCSVMultisigClosure with non-empty CSV locktime")
+		}
+
+		if smallest == nil || closureExitLocktime.LessThan(*smallest) {
+			smallest = closureExitLocktime
 		}
 	}
 
@@ -186,7 +197,7 @@ func (v *TapscriptsVtxoScript) ExitClosures() []Closure {
 	exits := make([]Closure, 0)
 	for _, closure := range v.Closures {
 		switch closure.(type) {
-		case *CSVMultisigClosure:
+		case *CSVMultisigClosure, *ConditionCSVMultisigClosure:
 			exits = append(exits, closure)
 		}
 	}


### PR DESCRIPTION
This PR fixes `VtxoScript.SmallestExitDelay` and `VtxoScript.ExitClosures` methods to include `ConditionCSVMultisigClosure` scripts.

it also increases unit test coverage for these methods in `script_test.go` 

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for exit delay validation across additional closure types.
  * Updated test fixtures with smallestExitDelay data for enhanced validation scenarios.

* **Improvements**
  * Enhanced exit delay handling to support additional closure types.
  * Improved validation of exit lock times with stricter error checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->