### PR TITLE
Bump go@1.26.0

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25.7
+        go-version: 1.26.0
 
     - name: Build binaries
       run: make build-all

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
       
       - name: Run Nigiri
         uses: vulpemventures/nigiri-github-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.7
+          go-version: 1.26.0
 
       # Build binaries for all architectures
       - name: Build binaries

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
 
       - name: Check for changes
         run: |
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
 
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.0 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/api-spec/go.mod
+++ b/api-spec/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/api-spec
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/meshapi/grpc-api-gateway v0.1.0

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet binary
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.0 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/arkdwallet.btcwallet.Dockerfile
+++ b/arkdwallet.btcwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.0 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/ark-cli/go.mod
+++ b/pkg/ark-cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/pkg/ark-cli
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/ark-lib/go.mod
+++ b/pkg/ark-lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/pkg/ark-lib
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/arkd-wallet/go.mod
+++ b/pkg/arkd-wallet/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/pkg/arkd-wallet
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/pkg/client-lib/go.mod
+++ b/pkg/client-lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/pkg/client-lib
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/arkade-os/arkd/api-spec => ../../api-spec
 

--- a/pkg/errors/go.mod
+++ b/pkg/errors/go.mod
@@ -2,7 +2,7 @@ module github.com/arkade-os/arkd/pkg/errors
 
 replace github.com/arkade-os/arkd/pkg/ark-lib => ../ark-lib
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-00010101000000-000000000000
@@ -21,5 +21,4 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 )

--- a/pkg/kvdb/go.mod
+++ b/pkg/kvdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/pkg/kvdb
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/btcsuite/btcwallet/walletdb v1.4.2

--- a/pkg/macaroons/go.mod
+++ b/pkg/macaroons/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/arkd/pkg/macaroons
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain from version 1.25.7 to 1.26.0 across CI/CD workflows, Docker build environments, and all module configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->