### PR TITLE
trivy-action commit 57a97c7e7821a5776cebc9bb87c984fa69cba8f1

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -25,7 +25,7 @@ jobs:
           tags: ${{ github.repository }}:${{ github.sha }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         env:
           # avoid GHCR rate limits, see https://github.com/aquasecurity/trivy-db/pull/440 and https://github.com/aquasecurity/trivy-action/issues/389
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2


### PR DESCRIPTION
incident: https://github.com/aquasecurity/trivy/discussions/10425
proposed fix is to use git commit hash instead of tag to prevent tag supply chain attack.

@chris-ricketts @altafan @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to pin the Trivy vulnerability scanner to a specific version for improved reliability and supply chain security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->