### PR TITLE
[client-lib] Fix returned value of batch expiry

### DIFF
--- a/pkg/client-lib/batch_session_handler.go
+++ b/pkg/client-lib/batch_session_handler.go
@@ -412,7 +412,7 @@ func (h *defaultBatchEventsHandler) OnBatchStarted(
 			h.batchExpiry = getBatchExpiryLocktime(uint32(event.BatchExpiry))
 			expiry := time.Duration(event.BatchExpiry) * time.Second
 			if h.batchExpiry.Type == arklib.LocktimeTypeBlock {
-				expiry = time.Duration(event.BatchExpiry) * arklib.SECONDS_PER_BLOCK
+				expiry = time.Duration(event.BatchExpiry*arklib.SECONDS_PER_BLOCK) * time.Second
 			}
 			return false, expiry, nil
 		}


### PR DESCRIPTION
Fixes the returned value of batch expiration in `OnBatchStarted` impl of the default handler used by the client.

Please @louisinger @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected batch session expiry calculation so block-based locktime values are converted to seconds, while seconds-based expiry values remain unchanged—ensuring accurate timeouts and consistent session behavior across expiry configuration types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->