### PR TITLE
guards for subdust in opreturn

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1749,6 +1749,13 @@ func (s *service) RegisterIntent(
 				)
 			}
 
+			if output.Value != 0 {
+				return "", errors.INVALID_INTENT_PSBT.New(
+					"extension output #%d has non-zero value (%d)",
+					outputIndex, output.Value,
+				)
+			}
+
 			ext, err = extension.NewExtensionFromBytes(output.PkScript)
 			if err != nil {
 				return "", errors.INVALID_INTENT_PROOF.New(
@@ -4274,6 +4281,13 @@ func validateOffchainTxOutputs(
 				).WithMetadata(errors.PsbtMetadata{Tx: signedArkTx})
 			}
 			foundExtension = true
+
+			if out.Value != 0 {
+				return nil, nil, errors.MALFORMED_ARK_TX.New(
+					"extension OP_RETURN output #%d has non-zero value (%d)",
+					outIndex, out.Value,
+				).WithMetadata(errors.PsbtMetadata{Tx: signedArkTx})
+			}
 
 			outputs = append(outputs, out)
 

--- a/internal/core/application/service_test.go
+++ b/internal/core/application/service_test.go
@@ -531,23 +531,38 @@ func TestValidateOffchainTxOutputs(t *testing.T) {
 			vtxoMinOffchainTxAmount: 0,
 			wantOutputCount:         1,
 		},
-		// Extension OP_RETURN can have any value
+		// Extension OP_RETURN must have value == 0
+		{
+			description: "reject: extension OP_RETURN with non-zero value",
+			txOuts: []*wire.TxOut{
+				anchor,
+				{Value: 1000, PkScript: testExtensionScript(t)},
+			},
+			dust:                    testDust,
+			vtxoMaxAmount:           -1,
+			vtxoMinOffchainTxAmount: 0,
+			wantErr:                 true,
+			wantErrCode:             errors.MALFORMED_ARK_TX.Code,
+			wantErrContains:         "extension OP_RETURN output",
+		},
+		{
+			description: "reject: extension OP_RETURN with value == 1",
+			txOuts: []*wire.TxOut{
+				anchor,
+				{Value: 1, PkScript: testExtensionScript(t)},
+			},
+			dust:                    testDust,
+			vtxoMaxAmount:           -1,
+			vtxoMinOffchainTxAmount: 0,
+			wantErr:                 true,
+			wantErrCode:             errors.MALFORMED_ARK_TX.Code,
+			wantErrContains:         "extension OP_RETURN output",
+		},
 		{
 			description: "valid: extension OP_RETURN with zero value",
 			txOuts: []*wire.TxOut{
 				anchor,
 				{Value: 0, PkScript: testExtensionScript(t)},
-			},
-			dust:                    testDust,
-			vtxoMaxAmount:           -1,
-			vtxoMinOffchainTxAmount: 0,
-			wantOutputCount:         1,
-		},
-		{
-			description: "valid: extension OP_RETURN with non-zero value",
-			txOuts: []*wire.TxOut{
-				anchor,
-				{Value: 1000, PkScript: testExtensionScript(t)},
 			},
 			dust:                    testDust,
 			vtxoMaxAmount:           -1,


### PR DESCRIPTION
Closes #841

*To be rebased off of https://github.com/arkade-os/arkd/pull/923 after it is merged first*

Created a functions `validateOffchainTxOutputs` called from within existing `SubmitOffchainTx` to separate out the validation logic. Within this logic is the addition of the 2 new guards outlined in the issue.

Tests were added against this new function in the new test file: `internal/core/application/validate_outputs_test.go`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and streamlined offchain transaction output validation, consolidating checks for anchors, OP_RETURN, dust, and per-output value limits while preserving existing behavior.

* **Tests**
  * Added comprehensive tests covering valid flows, error conditions, boundary values, and mixed scenarios to reduce regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->