### PR TITLE
chore: fix inaccurate comments for GetAddressNotifications function

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -631,8 +631,9 @@ func (n *nbxplorer) UnwatchAddresses(ctx context.Context, addresses ...string) e
 	return nil
 }
 
-// GetGroupNotifications monitors group UTXOs using WebSocket events and triggers UTXO rescanning
-// only when receiving "newtransaction" events. Returns only UTXOs from the specific new transaction.
+// GetAddressNotifications returns the channel where to listen for notifications about incoming 
+// UTXOs for the watched addresses.
+// If no underlying group is set, an empty one will be created.
 func (n *nbxplorer) GetAddressNotifications(ctx context.Context) (<-chan []ports.Utxo, error) {
 	if len(n.groupID) == 0 {
 		if err := n.createEmptyGroup(ctx); err != nil {


### PR DESCRIPTION
Updated the comments for the GetAddressNotifications function to accurately reflect its behavior of monitoring address notifications via WebSocket events for new transactions and returning related UTXOs, correcting the previous misleading description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched UTXO notification to address-centric real-time monitoring via WebSocket events instead of group-based tracking.
  * Added automatic reconnection and context-aware cancellation for more resilient streams.
  * Introduced buffered notification delivery to avoid blocking during concurrent updates and improve reliability of UTXO notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->