### PR TITLE
Add checks to prevent using empty strings in fee cmd flags

### DIFF
--- a/cmd/arkd/commands.go
+++ b/cmd/arkd/commands.go
@@ -1235,6 +1235,19 @@ func updateIntentFees(ctx *cli.Context) error {
 		return err
 	}
 
+	if ctx.IsSet(onchainInputFlagName) && onchainInputFee == "" {
+		return fmt.Errorf("--%s flag requires a non-empty string", onchainInputFlagName)
+	}
+	if ctx.IsSet(offchainInputFlagName) && offchainInputFee == "" {
+		return fmt.Errorf("--%s flag requires a non-empty string", offchainInputFlagName)
+	}
+	if ctx.IsSet(onchainOutputFlagName) && onchainOutputFee == "" {
+		return fmt.Errorf("--%s flag requires a non-empty string", onchainOutputFlagName)
+	}
+	if ctx.IsSet(offchainOutputFlagName) && offchainOutputFee == "" {
+		return fmt.Errorf("--%s flag requires a non-empty string", offchainOutputFlagName)
+	}
+
 	url := fmt.Sprintf("%s/v1/admin/intentFees", baseURL)
 	body := fmt.Sprintf(
 		`{"fees":{"onchain_input_fee": "%s", "offchain_input_fee": "%s", "onchain_output_fee": "%s", "offchain_output_fee": "%s"}}`,


### PR DESCRIPTION
This adds simple checks to prevent using (incorrectly) empty strings to unset a fee program with the cli (as they are gonna be ignored).

Please @louisinger review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter input validation for fee configuration settings to prevent invalid or incomplete configurations from being processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->