### PR TITLE
Fix parsing metadata from db record

### DIFF
--- a/internal/infrastructure/db/postgres/asset_repo.go
+++ b/internal/infrastructure/db/postgres/asset_repo.go
@@ -149,10 +149,9 @@ func (r *assetRepository) GetAssets(
 			if row.Metadata.Valid {
 				// Parsing metadata should never fail but if it does we just return an empty list
 				// of metadata and log the error
-				// nolint
 				ast.Metadata, err = asset.NewMetadataListFromString(row.Metadata.String)
 				if err != nil {
-					log.WithError(err).Warnf("failed to parse metadata or assset %s", row.ID)
+					log.WithError(err).Warnf("failed to parse metadata for asset %s", row.ID)
 				}
 			}
 

--- a/internal/infrastructure/db/sqlite/asset_repo.go
+++ b/internal/infrastructure/db/sqlite/asset_repo.go
@@ -152,10 +152,9 @@ func (r *assetRepository) GetAssets(
 			if row.Metadata.Valid {
 				// Parsing metadata should never fail but if it does we just return an empty list
 				// of metadata and log the error
-				// nolint
 				ast.Metadata, err = asset.NewMetadataListFromString(row.Metadata.String)
 				if err != nil {
-					log.WithError(err).Warnf("failed to parse metadata or assset %s", row.ID)
+					log.WithError(err).Warnf("failed to parse metadata for asset %s", row.ID)
 				}
 			}
 			assets = append(assets, ast)


### PR DESCRIPTION
This makes the asset repo return an asset with empty metadata if we fail to parse it from the string value in db record, instead of `conitnue`ing and make the method return an empty list of assets that leads to `asset not found` error when calling the indexer endpoint

@louisinger please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Assets are no longer dropped when metadata parsing fails; affected assets remain visible and processed.
  * Metadata parsing issues now emit warning logs (including asset identifiers) to aid troubleshooting without impacting user-visible results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->