### PR TITLE
Improve flag visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export ARKD_SIGNER_ADDR=localhost:7071
 
 2. Start arkd:
    ```sh
-   arkd
+   arkd start
    ```
 
 3. Create a new wallet:

--- a/cmd/arkd/commands.go
+++ b/cmd/arkd/commands.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/arkade-os/arkd/internal/config"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/urfave/cli/v2"
 )
@@ -20,6 +21,7 @@ var (
 	startCmd = &cli.Command{
 		Name:   "start",
 		Usage:  "Starts the arkd server",
+		Flags:  config.Flags,
 		Action: startAction,
 	}
 

--- a/cmd/arkd/main.go
+++ b/cmd/arkd/main.go
@@ -23,8 +23,8 @@ const (
 	tlsCertFile  = "cert.pem"
 )
 
-func startAction(_ *cli.Context) error {
-	cfg, err := config.LoadConfig()
+func startAction(c *cli.Context) error {
+	cfg, err := config.LoadConfig(c)
 	if err != nil {
 		return fmt.Errorf("invalid config: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/redis/go-redis/v9 v9.10.0
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/viper v1.20.1
 	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/timshannon/badgerhold/v4 v4.0.3
@@ -181,6 +180,7 @@ require (
 	github.com/rogpeppe/fastuuid v1.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/spf13/viper v1.20.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tidwall/gjson v1.17.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect


### PR DESCRIPTION
The main goal of this PR is to improve the flag visibility by document the usage within arkd. Now flags can be set with `--` syntax, while keeping compatibility with previous env var mechanic.

Flags are defined by cli and viper has been removed.
A comprehensive list of flags and its usage can be displayed as follows:
 ```bash

    NAME:
       arkd start - Starts the arkd server

    USAGE:
       arkd start [command options]

    OPTIONS:
       --datadir value                                         Directory to store data (default: "/home/gustavo/.arkd") [$ARKD_DATADIR]
       --port value                                            Port (public) to listen on (default: 7070) [$ARKD_PORT]
       --admin-port value                                      Admin port (private) to listen on, fallback to service port if 0 (default: 7071) [$ARKD_ADMIN_PORT]
       --log-level value                                       Logging level (0-6, where 6 is trace) (default: 4) [$ARKD_LOG_LEVEL]
       --session-duration value                                How long a batch session lasts (in seconds) before timing out once it started (default: 30) [$ARKD_SESSION_DURATION]
       --db-type value                                         Database type (postgres, sqlite, badger) (default: "postgres") [$ARKD_DB_TYPE]
       --pg-db-url value                                       Postgres connection url if ARKD_DB_TYPE is set to postgres [$ARKD_PG_DB_URL]
       --event-db-type value                                   Event database type (postgres, badger) (default: "postgres") [$ARKD_EVENT_DB_TYPE]
       --pg-event-db-url value                                 Postgres connection url if ARKD_EVENT_DB_TYPE is set to postgres [$ARKD_PG_EVENT_DB_URL]
       --tx-builder-type value                                 Transaction builder type (default: "covenantless") [$ARKD_TX_BUILDER_TYPE]
       --live-store-type value                                 Cache service type (redis, inmemory) (default: "redis") [$ARKD_LIVE_STORE_TYPE]
       --redis-url value                                       Redis db connection url if ARKD_LIVE_STORE_TYPE is set to redis [$ARKD_REDIS_URL]
       --redis-num-of-retries value                            Maximum number of retries for Redis write operations in case of conflicts (default: 10) [$ARKD_REDIS_NUM_OF_RETRIES]
       --vtxo-tree-expiry value                                VTXO tree expiry in seconds (default: 604672 (~7 days)) [$ARKD_VTXO_TREE_EXPIRY]
       --unilateral-exit-delay value                           Unilateral exit delay in seconds (default: 86400 (~24 hours)) [$ARKD_UNILATERAL_EXIT_DELAY]
       --public-unilateral-exit-delay value                    Public unilateral exit delay in seconds (default: 86400 (~24 hours)) [$ARKD_PUBLIC_UNILATERAL_EXIT_DELAY]
       --boarding-exit-delay value                             Boarding exit delay in seconds (default: 7776000 (~3 months)) [$ARKD_BOARDING_EXIT_DELAY]
       --esplora-url value                                     Esplora API URL (default: "https://blockstream.info/api") [$ARKD_ESPLORA_URL]
       --wallet-addr value                                     The arkd wallet address to connect to in the form host:port [$ARKD_WALLET_ADDR]
       --signer-addr value                                     The signer address to connect to in the form host:port (default: value of `ARKD_WALLET_ADDR`) [$ARKD_SIGNER_ADDR]
       --no-macaroons                                          Disable Macaroons authentication (default: false) [$ARKD_NO_MACAROONS]
       --no-tls                                                Disable TLS (default: true) [$ARKD_NO_TLS]
       --unlocker-type value                                   Wallet unlocker type (env, file) to enable auto-unlock [$ARKD_UNLOCKER_TYPE]
       --unlocker-file-path value                              Path to unlocker file [$ARKD_UNLOCKER_FILE_PATH]
       --unlocker-password value                               Wallet unlocker password [$ARKD_UNLOCKER_PASSWORD]
       --round-max-participants-count value                    Maximum number of participants per round (default: 128) [$ARKD_ROUND_MAX_PARTICIPANTS_COUNT]
       --round-min-participants-count value                    Minimum number of participants per round (default: 1) [$ARKD_ROUND_MIN_PARTICIPANTS_COUNT]
       --utxo-max-amount value                                 The maximum allowed amount for boarding or collaborative exit (default: -1 unset) [$ARKD_UTXO_MAX_AMOUNT]
       --utxo-min-amount value                                 The minimum allowed amount for boarding or collaborative exit (default: -1 dust) [$ARKD_UTXO_MIN_AMOUNT]
       --utxo-min-amount value                                 The minimum allowed amount for boarding or collaborative exit (default: -1 dust) [$ARKD_UTXO_MIN_AMOUNT]
       --vtxo-max-amount value                                 The maximum allowed amount for vtxos (default: -1 unset) [$ARKD_VTXO_MAX_AMOUNT]
       --vtxo-min-amount value                                 The minimum allowed amount for vtxos (default: -1 dust) [$ARKD_VTXO_MIN_AMOUNT]
       --ban-duration value                                    Ban duration in seconds (default: 300) [$ARKD_BAN_DURATION]
       --ban-threshold value                                   Number of crimes to trigger a ban (default: 3) [$ARKD_BAN_THRESHOLD]
       --scheduler-type value                                  Scheduler type (gocron, block) (default: "gocron") [$ARKD_SCHEDULER_TYPE]
       --checkpoint-exit-delay value                           Checkpoint exit delay in seconds (default: 86400) [$ARKD_CHECKPOINT_EXIT_DELAY]
       --tls-extra-ip value [ --tls-extra-ip value ]           Extra IP addresses for TLS (comma-separated) [$ARKD_TLS_EXTRA_IP]
       --tls-extra-domain value [ --tls-extra-domain value ]   Extra domains for TLS (comma-separated) [$ARKD_TLS_EXTRA_DOMAIN]
       --note-uri-prexi value                                  Note URI prefix [$ARKD_NOTE_URI_PREFIX]
       --scheduled-session-start-time value                    Scheduled session start time (Unix timestamp) (default: 0) [$ARKD_SCHEDULED_SESSION_START_TIME]
       --scheduled-session-end-time value                      Scheduled session end time (Unix timestamp) (default: 0) [$ARKD_SCHEDULED_SESSION_END_TIME]
       --scheduled-session-period value                        Scheduled session period in minutes (default: 0) [$ARKD_SCHEDULED_SESSION_PERIOD]
       --scheduled-session-duration value                      Scheduled session duration in seconds (default: 0) [$ARKD_SCHEDULED_SESSION_DURATION]
       --scheduled-session-min-round-participants-count value  Min participants for scheduled sessions [$ARKD_SCHEDULED_SESSION_MIN_ROUND_PARTICIPANTS_COUNT]
       --scheduled-session-max-round-participants-count value  Max participants for scheduled sessions [$ARKD_SCHEDULED_SESSION_MAX_ROUND_PARTICIPANTS_COUNT]
       --collector-endpoint value                              OpenTelemetry collector endpoint [$ARKD_COLLECTOR_ENDPOINT]
       --otel-push-internal value                              OpenTelemetry push interval in seconds (default: 10) [$ARKD_OTEL_PUSH_INTERVAL]
       --allow-csv-block-type                                  Allow CSV block type (default: false) [$ARKD_ALLOW_CSV_BLOCK_TYPE]
       --heartbeat-interval value                              Heartbeat interval in seconds (default: 60) [$ARKD_HEARTBEAT_INTERVAL]
       --round-report-enabled                                  Enable round report service (default: false) [$ARKD_ROUND_REPORT_ENABLED]
       --settlement-min-expiry-gap value                       (default: 0 disabled) [$ARKD_SETTLEMENT_MIN_EXPIRY_GAP]
       --vtxo-no-csv-validation-cutoff-date value              (default: 0 disabled) [$ARKD_VTXO_NO_CSV_VALIDATION_CUTOFF_DATE]
       --onchain-output-fee value                              (default: 0) [$ARKD_ONCHAIN_OUTPUT_FEE]
       --alert-manager-url value                                [$ARKD_ALERT_MANAGER_URL]
       --help, -h                                              show help
```

Closes #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Most application configuration options are now exposed as command-line flags for the arkd start command, allowing runtime configuration via flags or environment variables.

* **Documentation**
  * Setup instructions updated to reflect the new arkd start usage.

* **Chores**
  * Internal configuration system refactored to centralize flag/env handling and configuration loading; a dependency representation was adjusted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->