### PR TITLE
Safer boarding input signature validation

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -2709,6 +2709,8 @@ func (s *service) finalizeRound(roundTiming roundTiming) {
 		if len(boardingInputsIndexes) > 0 {
 			s.roundReportSvc.OpStarted(VerifyBoardingInputsSignaturesOp)
 
+			log.Debugf("signing boarding inputs of commitment tx for round %s\n", roundId)
+
 			txToSign, err = s.signer.SignTransactionTapscript(
 				ctx,
 				s.cache.CurrentRound().Get().CommitmentTx,
@@ -2716,7 +2718,7 @@ func (s *service) finalizeRound(roundTiming roundTiming) {
 			)
 			if err != nil {
 				changes = s.cache.CurrentRound().Fail(
-					errors.INTERNAL_ERROR.New("failed to sign commitment tx: %s", err),
+					errors.INTERNAL_ERROR.New("failed to sign boarding inputs of commitment tx: %s", err),
 				)
 				return
 			}

--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -539,7 +539,8 @@ func (w *wallet) SignTransaction(
 			return "", err
 		}
 		if privateKey == nil {
-			return "", fmt.Errorf("private key not found for script %x (input %d)", input.WitnessUtxo.PkScript, inputIndex)
+			return "", fmt.Errorf("script %x is not a wallet script, cannot sign input %s",
+				input.WitnessUtxo.PkScript, ptx.UnsignedTx.TxIn[inputIndex].PreviousOutPoint.String())
 		}
 
 		signature, err := txscript.RawTxInTaprootSignature(


### PR DESCRIPTION
This PR ensures that `VerifyAndCombinePartialTx` is using the commitment tx built by the server to compute the signature hashes. Thus, a malicious user modifying witnessUtxo fields cannot provide fake valid signatures.

Also improve logging and error message of boarding input signature flow.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved Taproot signature verification logic for enhanced reliability.
  * Enhanced error messages for transaction signing failures for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->