### PR TITLE
fix `decodeTx`: mark subdust vtxo as "swept"

### DIFF
--- a/internal/core/application/utils.go
+++ b/internal/core/application/utils.go
@@ -134,6 +134,7 @@ func decodeTx(offchainTx domain.OffchainTx) (string, []domain.Outpoint, []domain
 			CommitmentTxids:    offchainTx.CommitmentTxidsList(),
 			RootCommitmentTxid: offchainTx.RootCommitmentTxId,
 			Preconfirmed:       true,
+			Swept:              script.IsSubDustScript(out.PkScript),
 			CreatedAt:          offchainTx.StartingTimestamp,
 		})
 	}


### PR DESCRIPTION
The transaction stream was not handling correctly the subdust outputs returning them with `Swept = false`, leading to corrupted client DB. 

@altafan @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Enhanced internal transaction processing to improve tracking of output status during transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->