### PR TITLE
chore: fix function name mismatch in comment for StartEtcdTestBackend

### DIFF
--- a/pkg/kvdb/kvdb_etcd.go
+++ b/pkg/kvdb/kvdb_etcd.go
@@ -11,8 +11,8 @@ import (
 // defined, allowing testing our database code with etcd backend.
 const EtcdBackend = true
 
-// GetEtcdTestBackend creates an embedded etcd backend for testing
-// storig the database at the passed path.
+// StartEtcdTestBackend creates an embedded etcd backend for testing
+// storing the database at the passed path.
 func StartEtcdTestBackend(path string, clientPort, peerPort uint16,
 	logFile string) (*etcd.Config, func(), error) {
 


### PR DESCRIPTION

Corrected the comment for the `StartEtcdTestBackend`   function in `kvdb_etcd.go` to match the actual function name. Previously, the comment referred to "GetEtcdTestBackend" which was inconsistent with the implementation. 

This change ensures that the documentation accurately reflects the code, improving clarity for developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a comment to fix a naming reference and a spelling typo for clarity.

*Note: This release contains only internal documentation updates with no user-visible changes.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->