### PR TITLE
Fix error message when batch aborted because not enough intent conf received

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -2251,7 +2251,7 @@ func (s *service) startConfirmation(
 		// make the round fail if we didn't receive enoush confirmations
 		if len(confirmedIntents) == 0 {
 			s.cache.CurrentRound().
-				Fail(errors.INTERNAL_ERROR.New("not enough confirmation received"))
+				Fail(errors.INTERNAL_ERROR.New("not enough intent confirmations received"))
 			return
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity for confirmation validation failures, providing more specific feedback when intent confirmations are insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->