### PR TITLE
event channel send helper

### DIFF
--- a/pkg/client-lib/internal/utils/stream_retry.go
+++ b/pkg/client-lib/internal/utils/stream_retry.go
@@ -176,9 +176,9 @@ func StartReconnectingStream[S grpcClientStream, R any, E any](
 	eventsCh := make(chan E, 1)
 	streamMu := sync.Mutex{}
 
-	// Emit terminal errors with best-effort delivery: even if the context is
-	// already cancelled, wait up to 5 seconds so consumers always learn why
-	// the stream ended.
+	// Emit terminal errors with best-effort delivery:
+	// try immediate send; if context is still active, wait up to 5 seconds.
+	// If context is already canceled, skip waiting to avoid teardown stalls.
 	sendTerminalErr := func(err error) bool {
 		// Fast path: immediate delivery.
 		select {


### PR DESCRIPTION
requested via: https://github.com/arkade-os/arkd/pull/933#discussion_r2879577502

  Changes in pkg/client-lib/client/grpc/client.go:                                                                                                                                                         
  
  1. `GetEventStream` - send helper for `BatchEventChannel:` Consolidates all channel-send-or-ctx-cancel patterns into a single `send()` function. For terminal errors (ev.Err != nil), it uses a 5-second       
  timeout instead of `ctx.Done()`, ensuring consumers always learn why the stream ended even if the context was already cancelled.
  2. `GetTransactionsStream` - send helper for `TransactionEvent`: Same consolidation pattern, replacing 5 separate `select { case <-ctx.Done(): return; case eventsCh <- ... }` blocks with calls to `send()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sender blocking in streaming to improve reliability under backpressure
  * Improved delivery of terminal stream errors with a graceful timeout and cancellation handling
  * Reduced teardown stalls and expanded the window in which final errors may be observed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->