### PR TITLE
[Client-lib] Apply expiry threshold filter only to batch session methods

### DIFF
--- a/pkg/client-lib/batch_session.go
+++ b/pkg/client-lib/batch_session.go
@@ -274,6 +274,10 @@ func (a *service) getFundsToSettle(
 		}
 	}
 
+	if opts.expiryThreshold > 0 {
+		vtxos = utils.FilterVtxosByExpiry(vtxos, opts.expiryThreshold)
+	}
+
 	boardingUtxos := opts.utxos
 	if len(opts.vtxos) <= 0 && len(opts.utxos) <= 0 {
 		boardingUtxos, err = a.getClaimableBoardingUtxos(ctx, boardingAddrs, nil)

--- a/pkg/client-lib/internal/utils/utils.go
+++ b/pkg/client-lib/internal/utils/utils.go
@@ -416,11 +416,13 @@ func ListenToJSONStream(url string, chunkCh chan ChunkJSONStream) {
 	}
 }
 
-func FilterVtxosByExpiry(vtxos []types.Vtxo, expiryThreshold int64) []types.Vtxo {
+func FilterVtxosByExpiry(
+	vtxos []types.VtxoWithTapTree, expiryThreshold int64,
+) []types.VtxoWithTapTree {
 	now := time.Now()
 	threshold := time.Duration(expiryThreshold) * time.Second
 
-	nearExpiry := make([]types.Vtxo, 0, len(vtxos))
+	nearExpiry := make([]types.VtxoWithTapTree, 0, len(vtxos))
 	for _, vtxo := range vtxos {
 		// time until expiry
 		timeLeft := vtxo.ExpiresAt.Sub(now)

--- a/pkg/client-lib/internal/utils/utils_test.go
+++ b/pkg/client-lib/internal/utils/utils_test.go
@@ -1,0 +1,73 @@
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
+	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterVtxosByExpiry(t *testing.T) {
+	now := time.Now()
+
+	const threshold int64 = 3 * 24 * 60 * 60 // 3 days in seconds
+
+	vtxoExpiring1Day := types.VtxoWithTapTree{
+		Vtxo: types.Vtxo{ExpiresAt: now.Add(24 * time.Hour)},
+	}
+	vtxoExpiring3Days := types.VtxoWithTapTree{
+		Vtxo: types.Vtxo{ExpiresAt: now.Add(time.Duration(threshold) * time.Second)},
+	}
+	vtxoExpiring5Days := types.VtxoWithTapTree{
+		Vtxo: types.Vtxo{ExpiresAt: now.Add(5 * 24 * time.Hour)},
+	}
+	vtxoAlreadyExpired := types.VtxoWithTapTree{
+		Vtxo: types.Vtxo{ExpiresAt: now.Add(-1 * time.Hour)},
+	}
+
+	testCases := []struct {
+		name     string
+		vtxos    []types.VtxoWithTapTree
+		expected []types.VtxoWithTapTree
+	}{
+		{
+			name:     "vtxo expiring within threshold is kept",
+			vtxos:    []types.VtxoWithTapTree{vtxoExpiring1Day},
+			expected: []types.VtxoWithTapTree{vtxoExpiring1Day},
+		},
+		{
+			name:     "vtxo expiring at exactly threshold boundary is kept",
+			vtxos:    []types.VtxoWithTapTree{vtxoExpiring3Days},
+			expected: []types.VtxoWithTapTree{vtxoExpiring3Days},
+		},
+		{
+			name:     "vtxo expiring beyond threshold is excluded",
+			vtxos:    []types.VtxoWithTapTree{vtxoExpiring5Days},
+			expected: []types.VtxoWithTapTree{},
+		},
+		{
+			name:     "already expired vtxo is kept",
+			vtxos:    []types.VtxoWithTapTree{vtxoAlreadyExpired},
+			expected: []types.VtxoWithTapTree{vtxoAlreadyExpired},
+		},
+		{
+			name:     "mixed vtxos: only within-threshold ones are kept",
+			vtxos:    []types.VtxoWithTapTree{vtxoExpiring1Day, vtxoExpiring5Days, vtxoAlreadyExpired},
+			expected: []types.VtxoWithTapTree{vtxoExpiring1Day, vtxoAlreadyExpired},
+		},
+		{
+			name:     "empty input returns empty result",
+			vtxos:    []types.VtxoWithTapTree{},
+			expected: []types.VtxoWithTapTree{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := utils.FilterVtxosByExpiry(tc.vtxos, threshold)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/client-lib/service.go
+++ b/pkg/client-lib/service.go
@@ -395,10 +395,6 @@ func (a *service) getSpendableVtxos(
 		}
 	}
 
-	if opts != nil && opts.expiryThreshold > 0 {
-		allVtxos = utils.FilterVtxosByExpiry(allVtxos, opts.expiryThreshold)
-	}
-
 	if opts == nil || !opts.withoutExpirySorting {
 		allVtxos = utils.SortVtxosByExpiry(allVtxos)
 	}


### PR DESCRIPTION
Please @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized virtual transaction output expiry filtering to occur during settlement operations, improving efficiency when managing time-sensitive outputs.
* **Tests**
  * Added comprehensive unit tests validating expiry threshold filtering behavior across various scenarios including boundary conditions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->