### PR TITLE
GetPendingTxs: drop IsAccepted check

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1412,11 +1412,6 @@ func (s *service) GetPendingOffchainTxs(
 			continue
 		}
 
-		if !offchainTx.IsAccepted() {
-			// the tx must be in the "accepted" stage to be considered as pending
-			continue
-		}
-
 		seen[vtxo.ArkTxid] = struct{}{}
 		acceptedOffchainTxs = append(acceptedOffchainTxs, AcceptedOffchainTx{
 			TxId:                offchainTx.ArkTxid,


### PR DESCRIPTION
skip offchainTx.IsAccepted can skip accepted but "failed" transactions. Moreover this check is redundant because `GetPendingSpentVtxosWithOutpoints` is already returning vtxos related to pending txs.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Expanded pending offchain transaction retrieval to include a broader range of finalized transactions, providing more complete results to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->