### PR TITLE
fix: reject asset packet with duplicated asset groups

### DIFF
--- a/pkg/ark-lib/asset/packet.go
+++ b/pkg/ark-lib/asset/packet.go
@@ -137,10 +137,19 @@ func (p Packet) validate() error {
 	if len(p) <= 0 {
 		return fmt.Errorf("missing assets")
 	}
+	seen := make(map[AssetId]struct{})
 	for _, asset := range p {
+		if asset.AssetId != nil {
+			if _, ok := seen[*asset.AssetId]; ok {
+				return fmt.Errorf("duplicate asset group for asset %s", asset.AssetId)
+			}
+			seen[*asset.AssetId] = struct{}{}
+		}
+
 		if err := asset.validate(); err != nil {
 			return err
 		}
+
 		if asset.ControlAsset != nil && asset.ControlAsset.Type == AssetRefByGroup &&
 			int(asset.ControlAsset.GroupIndex) >= len(p) {
 			return fmt.Errorf(

--- a/pkg/ark-lib/asset/testdata/packet_fixtures.json
+++ b/pkg/ark-lib/asset/testdata/packet_fixtures.json
@@ -140,6 +140,52 @@
                     }
                 ],
                 "expectedError": "invalid control asset group index"
+            },
+            {
+                "name": "duplicate asset group",
+                "assets": [
+                    {
+                        "assetId": {
+                            "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            "index": 0
+                        },
+                        "inputs": [
+                            {
+                                "type": "local",
+                                "vin": 0,
+                                "amount": 100
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "local",
+                                "vout": 0,
+                                "amount": 100
+                            }
+                        ]
+                    },
+                    {
+                        "assetId": {
+                            "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            "index": 0
+                        },
+                        "inputs": [
+                            {
+                                "type": "local",
+                                "vin": 0,
+                                "amount": 100
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "local",
+                                "vout": 1,
+                                "amount": 100
+                            }
+                        ]
+                    }
+                ],
+                "expectedError": "duplicate asset group for asset aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000"
             }
         ],
         "newPacketFromString": [


### PR DESCRIPTION
The current `asset.Packet.validate()`  was allowing 2 asset groups with the same assetID. We must reject it because it would allow a malicious attacker to inflate the asset without owning the control token.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate asset identifiers within packets, ensuring data integrity and preventing processing of invalid packets.

* **Tests**
  * Added test cases to verify duplicate asset detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->