### PR TITLE
Support locktime in Intents

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -1166,6 +1166,7 @@ func TestDelegateRefresh(t *testing.T) {
 				PkScript: alicePkScript,
 			},
 		},
+		0,
 	)
 	require.NoError(t, err)
 

--- a/pkg/ark-lib/intent/proof_test.go
+++ b/pkg/ark-lib/intent/proof_test.go
@@ -19,7 +19,7 @@ func TestNewIntent(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, fixture := range validFixtures {
 			t.Run(fixture.Name, func(t *testing.T) {
-				proof, err := intent.New(fixture.Message, fixture.Inputs, fixture.Outputs)
+				proof, err := intent.New(fixture.Message, fixture.Inputs, fixture.Outputs, 0)
 				require.NoError(t, err)
 				require.NotNil(t, proof)
 				require.GreaterOrEqual(t, len(proof.Inputs), 2)
@@ -45,7 +45,7 @@ func TestNewIntent(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		for _, fixture := range invalidFixtures {
 			t.Run(fixture.Name, func(t *testing.T) {
-				proof, err := intent.New(fixture.Message, fixture.Inputs, fixture.Outputs)
+				proof, err := intent.New(fixture.Message, fixture.Inputs, fixture.Outputs, 0)
 				require.Error(t, err)
 				require.Nil(t, proof)
 				require.ErrorContains(t, err, fixture.ExpectedError)


### PR DESCRIPTION
This adds support for adding locktime to intents which would enable adding witness to CLTV inputs.

@altafan please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to reflect API signature changes.

* **Refactor**
  * Enhanced function signatures to support additional configuration parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->