### PR TITLE
Fix sqlite multi-pubkey vtxo query returning empty results

### DIFF
--- a/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -257,9 +257,9 @@ SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE txid = @txid AND vout = @vout;
 SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw;
 
 -- name: SelectVtxosWithPubkeys :many
-SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE pubkey IN (sqlc.slice('pubkeys'))
-    AND updated_at >= :after
-    AND (CAST(:before AS INTEGER) = 0 OR updated_at <= CAST(:before AS INTEGER));
+SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE updated_at >= :after
+    AND (CAST(:before AS INTEGER) = 0 OR updated_at <= CAST(:before AS INTEGER))
+    AND pubkey IN (sqlc.slice('pubkeys'));
 
 -- name: SelectExpiringLiquidityAmount :one
 SELECT COALESCE(SUM(amount), 0) AS amount
@@ -335,12 +335,12 @@ SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE spent = true AND unrolled = true A
 SELECT v.*
 FROM vtxo_vw v
 WHERE v.spent = TRUE AND v.unrolled = FALSE AND COALESCE(v.settled_by, '') = ''
-    AND v.pubkey IN (sqlc.slice('pubkeys'))
     AND v.ark_txid IS NOT NULL AND NOT EXISTS (
         SELECT 1 FROM vtxo AS o WHERE o.txid = v.ark_txid
     )
     AND v.updated_at >= :after
-    AND (CAST(:before AS INTEGER) = 0 OR v.updated_at <= CAST(:before AS INTEGER));
+    AND (CAST(:before AS INTEGER) = 0 OR v.updated_at <= CAST(:before AS INTEGER))
+    AND v.pubkey IN (sqlc.slice('pubkeys'));
 
 -- name: SelectPendingSpentVtxo :many
 SELECT v.*


### PR DESCRIPTION
## Summary
- Fixes a bug where `GetVtxos` with multiple scripts returns empty results on SQLite
- Root cause: `sqlc.slice()` generates unnumbered `?` placeholders that shift positional `?N` parameter references (`?2` for `after`, `?3` for `before`) when the slice has >1 element — e.g. with 2 pubkeys, `?2` points to the second pubkey string instead of the `after` timestamp, so `updated_at >= "76383949..."` filters out all rows
- Fix: move `sqlc.slice('pubkeys')` to the end of the WHERE clause so `?1`/`?2` for `after`/`before` are stable; regenerated sqlc code
- PostgreSQL is unaffected (uses `pq.Array()` as a single `$1` parameter)
- Adds a regression test for querying vtxos with multiple pubkeys

## Test plan
- [x] New test `test_get_vtxos_with_multiple_pubkeys` passes locally on SQLite
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test case for retrieving records filtered by multiple public keys, verifying accurate filtering for single and combined key queries.

* **Refactor**
  * Optimized database query parameter binding order to improve consistency in how filters are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->