### PR TITLE
fix: postgres/redis CI flaky test

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -2905,8 +2905,8 @@ func TestSweep(t *testing.T) {
 		err = generateBlocks(25)
 		require.NoError(t, err)
 
-		// give time for the server to process the sweep
-		time.Sleep(35 * time.Second)
+		// give time for the server to process the sweep and indexer to sync the vtxo table
+		time.Sleep(45 * time.Second)
 
 		// verify that all vtxos have been swept
 		aliceVtxos, _, err = alice.ListVtxos(ctx)


### PR DESCRIPTION
@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased wait times in end-to-end tests to allow backend indexing to catch up, reducing flaky balance/sweep checks and improving CI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->