### PR TITLE
chore: Fix inaccurate test function comment in e2e tests

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -2871,7 +2871,7 @@ func TestCollisionBetweenInRoundAndRedeemVtxo(t *testing.T) {
 
 }
 
-// TestDeleteIntent tests deleting an already registered intent
+// TestIntent tests intent registration and deletion functionality
 func TestIntent(t *testing.T) {
 	t.Run("register and delete", func(t *testing.T) {
 		ctx := t.Context()


### PR DESCRIPTION
Updated the comment for the `TestIntent` function in e2e tests to accurately reflect its functionality, which includes both intent registration and deletion tests, not just deletion as previously commented. 

This ensures code documentation aligns with actual implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **No user-facing changes** – This release contains only internal documentation updates with no impact on functionality or end-user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->