### PR TITLE
admin endpoint for listing and revoking tokens

### DIFF
--- a/api-spec/openapi/swagger/ark/v1/admin.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/admin.openapi.json
@@ -904,44 +904,21 @@
       }
     },
     "/v1/admin/tokens": {
-      "get": {
+      "post": {
         "tags": [
           "AdminService"
         ],
         "operationId": "AdminService_ListTokens",
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "description": "base64 auth token",
-            "schema": {
-              "type": "string"
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListTokensRequest"
+              }
             }
           },
-          {
-            "name": "hash",
-            "in": "query",
-            "description": "hex-encoded hash of outpoints",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "outpoint",
-            "in": "query",
-            "description": "txid:vout format",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "txid",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "a successful response.",

--- a/api-spec/openapi/swagger/ark/v1/admin.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/admin.openapi.json
@@ -902,6 +902,109 @@
           }
         }
       }
+    },
+    "/v1/admin/tokens": {
+      "get": {
+        "tags": [
+          "AdminService"
+        ],
+        "operationId": "AdminService_ListTokens",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "description": "base64 auth token",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "hash",
+            "in": "query",
+            "description": "hex-encoded hash of outpoints",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "outpoint",
+            "in": "query",
+            "description": "txid:vout format",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "txid",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTokensResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/tokens/revoke": {
+      "post": {
+        "tags": [
+          "AdminService"
+        ],
+        "operationId": "AdminService_RevokeTokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RevokeTokensRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "a successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeTokensResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1464,6 +1567,39 @@
           }
         }
       },
+      "ListTokensRequest": {
+        "title": "ListTokensRequest",
+        "type": "object",
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "hex-encoded hash of outpoints"
+          },
+          "outpoint": {
+            "type": "string",
+            "description": "txid:vout format"
+          },
+          "token": {
+            "type": "string",
+            "description": "base64 auth token"
+          },
+          "txid": {
+            "type": "string"
+          }
+        }
+      },
+      "ListTokensResponse": {
+        "title": "ListTokensResponse",
+        "type": "object",
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TokenInfo"
+            }
+          }
+        }
+      },
       "Output": {
         "title": "Output",
         "type": "object",
@@ -1509,6 +1645,37 @@
         "properties": {
           "token": {
             "type": "string"
+          }
+        }
+      },
+      "RevokeTokensRequest": {
+        "title": "RevokeTokensRequest",
+        "type": "object",
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "hex-encoded hash of outpoints"
+          },
+          "outpoint": {
+            "type": "string",
+            "description": "txid:vout format"
+          },
+          "token": {
+            "type": "string",
+            "description": "base64 auth token"
+          },
+          "txid": {
+            "type": "string"
+          }
+        }
+      },
+      "RevokeTokensResponse": {
+        "title": "RevokeTokensResponse",
+        "type": "object",
+        "properties": {
+          "revokedCount": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -1626,6 +1793,27 @@
           "vout": {
             "type": "integer",
             "format": "uint32"
+          }
+        }
+      },
+      "TokenInfo": {
+        "title": "TokenInfo",
+        "type": "object",
+        "properties": {
+          "expiresAt": {
+            "type": "integer",
+            "description": "unix timestamp",
+            "format": "int64"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "outpoints": {
+            "type": "array",
+            "description": "txid:vout format",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -112,7 +112,8 @@ service AdminService {
   }
   rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
     option (meshapi.gateway.http) = {
-      get: "/v1/admin/tokens"
+      post: "/v1/admin/tokens"
+      body: "*"
     };
   }
   rpc RevokeTokens(RevokeTokensRequest) returns (RevokeTokensResponse) {

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -110,6 +110,17 @@ service AdminService {
       body: "*"
     };
   }
+  rpc ListTokens(ListTokensRequest) returns (ListTokensResponse) {
+    option (meshapi.gateway.http) = {
+      get: "/v1/admin/tokens"
+    };
+  }
+  rpc RevokeTokens(RevokeTokensRequest) returns (RevokeTokensResponse) {
+    option (meshapi.gateway.http) = {
+      post: "/v1/admin/tokens/revoke"
+      body: "*"
+    };
+  }
   rpc GetExpiringLiquidity(GetExpiringLiquidityRequest) returns (GetExpiringLiquidityResponse) {
     option (meshapi.gateway.http) = {
       get: "/v1/admin/liquidity/expiring"
@@ -359,4 +370,30 @@ message SweepRequest {
 message SweepResponse {
   string txid = 1;
   string hex = 2;
+}
+
+message ListTokensRequest {
+  string token = 1;    // base64 auth token
+  string hash = 2;     // hex-encoded hash of outpoints
+  string outpoint = 3; // txid:vout format
+  string txid = 4;
+}
+message ListTokensResponse {
+  repeated TokenInfo tokens = 1;
+}
+
+message TokenInfo {
+  string hash = 1;
+  repeated string outpoints = 2; // txid:vout format
+  int64 expires_at = 3;         // unix timestamp
+}
+
+message RevokeTokensRequest {
+  string token = 1;    // base64 auth token
+  string hash = 2;     // hex-encoded hash of outpoints
+  string outpoint = 3; // txid:vout format
+  string txid = 4;
+}
+message RevokeTokensResponse {
+  int32 revoked_count = 1;
 }

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -373,10 +373,12 @@ message SweepResponse {
 }
 
 message ListTokensRequest {
-  string token = 1;    // base64 auth token
-  string hash = 2;     // hex-encoded hash of outpoints
-  string outpoint = 3; // txid:vout format
-  string txid = 4;
+  oneof filter {
+    string token = 1;    // base64 auth token
+    string hash = 2;     // hex-encoded hash of outpoints
+    string outpoint = 3; // txid:vout format
+    string txid = 4;
+  }
 }
 message ListTokensResponse {
   repeated TokenInfo tokens = 1;
@@ -389,10 +391,12 @@ message TokenInfo {
 }
 
 message RevokeTokensRequest {
-  string token = 1;    // base64 auth token
-  string hash = 2;     // hex-encoded hash of outpoints
-  string outpoint = 3; // txid:vout format
-  string txid = 4;
+  oneof filter {
+    string token = 1;    // base64 auth token
+    string hash = 2;     // hex-encoded hash of outpoints
+    string outpoint = 3; // txid:vout format
+    string txid = 4;
+  }
 }
 message RevokeTokensResponse {
   int32 revoked_count = 1;

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -373,12 +373,10 @@ message SweepResponse {
 }
 
 message ListTokensRequest {
-  oneof filter {
-    string token = 1;    // base64 auth token
-    string hash = 2;     // hex-encoded hash of outpoints
-    string outpoint = 3; // txid:vout format
-    string txid = 4;
-  }
+  string token = 1;    // base64 auth token
+  string hash = 2;     // hex-encoded hash of outpoints
+  string outpoint = 3; // txid:vout format
+  string txid = 4;
 }
 message ListTokensResponse {
   repeated TokenInfo tokens = 1;
@@ -391,12 +389,10 @@ message TokenInfo {
 }
 
 message RevokeTokensRequest {
-  oneof filter {
-    string token = 1;    // base64 auth token
-    string hash = 2;     // hex-encoded hash of outpoints
-    string outpoint = 3; // txid:vout format
-    string txid = 4;
-  }
+  string token = 1;    // base64 auth token
+  string hash = 2;     // hex-encoded hash of outpoints
+  string outpoint = 3; // txid:vout format
+  string txid = 4;
 }
 message RevokeTokensResponse {
   int32 revoked_count = 1;

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -3241,7 +3241,7 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x15CRIME_TYPE_MANUAL_BAN\x10\a*M\n" +
 	"\x0eConvictionType\x12\x1f\n" +
 	"\x1bCONVICTION_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\xd8\x16\n" +
+	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\xdb\x16\n" +
 	"\fAdminService\x12o\n" +
 	"\x11GetScheduledSweep\x12 .ark.v1.GetScheduledSweepRequest\x1a!.ark.v1.GetScheduledSweepResponse\"\x15\xb2J\x12\x12\x10/v1/admin/sweeps\x12s\n" +
 	"\x0fGetRoundDetails\x12\x1e.ark.v1.GetRoundDetailsRequest\x1a\x1f.ark.v1.GetRoundDetailsResponse\"\x1f\xb2J\x1c\x12\x1a/v1/admin/round/{round_id}\x12W\n" +
@@ -3263,9 +3263,9 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10PardonConviction\x12\x1f.ark.v1.PardonConvictionRequest\x1a .ark.v1.PardonConvictionResponse\")\xb2J&B\x01*\"!/v1/admin/convictions/{id}/pardon\x12b\n" +
 	"\tBanScript\x12\x18.ark.v1.BanScriptRequest\x1a\x19.ark.v1.BanScriptResponse\" \xb2J\x1dB\x01*\"\x18/v1/admin/conviction/ban\x12b\n" +
 	"\n" +
-	"RevokeAuth\x12\x19.ark.v1.RevokeAuthRequest\x1a\x1a.ark.v1.RevokeAuthResponse\"\x1d\xb2J\x1aB\x01*\"\x15/v1/admin/auth/revoke\x12Z\n" +
+	"RevokeAuth\x12\x19.ark.v1.RevokeAuthRequest\x1a\x1a.ark.v1.RevokeAuthResponse\"\x1d\xb2J\x1aB\x01*\"\x15/v1/admin/auth/revoke\x12]\n" +
 	"\n" +
-	"ListTokens\x12\x19.ark.v1.ListTokensRequest\x1a\x1a.ark.v1.ListTokensResponse\"\x15\xb2J\x12\x12\x10/v1/admin/tokens\x12j\n" +
+	"ListTokens\x12\x19.ark.v1.ListTokensRequest\x1a\x1a.ark.v1.ListTokensResponse\"\x18\xb2J\x15B\x01*\"\x10/v1/admin/tokens\x12j\n" +
 	"\fRevokeTokens\x12\x1b.ark.v1.RevokeTokensRequest\x1a\x1c.ark.v1.RevokeTokensResponse\"\x1f\xb2J\x1cB\x01*\"\x17/v1/admin/tokens/revoke\x12\x84\x01\n" +
 	"\x14GetExpiringLiquidity\x12#.ark.v1.GetExpiringLiquidityRequest\x1a$.ark.v1.GetExpiringLiquidityResponse\"!\xb2J\x1e\x12\x1c/v1/admin/liquidity/expiring\x12\x90\x01\n" +
 	"\x17GetRecoverableLiquidity\x12&.ark.v1.GetRecoverableLiquidityRequest\x1a'.ark.v1.GetRecoverableLiquidityResponse\"$\xb2J!\x12\x1f/v1/admin/liquidity/recoverable\x12M\n" +

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -2762,6 +2762,290 @@ func (x *SweepResponse) GetHex() string {
 	return ""
 }
 
+type ListTokensRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
+	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
+	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTokensRequest) Reset() {
+	*x = ListTokensRequest{}
+	mi := &file_ark_v1_admin_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTokensRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTokensRequest) ProtoMessage() {}
+
+func (x *ListTokensRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTokensRequest.ProtoReflect.Descriptor instead.
+func (*ListTokensRequest) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *ListTokensRequest) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *ListTokensRequest) GetHash() string {
+	if x != nil {
+		return x.Hash
+	}
+	return ""
+}
+
+func (x *ListTokensRequest) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *ListTokensRequest) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+type ListTokensResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Tokens        []*TokenInfo           `protobuf:"bytes,1,rep,name=tokens,proto3" json:"tokens,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListTokensResponse) Reset() {
+	*x = ListTokensResponse{}
+	mi := &file_ark_v1_admin_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListTokensResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListTokensResponse) ProtoMessage() {}
+
+func (x *ListTokensResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListTokensResponse.ProtoReflect.Descriptor instead.
+func (*ListTokensResponse) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *ListTokensResponse) GetTokens() []*TokenInfo {
+	if x != nil {
+		return x.Tokens
+	}
+	return nil
+}
+
+type TokenInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Hash          string                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
+	Outpoints     []string               `protobuf:"bytes,2,rep,name=outpoints,proto3" json:"outpoints,omitempty"`                   // txid:vout format
+	ExpiresAt     int64                  `protobuf:"varint,3,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"` // unix timestamp
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TokenInfo) Reset() {
+	*x = TokenInfo{}
+	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TokenInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TokenInfo) ProtoMessage() {}
+
+func (x *TokenInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TokenInfo.ProtoReflect.Descriptor instead.
+func (*TokenInfo) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *TokenInfo) GetHash() string {
+	if x != nil {
+		return x.Hash
+	}
+	return ""
+}
+
+func (x *TokenInfo) GetOutpoints() []string {
+	if x != nil {
+		return x.Outpoints
+	}
+	return nil
+}
+
+func (x *TokenInfo) GetExpiresAt() int64 {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return 0
+}
+
+type RevokeTokensRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
+	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
+	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeTokensRequest) Reset() {
+	*x = RevokeTokensRequest{}
+	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeTokensRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeTokensRequest) ProtoMessage() {}
+
+func (x *RevokeTokensRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeTokensRequest.ProtoReflect.Descriptor instead.
+func (*RevokeTokensRequest) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *RevokeTokensRequest) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *RevokeTokensRequest) GetHash() string {
+	if x != nil {
+		return x.Hash
+	}
+	return ""
+}
+
+func (x *RevokeTokensRequest) GetOutpoint() string {
+	if x != nil {
+		return x.Outpoint
+	}
+	return ""
+}
+
+func (x *RevokeTokensRequest) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+type RevokeTokensResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RevokedCount  int32                  `protobuf:"varint,1,opt,name=revoked_count,json=revokedCount,proto3" json:"revoked_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RevokeTokensResponse) Reset() {
+	*x = RevokeTokensResponse{}
+	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RevokeTokensResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RevokeTokensResponse) ProtoMessage() {}
+
+func (x *RevokeTokensResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RevokeTokensResponse.ProtoReflect.Descriptor instead.
+func (*RevokeTokensResponse) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *RevokeTokensResponse) GetRevokedCount() int32 {
+	if x != nil {
+		return x.RevokedCount
+	}
+	return 0
+}
+
 var File_ark_v1_admin_proto protoreflect.FileDescriptor
 
 const file_ark_v1_admin_proto_rawDesc = "" +
@@ -2926,7 +3210,26 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10commitment_txids\x18\x02 \x03(\tR\x0fcommitmentTxids\"5\n" +
 	"\rSweepResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x10\n" +
-	"\x03hex\x18\x02 \x01(\tR\x03hex*\xb6\x02\n" +
+	"\x03hex\x18\x02 \x01(\tR\x03hex\"m\n" +
+	"\x11ListTokensRequest\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
+	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
+	"\x04txid\x18\x04 \x01(\tR\x04txid\"?\n" +
+	"\x12ListTokensResponse\x12)\n" +
+	"\x06tokens\x18\x01 \x03(\v2\x11.ark.v1.TokenInfoR\x06tokens\"\\\n" +
+	"\tTokenInfo\x12\x12\n" +
+	"\x04hash\x18\x01 \x01(\tR\x04hash\x12\x1c\n" +
+	"\toutpoints\x18\x02 \x03(\tR\toutpoints\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x03 \x01(\x03R\texpiresAt\"o\n" +
+	"\x13RevokeTokensRequest\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
+	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
+	"\x04txid\x18\x04 \x01(\tR\x04txid\";\n" +
+	"\x14RevokeTokensResponse\x12#\n" +
+	"\rrevoked_count\x18\x01 \x01(\x05R\frevokedCount*\xb6\x02\n" +
 	"\tCrimeType\x12\x1a\n" +
 	"\x16CRIME_TYPE_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"CRIME_TYPE_MUSIG2_NONCE_SUBMISSION\x10\x01\x12*\n" +
@@ -2938,7 +3241,7 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x15CRIME_TYPE_MANUAL_BAN\x10\a*M\n" +
 	"\x0eConvictionType\x12\x1f\n" +
 	"\x1bCONVICTION_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\x90\x15\n" +
+	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\xd8\x16\n" +
 	"\fAdminService\x12o\n" +
 	"\x11GetScheduledSweep\x12 .ark.v1.GetScheduledSweepRequest\x1a!.ark.v1.GetScheduledSweepResponse\"\x15\xb2J\x12\x12\x10/v1/admin/sweeps\x12s\n" +
 	"\x0fGetRoundDetails\x12\x1e.ark.v1.GetRoundDetailsRequest\x1a\x1f.ark.v1.GetRoundDetailsResponse\"\x1f\xb2J\x1c\x12\x1a/v1/admin/round/{round_id}\x12W\n" +
@@ -2960,7 +3263,10 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10PardonConviction\x12\x1f.ark.v1.PardonConvictionRequest\x1a .ark.v1.PardonConvictionResponse\")\xb2J&B\x01*\"!/v1/admin/convictions/{id}/pardon\x12b\n" +
 	"\tBanScript\x12\x18.ark.v1.BanScriptRequest\x1a\x19.ark.v1.BanScriptResponse\" \xb2J\x1dB\x01*\"\x18/v1/admin/conviction/ban\x12b\n" +
 	"\n" +
-	"RevokeAuth\x12\x19.ark.v1.RevokeAuthRequest\x1a\x1a.ark.v1.RevokeAuthResponse\"\x1d\xb2J\x1aB\x01*\"\x15/v1/admin/auth/revoke\x12\x84\x01\n" +
+	"RevokeAuth\x12\x19.ark.v1.RevokeAuthRequest\x1a\x1a.ark.v1.RevokeAuthResponse\"\x1d\xb2J\x1aB\x01*\"\x15/v1/admin/auth/revoke\x12Z\n" +
+	"\n" +
+	"ListTokens\x12\x19.ark.v1.ListTokensRequest\x1a\x1a.ark.v1.ListTokensResponse\"\x15\xb2J\x12\x12\x10/v1/admin/tokens\x12j\n" +
+	"\fRevokeTokens\x12\x1b.ark.v1.RevokeTokensRequest\x1a\x1c.ark.v1.RevokeTokensResponse\"\x1f\xb2J\x1cB\x01*\"\x17/v1/admin/tokens/revoke\x12\x84\x01\n" +
 	"\x14GetExpiringLiquidity\x12#.ark.v1.GetExpiringLiquidityRequest\x1a$.ark.v1.GetExpiringLiquidityResponse\"!\xb2J\x1e\x12\x1c/v1/admin/liquidity/expiring\x12\x90\x01\n" +
 	"\x17GetRecoverableLiquidity\x12&.ark.v1.GetRecoverableLiquidityRequest\x1a'.ark.v1.GetRecoverableLiquidityResponse\"$\xb2J!\x12\x1f/v1/admin/liquidity/recoverable\x12M\n" +
 	"\x05Sweep\x12\x14.ark.v1.SweepRequest\x1a\x15.ark.v1.SweepResponse\"\x17\xb2J\x14B\x01*\"\x0f/v1/admin/sweepBy\n" +
@@ -2981,7 +3287,7 @@ func file_ark_v1_admin_proto_rawDescGZIP() []byte {
 }
 
 var file_ark_v1_admin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_ark_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_ark_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_ark_v1_admin_proto_goTypes = []any{
 	(CrimeType)(0),                               // 0: ark.v1.CrimeType
 	(ConvictionType)(0),                          // 1: ark.v1.ConvictionType
@@ -3037,8 +3343,13 @@ var file_ark_v1_admin_proto_goTypes = []any{
 	(*GetRecoverableLiquidityResponse)(nil),      // 51: ark.v1.GetRecoverableLiquidityResponse
 	(*SweepRequest)(nil),                         // 52: ark.v1.SweepRequest
 	(*SweepResponse)(nil),                        // 53: ark.v1.SweepResponse
-	(*FeeInfo)(nil),                              // 54: ark.v1.FeeInfo
-	(*Intent)(nil),                               // 55: ark.v1.Intent
+	(*ListTokensRequest)(nil),                    // 54: ark.v1.ListTokensRequest
+	(*ListTokensResponse)(nil),                   // 55: ark.v1.ListTokensResponse
+	(*TokenInfo)(nil),                            // 56: ark.v1.TokenInfo
+	(*RevokeTokensRequest)(nil),                  // 57: ark.v1.RevokeTokensRequest
+	(*RevokeTokensResponse)(nil),                 // 58: ark.v1.RevokeTokensResponse
+	(*FeeInfo)(nil),                              // 59: ark.v1.FeeInfo
+	(*Intent)(nil),                               // 60: ark.v1.Intent
 }
 var file_ark_v1_admin_proto_depIdxs = []int32{
 	41, // 0: ark.v1.GetScheduledSweepResponse.sweeps:type_name -> ark.v1.ScheduledSweep
@@ -3052,62 +3363,67 @@ var file_ark_v1_admin_proto_depIdxs = []int32{
 	47, // 8: ark.v1.GetConvictionsByRoundResponse.convictions:type_name -> ark.v1.Conviction
 	47, // 9: ark.v1.GetActiveScriptConvictionsResponse.convictions:type_name -> ark.v1.Conviction
 	40, // 10: ark.v1.ScheduledSweep.outputs:type_name -> ark.v1.SweepableOutput
-	54, // 11: ark.v1.ScheduledSessionConfig.fees:type_name -> ark.v1.FeeInfo
+	59, // 11: ark.v1.ScheduledSessionConfig.fees:type_name -> ark.v1.FeeInfo
 	46, // 12: ark.v1.IntentInfo.receivers:type_name -> ark.v1.Output
 	43, // 13: ark.v1.IntentInfo.inputs:type_name -> ark.v1.IntentInput
 	43, // 14: ark.v1.IntentInfo.boarding_inputs:type_name -> ark.v1.IntentInput
-	55, // 15: ark.v1.IntentInfo.intent:type_name -> ark.v1.Intent
+	60, // 15: ark.v1.IntentInfo.intent:type_name -> ark.v1.Intent
 	1,  // 16: ark.v1.Conviction.type:type_name -> ark.v1.ConvictionType
 	0,  // 17: ark.v1.Conviction.crime_type:type_name -> ark.v1.CrimeType
-	2,  // 18: ark.v1.AdminService.GetScheduledSweep:input_type -> ark.v1.GetScheduledSweepRequest
-	4,  // 19: ark.v1.AdminService.GetRoundDetails:input_type -> ark.v1.GetRoundDetailsRequest
-	6,  // 20: ark.v1.AdminService.GetRounds:input_type -> ark.v1.GetRoundsRequest
-	8,  // 21: ark.v1.AdminService.CreateNote:input_type -> ark.v1.CreateNoteRequest
-	10, // 22: ark.v1.AdminService.GetScheduledSessionConfig:input_type -> ark.v1.GetScheduledSessionConfigRequest
-	12, // 23: ark.v1.AdminService.UpdateScheduledSessionConfig:input_type -> ark.v1.UpdateScheduledSessionConfigRequest
-	14, // 24: ark.v1.AdminService.ClearScheduledSessionConfig:input_type -> ark.v1.ClearScheduledSessionConfigRequest
-	16, // 25: ark.v1.AdminService.ListIntents:input_type -> ark.v1.ListIntentsRequest
-	18, // 26: ark.v1.AdminService.DeleteIntents:input_type -> ark.v1.DeleteIntentsRequest
-	20, // 27: ark.v1.AdminService.GetIntentFees:input_type -> ark.v1.GetIntentFeesRequest
-	22, // 28: ark.v1.AdminService.UpdateIntentFees:input_type -> ark.v1.UpdateIntentFeesRequest
-	24, // 29: ark.v1.AdminService.ClearIntentFees:input_type -> ark.v1.ClearIntentFeesRequest
-	26, // 30: ark.v1.AdminService.GetConvictions:input_type -> ark.v1.GetConvictionsRequest
-	28, // 31: ark.v1.AdminService.GetConvictionsInRange:input_type -> ark.v1.GetConvictionsInRangeRequest
-	30, // 32: ark.v1.AdminService.GetConvictionsByRound:input_type -> ark.v1.GetConvictionsByRoundRequest
-	32, // 33: ark.v1.AdminService.GetActiveScriptConvictions:input_type -> ark.v1.GetActiveScriptConvictionsRequest
-	34, // 34: ark.v1.AdminService.PardonConviction:input_type -> ark.v1.PardonConvictionRequest
-	36, // 35: ark.v1.AdminService.BanScript:input_type -> ark.v1.BanScriptRequest
-	38, // 36: ark.v1.AdminService.RevokeAuth:input_type -> ark.v1.RevokeAuthRequest
-	48, // 37: ark.v1.AdminService.GetExpiringLiquidity:input_type -> ark.v1.GetExpiringLiquidityRequest
-	50, // 38: ark.v1.AdminService.GetRecoverableLiquidity:input_type -> ark.v1.GetRecoverableLiquidityRequest
-	52, // 39: ark.v1.AdminService.Sweep:input_type -> ark.v1.SweepRequest
-	3,  // 40: ark.v1.AdminService.GetScheduledSweep:output_type -> ark.v1.GetScheduledSweepResponse
-	5,  // 41: ark.v1.AdminService.GetRoundDetails:output_type -> ark.v1.GetRoundDetailsResponse
-	7,  // 42: ark.v1.AdminService.GetRounds:output_type -> ark.v1.GetRoundsResponse
-	9,  // 43: ark.v1.AdminService.CreateNote:output_type -> ark.v1.CreateNoteResponse
-	11, // 44: ark.v1.AdminService.GetScheduledSessionConfig:output_type -> ark.v1.GetScheduledSessionConfigResponse
-	13, // 45: ark.v1.AdminService.UpdateScheduledSessionConfig:output_type -> ark.v1.UpdateScheduledSessionConfigResponse
-	15, // 46: ark.v1.AdminService.ClearScheduledSessionConfig:output_type -> ark.v1.ClearScheduledSessionConfigResponse
-	17, // 47: ark.v1.AdminService.ListIntents:output_type -> ark.v1.ListIntentsResponse
-	19, // 48: ark.v1.AdminService.DeleteIntents:output_type -> ark.v1.DeleteIntentsResponse
-	21, // 49: ark.v1.AdminService.GetIntentFees:output_type -> ark.v1.GetIntentFeesResponse
-	23, // 50: ark.v1.AdminService.UpdateIntentFees:output_type -> ark.v1.UpdateIntentFeesResponse
-	25, // 51: ark.v1.AdminService.ClearIntentFees:output_type -> ark.v1.ClearIntentFeesResponse
-	27, // 52: ark.v1.AdminService.GetConvictions:output_type -> ark.v1.GetConvictionsResponse
-	29, // 53: ark.v1.AdminService.GetConvictionsInRange:output_type -> ark.v1.GetConvictionsInRangeResponse
-	31, // 54: ark.v1.AdminService.GetConvictionsByRound:output_type -> ark.v1.GetConvictionsByRoundResponse
-	33, // 55: ark.v1.AdminService.GetActiveScriptConvictions:output_type -> ark.v1.GetActiveScriptConvictionsResponse
-	35, // 56: ark.v1.AdminService.PardonConviction:output_type -> ark.v1.PardonConvictionResponse
-	37, // 57: ark.v1.AdminService.BanScript:output_type -> ark.v1.BanScriptResponse
-	39, // 58: ark.v1.AdminService.RevokeAuth:output_type -> ark.v1.RevokeAuthResponse
-	49, // 59: ark.v1.AdminService.GetExpiringLiquidity:output_type -> ark.v1.GetExpiringLiquidityResponse
-	51, // 60: ark.v1.AdminService.GetRecoverableLiquidity:output_type -> ark.v1.GetRecoverableLiquidityResponse
-	53, // 61: ark.v1.AdminService.Sweep:output_type -> ark.v1.SweepResponse
-	40, // [40:62] is the sub-list for method output_type
-	18, // [18:40] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	56, // 18: ark.v1.ListTokensResponse.tokens:type_name -> ark.v1.TokenInfo
+	2,  // 19: ark.v1.AdminService.GetScheduledSweep:input_type -> ark.v1.GetScheduledSweepRequest
+	4,  // 20: ark.v1.AdminService.GetRoundDetails:input_type -> ark.v1.GetRoundDetailsRequest
+	6,  // 21: ark.v1.AdminService.GetRounds:input_type -> ark.v1.GetRoundsRequest
+	8,  // 22: ark.v1.AdminService.CreateNote:input_type -> ark.v1.CreateNoteRequest
+	10, // 23: ark.v1.AdminService.GetScheduledSessionConfig:input_type -> ark.v1.GetScheduledSessionConfigRequest
+	12, // 24: ark.v1.AdminService.UpdateScheduledSessionConfig:input_type -> ark.v1.UpdateScheduledSessionConfigRequest
+	14, // 25: ark.v1.AdminService.ClearScheduledSessionConfig:input_type -> ark.v1.ClearScheduledSessionConfigRequest
+	16, // 26: ark.v1.AdminService.ListIntents:input_type -> ark.v1.ListIntentsRequest
+	18, // 27: ark.v1.AdminService.DeleteIntents:input_type -> ark.v1.DeleteIntentsRequest
+	20, // 28: ark.v1.AdminService.GetIntentFees:input_type -> ark.v1.GetIntentFeesRequest
+	22, // 29: ark.v1.AdminService.UpdateIntentFees:input_type -> ark.v1.UpdateIntentFeesRequest
+	24, // 30: ark.v1.AdminService.ClearIntentFees:input_type -> ark.v1.ClearIntentFeesRequest
+	26, // 31: ark.v1.AdminService.GetConvictions:input_type -> ark.v1.GetConvictionsRequest
+	28, // 32: ark.v1.AdminService.GetConvictionsInRange:input_type -> ark.v1.GetConvictionsInRangeRequest
+	30, // 33: ark.v1.AdminService.GetConvictionsByRound:input_type -> ark.v1.GetConvictionsByRoundRequest
+	32, // 34: ark.v1.AdminService.GetActiveScriptConvictions:input_type -> ark.v1.GetActiveScriptConvictionsRequest
+	34, // 35: ark.v1.AdminService.PardonConviction:input_type -> ark.v1.PardonConvictionRequest
+	36, // 36: ark.v1.AdminService.BanScript:input_type -> ark.v1.BanScriptRequest
+	38, // 37: ark.v1.AdminService.RevokeAuth:input_type -> ark.v1.RevokeAuthRequest
+	54, // 38: ark.v1.AdminService.ListTokens:input_type -> ark.v1.ListTokensRequest
+	57, // 39: ark.v1.AdminService.RevokeTokens:input_type -> ark.v1.RevokeTokensRequest
+	48, // 40: ark.v1.AdminService.GetExpiringLiquidity:input_type -> ark.v1.GetExpiringLiquidityRequest
+	50, // 41: ark.v1.AdminService.GetRecoverableLiquidity:input_type -> ark.v1.GetRecoverableLiquidityRequest
+	52, // 42: ark.v1.AdminService.Sweep:input_type -> ark.v1.SweepRequest
+	3,  // 43: ark.v1.AdminService.GetScheduledSweep:output_type -> ark.v1.GetScheduledSweepResponse
+	5,  // 44: ark.v1.AdminService.GetRoundDetails:output_type -> ark.v1.GetRoundDetailsResponse
+	7,  // 45: ark.v1.AdminService.GetRounds:output_type -> ark.v1.GetRoundsResponse
+	9,  // 46: ark.v1.AdminService.CreateNote:output_type -> ark.v1.CreateNoteResponse
+	11, // 47: ark.v1.AdminService.GetScheduledSessionConfig:output_type -> ark.v1.GetScheduledSessionConfigResponse
+	13, // 48: ark.v1.AdminService.UpdateScheduledSessionConfig:output_type -> ark.v1.UpdateScheduledSessionConfigResponse
+	15, // 49: ark.v1.AdminService.ClearScheduledSessionConfig:output_type -> ark.v1.ClearScheduledSessionConfigResponse
+	17, // 50: ark.v1.AdminService.ListIntents:output_type -> ark.v1.ListIntentsResponse
+	19, // 51: ark.v1.AdminService.DeleteIntents:output_type -> ark.v1.DeleteIntentsResponse
+	21, // 52: ark.v1.AdminService.GetIntentFees:output_type -> ark.v1.GetIntentFeesResponse
+	23, // 53: ark.v1.AdminService.UpdateIntentFees:output_type -> ark.v1.UpdateIntentFeesResponse
+	25, // 54: ark.v1.AdminService.ClearIntentFees:output_type -> ark.v1.ClearIntentFeesResponse
+	27, // 55: ark.v1.AdminService.GetConvictions:output_type -> ark.v1.GetConvictionsResponse
+	29, // 56: ark.v1.AdminService.GetConvictionsInRange:output_type -> ark.v1.GetConvictionsInRangeResponse
+	31, // 57: ark.v1.AdminService.GetConvictionsByRound:output_type -> ark.v1.GetConvictionsByRoundResponse
+	33, // 58: ark.v1.AdminService.GetActiveScriptConvictions:output_type -> ark.v1.GetActiveScriptConvictionsResponse
+	35, // 59: ark.v1.AdminService.PardonConviction:output_type -> ark.v1.PardonConvictionResponse
+	37, // 60: ark.v1.AdminService.BanScript:output_type -> ark.v1.BanScriptResponse
+	39, // 61: ark.v1.AdminService.RevokeAuth:output_type -> ark.v1.RevokeAuthResponse
+	55, // 62: ark.v1.AdminService.ListTokens:output_type -> ark.v1.ListTokensResponse
+	58, // 63: ark.v1.AdminService.RevokeTokens:output_type -> ark.v1.RevokeTokensResponse
+	49, // 64: ark.v1.AdminService.GetExpiringLiquidity:output_type -> ark.v1.GetExpiringLiquidityResponse
+	51, // 65: ark.v1.AdminService.GetRecoverableLiquidity:output_type -> ark.v1.GetRecoverableLiquidityResponse
+	53, // 66: ark.v1.AdminService.Sweep:output_type -> ark.v1.SweepResponse
+	43, // [43:67] is the sub-list for method output_type
+	19, // [19:43] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_ark_v1_admin_proto_init() }
@@ -3126,7 +3442,7 @@ func file_ark_v1_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ark_v1_admin_proto_rawDesc), len(file_ark_v1_admin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   52,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -2763,14 +2763,11 @@ func (x *SweepResponse) GetHex() string {
 }
 
 type ListTokensRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Types that are valid to be assigned to Filter:
-	//
-	//	*ListTokensRequest_Token
-	//	*ListTokensRequest_Hash
-	//	*ListTokensRequest_Outpoint
-	//	*ListTokensRequest_Txid
-	Filter        isListTokensRequest_Filter `protobuf_oneof:"filter"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
+	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
+	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2805,76 +2802,33 @@ func (*ListTokensRequest) Descriptor() ([]byte, []int) {
 	return file_ark_v1_admin_proto_rawDescGZIP(), []int{52}
 }
 
-func (x *ListTokensRequest) GetFilter() isListTokensRequest_Filter {
-	if x != nil {
-		return x.Filter
-	}
-	return nil
-}
-
 func (x *ListTokensRequest) GetToken() string {
 	if x != nil {
-		if x, ok := x.Filter.(*ListTokensRequest_Token); ok {
-			return x.Token
-		}
+		return x.Token
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetHash() string {
 	if x != nil {
-		if x, ok := x.Filter.(*ListTokensRequest_Hash); ok {
-			return x.Hash
-		}
+		return x.Hash
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetOutpoint() string {
 	if x != nil {
-		if x, ok := x.Filter.(*ListTokensRequest_Outpoint); ok {
-			return x.Outpoint
-		}
+		return x.Outpoint
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetTxid() string {
 	if x != nil {
-		if x, ok := x.Filter.(*ListTokensRequest_Txid); ok {
-			return x.Txid
-		}
+		return x.Txid
 	}
 	return ""
 }
-
-type isListTokensRequest_Filter interface {
-	isListTokensRequest_Filter()
-}
-
-type ListTokensRequest_Token struct {
-	Token string `protobuf:"bytes,1,opt,name=token,proto3,oneof"` // base64 auth token
-}
-
-type ListTokensRequest_Hash struct {
-	Hash string `protobuf:"bytes,2,opt,name=hash,proto3,oneof"` // hex-encoded hash of outpoints
-}
-
-type ListTokensRequest_Outpoint struct {
-	Outpoint string `protobuf:"bytes,3,opt,name=outpoint,proto3,oneof"` // txid:vout format
-}
-
-type ListTokensRequest_Txid struct {
-	Txid string `protobuf:"bytes,4,opt,name=txid,proto3,oneof"`
-}
-
-func (*ListTokensRequest_Token) isListTokensRequest_Filter() {}
-
-func (*ListTokensRequest_Hash) isListTokensRequest_Filter() {}
-
-func (*ListTokensRequest_Outpoint) isListTokensRequest_Filter() {}
-
-func (*ListTokensRequest_Txid) isListTokensRequest_Filter() {}
 
 type ListTokensResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2981,14 +2935,11 @@ func (x *TokenInfo) GetExpiresAt() int64 {
 }
 
 type RevokeTokensRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Types that are valid to be assigned to Filter:
-	//
-	//	*RevokeTokensRequest_Token
-	//	*RevokeTokensRequest_Hash
-	//	*RevokeTokensRequest_Outpoint
-	//	*RevokeTokensRequest_Txid
-	Filter        isRevokeTokensRequest_Filter `protobuf_oneof:"filter"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
+	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
+	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
+	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3023,76 +2974,33 @@ func (*RevokeTokensRequest) Descriptor() ([]byte, []int) {
 	return file_ark_v1_admin_proto_rawDescGZIP(), []int{55}
 }
 
-func (x *RevokeTokensRequest) GetFilter() isRevokeTokensRequest_Filter {
-	if x != nil {
-		return x.Filter
-	}
-	return nil
-}
-
 func (x *RevokeTokensRequest) GetToken() string {
 	if x != nil {
-		if x, ok := x.Filter.(*RevokeTokensRequest_Token); ok {
-			return x.Token
-		}
+		return x.Token
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetHash() string {
 	if x != nil {
-		if x, ok := x.Filter.(*RevokeTokensRequest_Hash); ok {
-			return x.Hash
-		}
+		return x.Hash
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetOutpoint() string {
 	if x != nil {
-		if x, ok := x.Filter.(*RevokeTokensRequest_Outpoint); ok {
-			return x.Outpoint
-		}
+		return x.Outpoint
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetTxid() string {
 	if x != nil {
-		if x, ok := x.Filter.(*RevokeTokensRequest_Txid); ok {
-			return x.Txid
-		}
+		return x.Txid
 	}
 	return ""
 }
-
-type isRevokeTokensRequest_Filter interface {
-	isRevokeTokensRequest_Filter()
-}
-
-type RevokeTokensRequest_Token struct {
-	Token string `protobuf:"bytes,1,opt,name=token,proto3,oneof"` // base64 auth token
-}
-
-type RevokeTokensRequest_Hash struct {
-	Hash string `protobuf:"bytes,2,opt,name=hash,proto3,oneof"` // hex-encoded hash of outpoints
-}
-
-type RevokeTokensRequest_Outpoint struct {
-	Outpoint string `protobuf:"bytes,3,opt,name=outpoint,proto3,oneof"` // txid:vout format
-}
-
-type RevokeTokensRequest_Txid struct {
-	Txid string `protobuf:"bytes,4,opt,name=txid,proto3,oneof"`
-}
-
-func (*RevokeTokensRequest_Token) isRevokeTokensRequest_Filter() {}
-
-func (*RevokeTokensRequest_Hash) isRevokeTokensRequest_Filter() {}
-
-func (*RevokeTokensRequest_Outpoint) isRevokeTokensRequest_Filter() {}
-
-func (*RevokeTokensRequest_Txid) isRevokeTokensRequest_Filter() {}
 
 type RevokeTokensResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -3302,26 +3210,24 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10commitment_txids\x18\x02 \x03(\tR\x0fcommitmentTxids\"5\n" +
 	"\rSweepResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x10\n" +
-	"\x03hex\x18\x02 \x01(\tR\x03hex\"\x7f\n" +
-	"\x11ListTokensRequest\x12\x16\n" +
-	"\x05token\x18\x01 \x01(\tH\x00R\x05token\x12\x14\n" +
-	"\x04hash\x18\x02 \x01(\tH\x00R\x04hash\x12\x1c\n" +
-	"\boutpoint\x18\x03 \x01(\tH\x00R\boutpoint\x12\x14\n" +
-	"\x04txid\x18\x04 \x01(\tH\x00R\x04txidB\b\n" +
-	"\x06filter\"?\n" +
+	"\x03hex\x18\x02 \x01(\tR\x03hex\"m\n" +
+	"\x11ListTokensRequest\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
+	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
+	"\x04txid\x18\x04 \x01(\tR\x04txid\"?\n" +
 	"\x12ListTokensResponse\x12)\n" +
 	"\x06tokens\x18\x01 \x03(\v2\x11.ark.v1.TokenInfoR\x06tokens\"\\\n" +
 	"\tTokenInfo\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\tR\x04hash\x12\x1c\n" +
 	"\toutpoints\x18\x02 \x03(\tR\toutpoints\x12\x1d\n" +
 	"\n" +
-	"expires_at\x18\x03 \x01(\x03R\texpiresAt\"\x81\x01\n" +
-	"\x13RevokeTokensRequest\x12\x16\n" +
-	"\x05token\x18\x01 \x01(\tH\x00R\x05token\x12\x14\n" +
-	"\x04hash\x18\x02 \x01(\tH\x00R\x04hash\x12\x1c\n" +
-	"\boutpoint\x18\x03 \x01(\tH\x00R\boutpoint\x12\x14\n" +
-	"\x04txid\x18\x04 \x01(\tH\x00R\x04txidB\b\n" +
-	"\x06filter\";\n" +
+	"expires_at\x18\x03 \x01(\x03R\texpiresAt\"o\n" +
+	"\x13RevokeTokensRequest\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
+	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
+	"\x04txid\x18\x04 \x01(\tR\x04txid\";\n" +
 	"\x14RevokeTokensResponse\x12#\n" +
 	"\rrevoked_count\x18\x01 \x01(\x05R\frevokedCount*\xb6\x02\n" +
 	"\tCrimeType\x12\x1a\n" +
@@ -3529,18 +3435,6 @@ func file_ark_v1_admin_proto_init() {
 	file_ark_v1_admin_proto_msgTypes[44].OneofWrappers = []any{
 		(*Output_VtxoScript)(nil),
 		(*Output_OnchainAddress)(nil),
-	}
-	file_ark_v1_admin_proto_msgTypes[52].OneofWrappers = []any{
-		(*ListTokensRequest_Token)(nil),
-		(*ListTokensRequest_Hash)(nil),
-		(*ListTokensRequest_Outpoint)(nil),
-		(*ListTokensRequest_Txid)(nil),
-	}
-	file_ark_v1_admin_proto_msgTypes[55].OneofWrappers = []any{
-		(*RevokeTokensRequest_Token)(nil),
-		(*RevokeTokensRequest_Hash)(nil),
-		(*RevokeTokensRequest_Outpoint)(nil),
-		(*RevokeTokensRequest_Txid)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -2763,11 +2763,14 @@ func (x *SweepResponse) GetHex() string {
 }
 
 type ListTokensRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
-	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
-	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
-	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Filter:
+	//
+	//	*ListTokensRequest_Token
+	//	*ListTokensRequest_Hash
+	//	*ListTokensRequest_Outpoint
+	//	*ListTokensRequest_Txid
+	Filter        isListTokensRequest_Filter `protobuf_oneof:"filter"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2802,33 +2805,76 @@ func (*ListTokensRequest) Descriptor() ([]byte, []int) {
 	return file_ark_v1_admin_proto_rawDescGZIP(), []int{52}
 }
 
+func (x *ListTokensRequest) GetFilter() isListTokensRequest_Filter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
+}
+
 func (x *ListTokensRequest) GetToken() string {
 	if x != nil {
-		return x.Token
+		if x, ok := x.Filter.(*ListTokensRequest_Token); ok {
+			return x.Token
+		}
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetHash() string {
 	if x != nil {
-		return x.Hash
+		if x, ok := x.Filter.(*ListTokensRequest_Hash); ok {
+			return x.Hash
+		}
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetOutpoint() string {
 	if x != nil {
-		return x.Outpoint
+		if x, ok := x.Filter.(*ListTokensRequest_Outpoint); ok {
+			return x.Outpoint
+		}
 	}
 	return ""
 }
 
 func (x *ListTokensRequest) GetTxid() string {
 	if x != nil {
-		return x.Txid
+		if x, ok := x.Filter.(*ListTokensRequest_Txid); ok {
+			return x.Txid
+		}
 	}
 	return ""
 }
+
+type isListTokensRequest_Filter interface {
+	isListTokensRequest_Filter()
+}
+
+type ListTokensRequest_Token struct {
+	Token string `protobuf:"bytes,1,opt,name=token,proto3,oneof"` // base64 auth token
+}
+
+type ListTokensRequest_Hash struct {
+	Hash string `protobuf:"bytes,2,opt,name=hash,proto3,oneof"` // hex-encoded hash of outpoints
+}
+
+type ListTokensRequest_Outpoint struct {
+	Outpoint string `protobuf:"bytes,3,opt,name=outpoint,proto3,oneof"` // txid:vout format
+}
+
+type ListTokensRequest_Txid struct {
+	Txid string `protobuf:"bytes,4,opt,name=txid,proto3,oneof"`
+}
+
+func (*ListTokensRequest_Token) isListTokensRequest_Filter() {}
+
+func (*ListTokensRequest_Hash) isListTokensRequest_Filter() {}
+
+func (*ListTokensRequest_Outpoint) isListTokensRequest_Filter() {}
+
+func (*ListTokensRequest_Txid) isListTokensRequest_Filter() {}
 
 type ListTokensResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2935,11 +2981,14 @@ func (x *TokenInfo) GetExpiresAt() int64 {
 }
 
 type RevokeTokensRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
-	Hash          string                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`         // hex-encoded hash of outpoints
-	Outpoint      string                 `protobuf:"bytes,3,opt,name=outpoint,proto3" json:"outpoint,omitempty"` // txid:vout format
-	Txid          string                 `protobuf:"bytes,4,opt,name=txid,proto3" json:"txid,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Filter:
+	//
+	//	*RevokeTokensRequest_Token
+	//	*RevokeTokensRequest_Hash
+	//	*RevokeTokensRequest_Outpoint
+	//	*RevokeTokensRequest_Txid
+	Filter        isRevokeTokensRequest_Filter `protobuf_oneof:"filter"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2974,33 +3023,76 @@ func (*RevokeTokensRequest) Descriptor() ([]byte, []int) {
 	return file_ark_v1_admin_proto_rawDescGZIP(), []int{55}
 }
 
+func (x *RevokeTokensRequest) GetFilter() isRevokeTokensRequest_Filter {
+	if x != nil {
+		return x.Filter
+	}
+	return nil
+}
+
 func (x *RevokeTokensRequest) GetToken() string {
 	if x != nil {
-		return x.Token
+		if x, ok := x.Filter.(*RevokeTokensRequest_Token); ok {
+			return x.Token
+		}
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetHash() string {
 	if x != nil {
-		return x.Hash
+		if x, ok := x.Filter.(*RevokeTokensRequest_Hash); ok {
+			return x.Hash
+		}
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetOutpoint() string {
 	if x != nil {
-		return x.Outpoint
+		if x, ok := x.Filter.(*RevokeTokensRequest_Outpoint); ok {
+			return x.Outpoint
+		}
 	}
 	return ""
 }
 
 func (x *RevokeTokensRequest) GetTxid() string {
 	if x != nil {
-		return x.Txid
+		if x, ok := x.Filter.(*RevokeTokensRequest_Txid); ok {
+			return x.Txid
+		}
 	}
 	return ""
 }
+
+type isRevokeTokensRequest_Filter interface {
+	isRevokeTokensRequest_Filter()
+}
+
+type RevokeTokensRequest_Token struct {
+	Token string `protobuf:"bytes,1,opt,name=token,proto3,oneof"` // base64 auth token
+}
+
+type RevokeTokensRequest_Hash struct {
+	Hash string `protobuf:"bytes,2,opt,name=hash,proto3,oneof"` // hex-encoded hash of outpoints
+}
+
+type RevokeTokensRequest_Outpoint struct {
+	Outpoint string `protobuf:"bytes,3,opt,name=outpoint,proto3,oneof"` // txid:vout format
+}
+
+type RevokeTokensRequest_Txid struct {
+	Txid string `protobuf:"bytes,4,opt,name=txid,proto3,oneof"`
+}
+
+func (*RevokeTokensRequest_Token) isRevokeTokensRequest_Filter() {}
+
+func (*RevokeTokensRequest_Hash) isRevokeTokensRequest_Filter() {}
+
+func (*RevokeTokensRequest_Outpoint) isRevokeTokensRequest_Filter() {}
+
+func (*RevokeTokensRequest_Txid) isRevokeTokensRequest_Filter() {}
 
 type RevokeTokensResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -3210,24 +3302,26 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10commitment_txids\x18\x02 \x03(\tR\x0fcommitmentTxids\"5\n" +
 	"\rSweepResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x10\n" +
-	"\x03hex\x18\x02 \x01(\tR\x03hex\"m\n" +
-	"\x11ListTokensRequest\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
-	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
-	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
-	"\x04txid\x18\x04 \x01(\tR\x04txid\"?\n" +
+	"\x03hex\x18\x02 \x01(\tR\x03hex\"\x7f\n" +
+	"\x11ListTokensRequest\x12\x16\n" +
+	"\x05token\x18\x01 \x01(\tH\x00R\x05token\x12\x14\n" +
+	"\x04hash\x18\x02 \x01(\tH\x00R\x04hash\x12\x1c\n" +
+	"\boutpoint\x18\x03 \x01(\tH\x00R\boutpoint\x12\x14\n" +
+	"\x04txid\x18\x04 \x01(\tH\x00R\x04txidB\b\n" +
+	"\x06filter\"?\n" +
 	"\x12ListTokensResponse\x12)\n" +
 	"\x06tokens\x18\x01 \x03(\v2\x11.ark.v1.TokenInfoR\x06tokens\"\\\n" +
 	"\tTokenInfo\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\tR\x04hash\x12\x1c\n" +
 	"\toutpoints\x18\x02 \x03(\tR\toutpoints\x12\x1d\n" +
 	"\n" +
-	"expires_at\x18\x03 \x01(\x03R\texpiresAt\"o\n" +
-	"\x13RevokeTokensRequest\x12\x14\n" +
-	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
-	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
-	"\boutpoint\x18\x03 \x01(\tR\boutpoint\x12\x12\n" +
-	"\x04txid\x18\x04 \x01(\tR\x04txid\";\n" +
+	"expires_at\x18\x03 \x01(\x03R\texpiresAt\"\x81\x01\n" +
+	"\x13RevokeTokensRequest\x12\x16\n" +
+	"\x05token\x18\x01 \x01(\tH\x00R\x05token\x12\x14\n" +
+	"\x04hash\x18\x02 \x01(\tH\x00R\x04hash\x12\x1c\n" +
+	"\boutpoint\x18\x03 \x01(\tH\x00R\boutpoint\x12\x14\n" +
+	"\x04txid\x18\x04 \x01(\tH\x00R\x04txidB\b\n" +
+	"\x06filter\";\n" +
 	"\x14RevokeTokensResponse\x12#\n" +
 	"\rrevoked_count\x18\x01 \x01(\x05R\frevokedCount*\xb6\x02\n" +
 	"\tCrimeType\x12\x1a\n" +
@@ -3435,6 +3529,18 @@ func file_ark_v1_admin_proto_init() {
 	file_ark_v1_admin_proto_msgTypes[44].OneofWrappers = []any{
 		(*Output_VtxoScript)(nil),
 		(*Output_OnchainAddress)(nil),
+	}
+	file_ark_v1_admin_proto_msgTypes[52].OneofWrappers = []any{
+		(*ListTokensRequest_Token)(nil),
+		(*ListTokensRequest_Hash)(nil),
+		(*ListTokensRequest_Outpoint)(nil),
+		(*ListTokensRequest_Txid)(nil),
+	}
+	file_ark_v1_admin_proto_msgTypes[55].OneofWrappers = []any{
+		(*RevokeTokensRequest_Token)(nil),
+		(*RevokeTokensRequest_Hash)(nil),
+		(*RevokeTokensRequest_Outpoint)(nil),
+		(*RevokeTokensRequest_Txid)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
@@ -347,21 +347,12 @@ func request_AdminService_RevokeAuth_0(ctx context.Context, marshaler gateway.Ma
 
 }
 
-var (
-	query_params_AdminService_ListTokens_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New(),
-	}
-)
-
 func request_AdminService_ListTokens_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client AdminServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
 	var protoReq ListTokensRequest
 	var metadata gateway.ServerMetadata
 
-	if err := req.ParseForm(); err != nil {
-		return nil, metadata, gateway.ErrInvalidQueryParameters{Err: err}
-	}
-	if err := mux.PopulateQueryParameters(&protoReq, req.Form, query_params_AdminService_ListTokens_0); err != nil {
-		return nil, metadata, gateway.ErrInvalidQueryParameters{Err: err}
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, gateway.ErrMarshal{Err: err, Inbound: true}
 	}
 
 	msg, err := client.ListTokens(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -883,7 +874,7 @@ func RegisterAdminServiceHandlerClient(ctx context.Context, mux *gateway.ServeMu
 		mux.ForwardResponseMessage(annotatedContext, outboundMarshaler, w, req, resp)
 	})
 
-	mux.HandleWithParams("GET", "/v1/admin/tokens", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
+	mux.HandleWithParams("POST", "/v1/admin/tokens", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := mux.MarshalerForRequest(req)

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
@@ -348,6 +348,41 @@ func request_AdminService_RevokeAuth_0(ctx context.Context, marshaler gateway.Ma
 }
 
 var (
+	query_params_AdminService_ListTokens_0 = gateway.QueryParameterParseOptions{
+		Filter: trie.New(),
+	}
+)
+
+func request_AdminService_ListTokens_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client AdminServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
+	var protoReq ListTokensRequest
+	var metadata gateway.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, gateway.ErrInvalidQueryParameters{Err: err}
+	}
+	if err := mux.PopulateQueryParameters(&protoReq, req.Form, query_params_AdminService_ListTokens_0); err != nil {
+		return nil, metadata, gateway.ErrInvalidQueryParameters{Err: err}
+	}
+
+	msg, err := client.ListTokens(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func request_AdminService_RevokeTokens_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client AdminServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
+	var protoReq RevokeTokensRequest
+	var metadata gateway.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, gateway.ErrMarshal{Err: err, Inbound: true}
+	}
+
+	msg, err := client.RevokeTokens(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+var (
 	query_params_AdminService_GetExpiringLiquidity_0 = gateway.QueryParameterParseOptions{
 		Filter: trie.New(),
 	}
@@ -839,6 +874,50 @@ func RegisterAdminServiceHandlerClient(ctx context.Context, mux *gateway.ServeMu
 		}
 
 		resp, md, err := request_AdminService_RevokeAuth_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
+		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)
+			return
+		}
+
+		mux.ForwardResponseMessage(annotatedContext, outboundMarshaler, w, req, resp)
+	})
+
+	mux.HandleWithParams("GET", "/v1/admin/tokens", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := mux.MarshalerForRequest(req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = gateway.AnnotateContext(ctx, mux, req, "/ark.v1.AdminService/ListTokens", gateway.WithHTTPPathPattern("/v1/admin/tokens"))
+		if err != nil {
+			mux.HTTPError(ctx, outboundMarshaler, w, req, err)
+			return
+		}
+
+		resp, md, err := request_AdminService_ListTokens_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
+		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)
+			return
+		}
+
+		mux.ForwardResponseMessage(annotatedContext, outboundMarshaler, w, req, resp)
+	})
+
+	mux.HandleWithParams("POST", "/v1/admin/tokens/revoke", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := mux.MarshalerForRequest(req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = gateway.AnnotateContext(ctx, mux, req, "/ark.v1.AdminService/RevokeTokens", gateway.WithHTTPPathPattern("/v1/admin/tokens/revoke"))
+		if err != nil {
+			mux.HTTPError(ctx, outboundMarshaler, w, req, err)
+			return
+		}
+
+		resp, md, err := request_AdminService_RevokeTokens_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
 		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)

--- a/api-spec/protobuf/gen/ark/v1/admin_grpc.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin_grpc.pb.go
@@ -38,6 +38,8 @@ const (
 	AdminService_PardonConviction_FullMethodName             = "/ark.v1.AdminService/PardonConviction"
 	AdminService_BanScript_FullMethodName                    = "/ark.v1.AdminService/BanScript"
 	AdminService_RevokeAuth_FullMethodName                   = "/ark.v1.AdminService/RevokeAuth"
+	AdminService_ListTokens_FullMethodName                   = "/ark.v1.AdminService/ListTokens"
+	AdminService_RevokeTokens_FullMethodName                 = "/ark.v1.AdminService/RevokeTokens"
 	AdminService_GetExpiringLiquidity_FullMethodName         = "/ark.v1.AdminService/GetExpiringLiquidity"
 	AdminService_GetRecoverableLiquidity_FullMethodName      = "/ark.v1.AdminService/GetRecoverableLiquidity"
 	AdminService_Sweep_FullMethodName                        = "/ark.v1.AdminService/Sweep"
@@ -66,6 +68,8 @@ type AdminServiceClient interface {
 	PardonConviction(ctx context.Context, in *PardonConvictionRequest, opts ...grpc.CallOption) (*PardonConvictionResponse, error)
 	BanScript(ctx context.Context, in *BanScriptRequest, opts ...grpc.CallOption) (*BanScriptResponse, error)
 	RevokeAuth(ctx context.Context, in *RevokeAuthRequest, opts ...grpc.CallOption) (*RevokeAuthResponse, error)
+	ListTokens(ctx context.Context, in *ListTokensRequest, opts ...grpc.CallOption) (*ListTokensResponse, error)
+	RevokeTokens(ctx context.Context, in *RevokeTokensRequest, opts ...grpc.CallOption) (*RevokeTokensResponse, error)
 	GetExpiringLiquidity(ctx context.Context, in *GetExpiringLiquidityRequest, opts ...grpc.CallOption) (*GetExpiringLiquidityResponse, error)
 	GetRecoverableLiquidity(ctx context.Context, in *GetRecoverableLiquidityRequest, opts ...grpc.CallOption) (*GetRecoverableLiquidityResponse, error)
 	Sweep(ctx context.Context, in *SweepRequest, opts ...grpc.CallOption) (*SweepResponse, error)
@@ -269,6 +273,26 @@ func (c *adminServiceClient) RevokeAuth(ctx context.Context, in *RevokeAuthReque
 	return out, nil
 }
 
+func (c *adminServiceClient) ListTokens(ctx context.Context, in *ListTokensRequest, opts ...grpc.CallOption) (*ListTokensResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListTokensResponse)
+	err := c.cc.Invoke(ctx, AdminService_ListTokens_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *adminServiceClient) RevokeTokens(ctx context.Context, in *RevokeTokensRequest, opts ...grpc.CallOption) (*RevokeTokensResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RevokeTokensResponse)
+	err := c.cc.Invoke(ctx, AdminService_RevokeTokens_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *adminServiceClient) GetExpiringLiquidity(ctx context.Context, in *GetExpiringLiquidityRequest, opts ...grpc.CallOption) (*GetExpiringLiquidityResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetExpiringLiquidityResponse)
@@ -322,6 +346,8 @@ type AdminServiceServer interface {
 	PardonConviction(context.Context, *PardonConvictionRequest) (*PardonConvictionResponse, error)
 	BanScript(context.Context, *BanScriptRequest) (*BanScriptResponse, error)
 	RevokeAuth(context.Context, *RevokeAuthRequest) (*RevokeAuthResponse, error)
+	ListTokens(context.Context, *ListTokensRequest) (*ListTokensResponse, error)
+	RevokeTokens(context.Context, *RevokeTokensRequest) (*RevokeTokensResponse, error)
 	GetExpiringLiquidity(context.Context, *GetExpiringLiquidityRequest) (*GetExpiringLiquidityResponse, error)
 	GetRecoverableLiquidity(context.Context, *GetRecoverableLiquidityRequest) (*GetRecoverableLiquidityResponse, error)
 	Sweep(context.Context, *SweepRequest) (*SweepResponse, error)
@@ -390,6 +416,12 @@ func (UnimplementedAdminServiceServer) BanScript(context.Context, *BanScriptRequ
 }
 func (UnimplementedAdminServiceServer) RevokeAuth(context.Context, *RevokeAuthRequest) (*RevokeAuthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RevokeAuth not implemented")
+}
+func (UnimplementedAdminServiceServer) ListTokens(context.Context, *ListTokensRequest) (*ListTokensResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListTokens not implemented")
+}
+func (UnimplementedAdminServiceServer) RevokeTokens(context.Context, *RevokeTokensRequest) (*RevokeTokensResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method RevokeTokens not implemented")
 }
 func (UnimplementedAdminServiceServer) GetExpiringLiquidity(context.Context, *GetExpiringLiquidityRequest) (*GetExpiringLiquidityResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetExpiringLiquidity not implemented")
@@ -762,6 +794,42 @@ func _AdminService_RevokeAuth_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AdminService_ListTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListTokensRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AdminServiceServer).ListTokens(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AdminService_ListTokens_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AdminServiceServer).ListTokens(ctx, req.(*ListTokensRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AdminService_RevokeTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RevokeTokensRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AdminServiceServer).RevokeTokens(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AdminService_RevokeTokens_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AdminServiceServer).RevokeTokens(ctx, req.(*RevokeTokensRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _AdminService_GetExpiringLiquidity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetExpiringLiquidityRequest)
 	if err := dec(in); err != nil {
@@ -898,6 +966,14 @@ var AdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeAuth",
 			Handler:    _AdminService_RevokeAuth_Handler,
+		},
+		{
+			MethodName: "ListTokens",
+			Handler:    _AdminService_ListTokens_Handler,
+		},
+		{
+			MethodName: "RevokeTokens",
+			Handler:    _AdminService_RevokeTokens_Handler,
 		},
 		{
 			MethodName: "GetExpiringLiquidity",

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
@@ -243,7 +243,7 @@ func request_IndexerService_GetVtxos_0(ctx context.Context, marshaler gateway.Ma
 
 var (
 	query_params_IndexerService_GetVtxoChain_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New("vout", "outpoint.txid", "outpoint.vout", "txid"),
+		Filter: trie.New("outpoint.txid", "outpoint.vout", "txid", "vout"),
 	}
 )
 

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
@@ -125,7 +125,7 @@ func request_IndexerService_GetConnectors_0(ctx context.Context, marshaler gatew
 
 var (
 	query_params_IndexerService_GetVtxoTree_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New("batch_outpoint.vout", "batch_outpoint.txid", "txid", "vout"),
+		Filter: trie.New("batch_outpoint.txid", "batch_outpoint.vout", "txid", "vout"),
 	}
 )
 
@@ -243,7 +243,7 @@ func request_IndexerService_GetVtxos_0(ctx context.Context, marshaler gateway.Ma
 
 var (
 	query_params_IndexerService_GetVtxoChain_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New("outpoint.vout", "outpoint.txid", "txid", "vout"),
+		Filter: trie.New("outpoint.txid", "outpoint.vout", "txid", "vout"),
 	}
 )
 

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.rgw.go
@@ -125,7 +125,7 @@ func request_IndexerService_GetConnectors_0(ctx context.Context, marshaler gatew
 
 var (
 	query_params_IndexerService_GetVtxoTree_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New("batch_outpoint.txid", "batch_outpoint.vout", "txid", "vout"),
+		Filter: trie.New("batch_outpoint.vout", "batch_outpoint.txid", "txid", "vout"),
 	}
 )
 
@@ -243,7 +243,7 @@ func request_IndexerService_GetVtxos_0(ctx context.Context, marshaler gateway.Ma
 
 var (
 	query_params_IndexerService_GetVtxoChain_0 = gateway.QueryParameterParseOptions{
-		Filter: trie.New("outpoint.txid", "outpoint.vout", "txid", "vout"),
+		Filter: trie.New("outpoint.vout", "outpoint.txid", "txid", "vout"),
 	}
 )
 

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -972,19 +972,7 @@ func (i *indexerService) extractTokenHash(authToken string) (string, error) {
 		return "", fmt.Errorf("%w: invalid auth token length", ErrInvalidInput)
 	}
 
-	msg := tokenBytes[0:40]
-	sigBytes := tokenBytes[40:]
-
-	msgHash := chainhash.HashB(msg)
-	sig, err := schnorr.ParseSignature(sigBytes)
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to parse auth token signature: %w", ErrInvalidInput, err)
-	}
-	if !sig.Verify(msgHash, i.authPrvkey.PubKey()) {
-		return "", fmt.Errorf("%w: signature verification failed", ErrInvalidInput)
-	}
-
-	return hex.EncodeToString(msg[:32]), nil
+	return hex.EncodeToString(tokenBytes[:32]), nil
 }
 
 func (i *indexerService) resolveTokenFilter(

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -75,6 +75,8 @@ type IndexerService interface {
 	GetVirtualTxsByIntent(ctx context.Context, intent Intent, page *Page) (*VirtualTxsResp, error)
 	GetBatchSweepTxs(ctx context.Context, batchOutpoint Outpoint) ([]string, error)
 	GetAsset(ctx context.Context, assetID string) ([]Asset, error)
+	ListTokens(ctx context.Context, token, hash, outpoint, txid string) ([]TokenEntry, error)
+	RevokeTokens(ctx context.Context, token, hash, outpoint, txid string) (int, error)
 }
 
 type indexerService struct {
@@ -947,6 +949,48 @@ func (i *indexerService) validateAuthToken(authToken string) (string, error) {
 	}
 
 	return hex.EncodeToString(msg[:32]), nil
+}
+
+// extractTokenHash decodes an auth token and returns the outpoints hash
+// without checking expiry or signature. This is for admin introspection.
+func (i *indexerService) extractTokenHash(authToken string) (string, error) {
+	tokenBytes, err := base64.StdEncoding.DecodeString(authToken)
+	if err != nil {
+		return "", fmt.Errorf("invalid auth token format, must be base64")
+	}
+	if len(tokenBytes) != 40+64 {
+		return "", fmt.Errorf("invalid auth token length")
+	}
+	return hex.EncodeToString(tokenBytes[:32]), nil
+}
+
+func (i *indexerService) resolveTokenFilter(
+	token, hash string,
+) (string, error) {
+	if token != "" {
+		return i.extractTokenHash(token)
+	}
+	return hash, nil
+}
+
+func (i *indexerService) ListTokens(
+	_ context.Context, token, hash, outpoint, txid string,
+) ([]TokenEntry, error) {
+	h, err := i.resolveTokenFilter(token, hash)
+	if err != nil {
+		return nil, err
+	}
+	return i.tokenCache.list(h, outpoint, txid), nil
+}
+
+func (i *indexerService) RevokeTokens(
+	_ context.Context, token, hash, outpoint, txid string,
+) (int, error) {
+	h, err := i.resolveTokenFilter(token, hash)
+	if err != nil {
+		return 0, err
+	}
+	return i.tokenCache.revoke(h, outpoint, txid), nil
 }
 
 // hashOutpoints clones the given outpoints, sorts them lexicographically by txid and vout,

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -952,8 +952,12 @@ func (i *indexerService) validateAuthToken(authToken string) (string, error) {
 }
 
 // extractTokenHash decodes an auth token and returns the outpoints hash
-// without checking expiry or signature. This is for admin introspection.
+// without checking expiry. Signature is still verified.
 func (i *indexerService) extractTokenHash(authToken string) (string, error) {
+	if i.authPrvkey == nil {
+		return "", fmt.Errorf("token filter not available in public exposure mode")
+	}
+
 	tokenBytes, err := base64.StdEncoding.DecodeString(authToken)
 	if err != nil {
 		return "", fmt.Errorf("invalid auth token format, must be base64")
@@ -961,7 +965,20 @@ func (i *indexerService) extractTokenHash(authToken string) (string, error) {
 	if len(tokenBytes) != 40+64 {
 		return "", fmt.Errorf("invalid auth token length")
 	}
-	return hex.EncodeToString(tokenBytes[:32]), nil
+
+	msg := tokenBytes[0:40]
+	sigBytes := tokenBytes[40:]
+
+	msgHash := chainhash.HashB(msg)
+	sig, err := schnorr.ParseSignature(sigBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse auth token signature: %w", err)
+	}
+	if !sig.Verify(msgHash, i.authPrvkey.PubKey()) {
+		return "", fmt.Errorf("signature verification failed")
+	}
+
+	return hex.EncodeToString(msg[:32]), nil
 }
 
 func (i *indexerService) resolveTokenFilter(
@@ -973,6 +990,19 @@ func (i *indexerService) resolveTokenFilter(
 	return hash, nil
 }
 
+// normalizeOutpoint validates and normalizes an outpoint string (txid:vout).
+// Returns empty string if input is empty.
+func normalizeOutpoint(outpoint string) (string, error) {
+	if outpoint == "" {
+		return "", nil
+	}
+	var op Outpoint
+	if err := op.FromString(outpoint); err != nil {
+		return "", fmt.Errorf("invalid outpoint filter: %w", err)
+	}
+	return op.String(), nil
+}
+
 func (i *indexerService) ListTokens(
 	_ context.Context, token, hash, outpoint, txid string,
 ) ([]TokenEntry, error) {
@@ -980,7 +1010,11 @@ func (i *indexerService) ListTokens(
 	if err != nil {
 		return nil, err
 	}
-	return i.tokenCache.list(h, outpoint, txid), nil
+	op, err := normalizeOutpoint(outpoint)
+	if err != nil {
+		return nil, err
+	}
+	return i.tokenCache.list(h, op, txid), nil
 }
 
 func (i *indexerService) RevokeTokens(
@@ -990,7 +1024,11 @@ func (i *indexerService) RevokeTokens(
 	if err != nil {
 		return 0, err
 	}
-	return i.tokenCache.revoke(h, outpoint, txid), nil
+	op, err := normalizeOutpoint(outpoint)
+	if err != nil {
+		return 0, err
+	}
+	return i.tokenCache.revoke(h, op, txid), nil
 }
 
 // hashOutpoints clones the given outpoints, sorts them lexicographically by txid and vout,

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -35,6 +36,8 @@ const (
 
 	defaultAuthTokenTTL = 5 * time.Minute
 )
+
+var ErrInvalidInput = errors.New("invalid input")
 
 type exposure string
 
@@ -955,15 +958,18 @@ func (i *indexerService) validateAuthToken(authToken string) (string, error) {
 // without checking expiry. Signature is still verified.
 func (i *indexerService) extractTokenHash(authToken string) (string, error) {
 	if i.authPrvkey == nil {
-		return "", fmt.Errorf("token filter not available in public exposure mode")
+		return "", fmt.Errorf(
+			"%w: token filter not available in public exposure mode",
+			ErrInvalidInput,
+		)
 	}
 
 	tokenBytes, err := base64.StdEncoding.DecodeString(authToken)
 	if err != nil {
-		return "", fmt.Errorf("invalid auth token format, must be base64")
+		return "", fmt.Errorf("%w: invalid auth token format, must be base64", ErrInvalidInput)
 	}
 	if len(tokenBytes) != 40+64 {
-		return "", fmt.Errorf("invalid auth token length")
+		return "", fmt.Errorf("%w: invalid auth token length", ErrInvalidInput)
 	}
 
 	msg := tokenBytes[0:40]
@@ -972,10 +978,10 @@ func (i *indexerService) extractTokenHash(authToken string) (string, error) {
 	msgHash := chainhash.HashB(msg)
 	sig, err := schnorr.ParseSignature(sigBytes)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse auth token signature: %w", err)
+		return "", fmt.Errorf("%w: failed to parse auth token signature: %w", ErrInvalidInput, err)
 	}
 	if !sig.Verify(msgHash, i.authPrvkey.PubKey()) {
-		return "", fmt.Errorf("signature verification failed")
+		return "", fmt.Errorf("%w: signature verification failed", ErrInvalidInput)
 	}
 
 	return hex.EncodeToString(msg[:32]), nil
@@ -998,7 +1004,7 @@ func normalizeOutpoint(outpoint string) (string, error) {
 	}
 	var op Outpoint
 	if err := op.FromString(outpoint); err != nil {
-		return "", fmt.Errorf("invalid outpoint filter: %w", err)
+		return "", fmt.Errorf("%w: invalid outpoint filter: %w", ErrInvalidInput, err)
 	}
 	return op.String(), nil
 }
@@ -1027,6 +1033,9 @@ func (i *indexerService) RevokeTokens(
 	op, err := normalizeOutpoint(outpoint)
 	if err != nil {
 		return 0, err
+	}
+	if h == "" && op == "" && txid == "" {
+		return 0, fmt.Errorf("%w: at least one filter is required", ErrInvalidInput)
 	}
 	return i.tokenCache.revoke(h, op, txid), nil
 }

--- a/internal/core/application/indexer_admin_test.go
+++ b/internal/core/application/indexer_admin_test.go
@@ -161,28 +161,39 @@ func TestNormalizeOutpoint(t *testing.T) {
 	})
 
 	t.Run("valid outpoint is normalized", func(t *testing.T) {
-		out, err := normalizeOutpoint("aabb:0")
+		txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		out, err := normalizeOutpoint(txid + ":0")
 		require.NoError(t, err)
-		require.Equal(t, "aabb:0", out)
+		require.Equal(t, txid+":0", out)
 	})
 
 	t.Run("rejects missing vout", func(t *testing.T) {
-		_, err := normalizeOutpoint("aabb")
+		_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid outpoint")
 	})
 
 	t.Run("rejects non-numeric vout", func(t *testing.T) {
-		_, err := normalizeOutpoint("aabb:xyz")
+		_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:xyz")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid")
 	})
 
-	t.Run("rejects empty txid with vout", func(t *testing.T) {
-		// FromString doesn't validate txid content, but ":0" splits into ["", "0"]
-		// which is technically valid per FromString. This tests current behavior.
-		out, err := normalizeOutpoint(":0")
-		require.NoError(t, err)
-		require.Equal(t, ":0", out)
+	t.Run("rejects short txid", func(t *testing.T) {
+		_, err := normalizeOutpoint("aabb:0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "txid length")
+	})
+
+	t.Run("rejects non-hex txid", func(t *testing.T) {
+		_, err := normalizeOutpoint("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "txid hex")
+	})
+
+	t.Run("rejects empty txid", func(t *testing.T) {
+		_, err := normalizeOutpoint(":0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "txid length")
 	})
 }

--- a/internal/core/application/indexer_admin_test.go
+++ b/internal/core/application/indexer_admin_test.go
@@ -24,90 +24,74 @@ func TestExtractTokenHash(t *testing.T) {
 		{Txid: "aabbcc1100000000000000000000000000000000000000000000000000000000", VOut: 0},
 	}
 
-	t.Run("extracts hash from valid token", func(t *testing.T) {
-		token, err := svc.createAuthToken(outpoints)
-		require.NoError(t, err)
+	t.Run("valid", func(t *testing.T) {
+		t.Run("valid token", func(t *testing.T) {
+			token, err := svc.createAuthToken(outpoints)
+			require.NoError(t, err)
 
-		// Validate with full validation first to get the expected hash.
-		expectedHash, err := svc.validateAuthToken(token)
-		require.NoError(t, err)
+			// Validate with full validation first to get the expected hash.
+			expectedHash, err := svc.validateAuthToken(token)
+			require.NoError(t, err)
 
-		// extractTokenHash should return the same hash.
-		hash, err := svc.extractTokenHash(token)
-		require.NoError(t, err)
-		require.Equal(t, expectedHash, hash)
+			// extractTokenHash should return the same hash.
+			hash, err := svc.extractTokenHash(token)
+			require.NoError(t, err)
+			require.Equal(t, expectedHash, hash)
+		})
+
+		t.Run("expired token", func(t *testing.T) {
+			shortSvc := &indexerService{
+				authPrvkey:   key,
+				authTokenTTL: 10 * time.Millisecond,
+				tokenCache:   newTokenCache(10 * time.Millisecond),
+			}
+			t.Cleanup(shortSvc.tokenCache.close)
+
+			token, err := shortSvc.createAuthToken(outpoints)
+			require.NoError(t, err)
+			time.Sleep(20 * time.Millisecond)
+
+			// validateAuthToken should fail (expired).
+			_, err = shortSvc.validateAuthToken(token)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "expired")
+
+			// extractTokenHash should still succeed.
+			hash, err := shortSvc.extractTokenHash(token)
+			require.NoError(t, err)
+			require.NotEmpty(t, hash)
+		})
 	})
 
-	t.Run("extracts hash from expired token", func(t *testing.T) {
-		shortSvc := &indexerService{
-			authPrvkey:   key,
-			authTokenTTL: 10 * time.Millisecond,
-			tokenCache:   newTokenCache(10 * time.Millisecond),
-		}
-		t.Cleanup(shortSvc.tokenCache.close)
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("invalid base64", func(t *testing.T) {
+			_, err := svc.extractTokenHash("not-valid-base64!!!")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "base64")
+		})
 
-		token, err := shortSvc.createAuthToken(outpoints)
-		require.NoError(t, err)
-		time.Sleep(20 * time.Millisecond)
+		t.Run("wrong length", func(t *testing.T) {
+			short := base64.StdEncoding.EncodeToString([]byte("tooshort"))
+			_, err := svc.extractTokenHash(short)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "length")
+		})
 
-		// validateAuthToken should fail (expired).
-		_, err = shortSvc.validateAuthToken(token)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "expired")
+		t.Run("authPrvkey is nil", func(t *testing.T) {
+			publicSvc := &indexerService{
+				authPrvkey:   nil,
+				authTokenTTL: defaultAuthTokenTTL,
+				tokenCache:   newTokenCache(defaultAuthTokenTTL),
+			}
+			t.Cleanup(publicSvc.tokenCache.close)
 
-		// extractTokenHash should still succeed.
-		hash, err := shortSvc.extractTokenHash(token)
-		require.NoError(t, err)
-		require.NotEmpty(t, hash)
-	})
+			token, err := svc.createAuthToken(outpoints)
+			require.NoError(t, err)
 
-	t.Run("rejects invalid base64", func(t *testing.T) {
-		_, err := svc.extractTokenHash("not-valid-base64!!!")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "base64")
-	})
-
-	t.Run("rejects wrong length", func(t *testing.T) {
-		short := base64.StdEncoding.EncodeToString([]byte("tooshort"))
-		_, err := svc.extractTokenHash(short)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "length")
-	})
-
-	t.Run("rejects token signed by different key", func(t *testing.T) {
-		otherKey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-
-		otherSvc := &indexerService{
-			authPrvkey:   otherKey,
-			authTokenTTL: defaultAuthTokenTTL,
-			tokenCache:   newTokenCache(defaultAuthTokenTTL),
-		}
-		t.Cleanup(otherSvc.tokenCache.close)
-
-		token, err := otherSvc.createAuthToken(outpoints)
-		require.NoError(t, err)
-
-		// svc uses a different key, so signature verification should fail.
-		_, err = svc.extractTokenHash(token)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "signature verification failed")
-	})
-
-	t.Run("errors when authPrvkey is nil", func(t *testing.T) {
-		publicSvc := &indexerService{
-			authPrvkey:   nil,
-			authTokenTTL: defaultAuthTokenTTL,
-			tokenCache:   newTokenCache(defaultAuthTokenTTL),
-		}
-		t.Cleanup(publicSvc.tokenCache.close)
-
-		token, err := svc.createAuthToken(outpoints)
-		require.NoError(t, err)
-
-		_, err = publicSvc.extractTokenHash(token)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "public exposure")
+			_, err = publicSvc.extractTokenHash(token)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "public exposure")
+		})
 	})
 }
 
@@ -122,78 +106,86 @@ func TestResolveTokenFilter(t *testing.T) {
 	}
 	t.Cleanup(svc.tokenCache.close)
 
-	t.Run("returns hash when token is empty", func(t *testing.T) {
-		h, err := svc.resolveTokenFilter("", "myhash")
-		require.NoError(t, err)
-		require.Equal(t, "myhash", h)
+	t.Run("valid", func(t *testing.T) {
+		t.Run("returns hash when token is empty", func(t *testing.T) {
+			h, err := svc.resolveTokenFilter("", "myhash")
+			require.NoError(t, err)
+			require.Equal(t, "myhash", h)
+		})
+
+		t.Run("returns empty when both empty", func(t *testing.T) {
+			h, err := svc.resolveTokenFilter("", "")
+			require.NoError(t, err)
+			require.Empty(t, h)
+		})
+
+		t.Run("token takes precedence over hash", func(t *testing.T) {
+			outpoints := []Outpoint{
+				{Txid: "aabbcc1100000000000000000000000000000000000000000000000000000000", VOut: 0},
+			}
+			token, err := svc.createAuthToken(outpoints)
+			require.NoError(t, err)
+
+			h, err := svc.resolveTokenFilter(token, "ignored-hash")
+			require.NoError(t, err)
+			require.NotEqual(t, "ignored-hash", h)
+			require.NotEmpty(t, h)
+		})
 	})
 
-	t.Run("returns empty when both empty", func(t *testing.T) {
-		h, err := svc.resolveTokenFilter("", "")
-		require.NoError(t, err)
-		require.Empty(t, h)
-	})
-
-	t.Run("token takes precedence over hash", func(t *testing.T) {
-		outpoints := []Outpoint{
-			{Txid: "aabbcc1100000000000000000000000000000000000000000000000000000000", VOut: 0},
-		}
-		token, err := svc.createAuthToken(outpoints)
-		require.NoError(t, err)
-
-		h, err := svc.resolveTokenFilter(token, "ignored-hash")
-		require.NoError(t, err)
-		require.NotEqual(t, "ignored-hash", h)
-		require.NotEmpty(t, h)
-	})
-
-	t.Run("propagates token error", func(t *testing.T) {
-		_, err := svc.resolveTokenFilter("bad-token!!!", "")
-		require.Error(t, err)
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("propagates token error", func(t *testing.T) {
+			_, err := svc.resolveTokenFilter("bad-token!!!", "")
+			require.Error(t, err)
+		})
 	})
 }
 
 func TestNormalizeOutpoint(t *testing.T) {
-	t.Run("empty string returns empty", func(t *testing.T) {
-		out, err := normalizeOutpoint("")
-		require.NoError(t, err)
-		require.Empty(t, out)
+	t.Run("valid", func(t *testing.T) {
+		t.Run("empty string returns empty", func(t *testing.T) {
+			out, err := normalizeOutpoint("")
+			require.NoError(t, err)
+			require.Empty(t, out)
+		})
+
+		t.Run("valid outpoint is normalized", func(t *testing.T) {
+			txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			out, err := normalizeOutpoint(txid + ":0")
+			require.NoError(t, err)
+			require.Equal(t, txid+":0", out)
+		})
 	})
 
-	t.Run("valid outpoint is normalized", func(t *testing.T) {
-		txid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		out, err := normalizeOutpoint(txid + ":0")
-		require.NoError(t, err)
-		require.Equal(t, txid+":0", out)
-	})
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("missing vout", func(t *testing.T) {
+			_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid outpoint")
+		})
 
-	t.Run("rejects missing vout", func(t *testing.T) {
-		_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid outpoint")
-	})
+		t.Run("non-numeric vout", func(t *testing.T) {
+			_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:xyz")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid")
+		})
 
-	t.Run("rejects non-numeric vout", func(t *testing.T) {
-		_, err := normalizeOutpoint("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:xyz")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid")
-	})
+		t.Run("short txid", func(t *testing.T) {
+			_, err := normalizeOutpoint("aabb:0")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "txid length")
+		})
 
-	t.Run("rejects short txid", func(t *testing.T) {
-		_, err := normalizeOutpoint("aabb:0")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "txid length")
-	})
+		t.Run("non-hex txid", func(t *testing.T) {
+			_, err := normalizeOutpoint("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:0")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "txid hex")
+		})
 
-	t.Run("rejects non-hex txid", func(t *testing.T) {
-		_, err := normalizeOutpoint("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz:0")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "txid hex")
-	})
-
-	t.Run("rejects empty txid", func(t *testing.T) {
-		_, err := normalizeOutpoint(":0")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "txid length")
+		t.Run("empty txid", func(t *testing.T) {
+			_, err := normalizeOutpoint(":0")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "txid length")
+		})
 	})
 }

--- a/internal/core/application/indexer_admin_test.go
+++ b/internal/core/application/indexer_admin_test.go
@@ -1,0 +1,188 @@
+package application
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTokenHash(t *testing.T) {
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	svc := &indexerService{
+		authPrvkey:   key,
+		authTokenTTL: defaultAuthTokenTTL,
+		tokenCache:   newTokenCache(defaultAuthTokenTTL),
+	}
+	t.Cleanup(svc.tokenCache.close)
+
+	outpoints := []Outpoint{
+		{Txid: "aabbcc1100000000000000000000000000000000000000000000000000000000", VOut: 0},
+	}
+
+	t.Run("extracts hash from valid token", func(t *testing.T) {
+		token, err := svc.createAuthToken(outpoints)
+		require.NoError(t, err)
+
+		// Validate with full validation first to get the expected hash.
+		expectedHash, err := svc.validateAuthToken(token)
+		require.NoError(t, err)
+
+		// extractTokenHash should return the same hash.
+		hash, err := svc.extractTokenHash(token)
+		require.NoError(t, err)
+		require.Equal(t, expectedHash, hash)
+	})
+
+	t.Run("extracts hash from expired token", func(t *testing.T) {
+		shortSvc := &indexerService{
+			authPrvkey:   key,
+			authTokenTTL: 10 * time.Millisecond,
+			tokenCache:   newTokenCache(10 * time.Millisecond),
+		}
+		t.Cleanup(shortSvc.tokenCache.close)
+
+		token, err := shortSvc.createAuthToken(outpoints)
+		require.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+
+		// validateAuthToken should fail (expired).
+		_, err = shortSvc.validateAuthToken(token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expired")
+
+		// extractTokenHash should still succeed.
+		hash, err := shortSvc.extractTokenHash(token)
+		require.NoError(t, err)
+		require.NotEmpty(t, hash)
+	})
+
+	t.Run("rejects invalid base64", func(t *testing.T) {
+		_, err := svc.extractTokenHash("not-valid-base64!!!")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base64")
+	})
+
+	t.Run("rejects wrong length", func(t *testing.T) {
+		short := base64.StdEncoding.EncodeToString([]byte("tooshort"))
+		_, err := svc.extractTokenHash(short)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "length")
+	})
+
+	t.Run("rejects token signed by different key", func(t *testing.T) {
+		otherKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		otherSvc := &indexerService{
+			authPrvkey:   otherKey,
+			authTokenTTL: defaultAuthTokenTTL,
+			tokenCache:   newTokenCache(defaultAuthTokenTTL),
+		}
+		t.Cleanup(otherSvc.tokenCache.close)
+
+		token, err := otherSvc.createAuthToken(outpoints)
+		require.NoError(t, err)
+
+		// svc uses a different key, so signature verification should fail.
+		_, err = svc.extractTokenHash(token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature verification failed")
+	})
+
+	t.Run("errors when authPrvkey is nil", func(t *testing.T) {
+		publicSvc := &indexerService{
+			authPrvkey:   nil,
+			authTokenTTL: defaultAuthTokenTTL,
+			tokenCache:   newTokenCache(defaultAuthTokenTTL),
+		}
+		t.Cleanup(publicSvc.tokenCache.close)
+
+		token, err := svc.createAuthToken(outpoints)
+		require.NoError(t, err)
+
+		_, err = publicSvc.extractTokenHash(token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "public exposure")
+	})
+}
+
+func TestResolveTokenFilter(t *testing.T) {
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	svc := &indexerService{
+		authPrvkey:   key,
+		authTokenTTL: defaultAuthTokenTTL,
+		tokenCache:   newTokenCache(defaultAuthTokenTTL),
+	}
+	t.Cleanup(svc.tokenCache.close)
+
+	t.Run("returns hash when token is empty", func(t *testing.T) {
+		h, err := svc.resolveTokenFilter("", "myhash")
+		require.NoError(t, err)
+		require.Equal(t, "myhash", h)
+	})
+
+	t.Run("returns empty when both empty", func(t *testing.T) {
+		h, err := svc.resolveTokenFilter("", "")
+		require.NoError(t, err)
+		require.Empty(t, h)
+	})
+
+	t.Run("token takes precedence over hash", func(t *testing.T) {
+		outpoints := []Outpoint{
+			{Txid: "aabbcc1100000000000000000000000000000000000000000000000000000000", VOut: 0},
+		}
+		token, err := svc.createAuthToken(outpoints)
+		require.NoError(t, err)
+
+		h, err := svc.resolveTokenFilter(token, "ignored-hash")
+		require.NoError(t, err)
+		require.NotEqual(t, "ignored-hash", h)
+		require.NotEmpty(t, h)
+	})
+
+	t.Run("propagates token error", func(t *testing.T) {
+		_, err := svc.resolveTokenFilter("bad-token!!!", "")
+		require.Error(t, err)
+	})
+}
+
+func TestNormalizeOutpoint(t *testing.T) {
+	t.Run("empty string returns empty", func(t *testing.T) {
+		out, err := normalizeOutpoint("")
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("valid outpoint is normalized", func(t *testing.T) {
+		out, err := normalizeOutpoint("aabb:0")
+		require.NoError(t, err)
+		require.Equal(t, "aabb:0", out)
+	})
+
+	t.Run("rejects missing vout", func(t *testing.T) {
+		_, err := normalizeOutpoint("aabb")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid outpoint")
+	})
+
+	t.Run("rejects non-numeric vout", func(t *testing.T) {
+		_, err := normalizeOutpoint("aabb:xyz")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid")
+	})
+
+	t.Run("rejects empty txid with vout", func(t *testing.T) {
+		// FromString doesn't validate txid content, but ":0" splits into ["", "0"]
+		// which is technically valid per FromString. This tests current behavior.
+		out, err := normalizeOutpoint(":0")
+		require.NoError(t, err)
+		require.Equal(t, ":0", out)
+	})
+}

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -920,6 +920,134 @@ func TestStripSignerSignatures(t *testing.T) {
 	})
 }
 
+func TestListAndRevokeTokens(t *testing.T) {
+	privkey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+
+	outpoints1 := []Outpoint{{Txid: testTxids[0], VOut: 0}}
+	outpoints2 := []Outpoint{{Txid: testVtxoTxid, VOut: testVtxoVout}}
+	outpoints3 := []Outpoint{{Txid: differentTxid, VOut: 0}}
+
+	ctx := t.Context()
+
+	t.Run("list returns tokens created via createAuthToken", func(t *testing.T) {
+		token1, err := indexer.createAuthToken(outpoints1)
+		require.NoError(t, err)
+		_, err = indexer.createAuthToken(outpoints2)
+		require.NoError(t, err)
+
+		entries, err := indexer.ListTokens(ctx, "", "", "", "")
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+
+		// Verify filtering by the token string resolves to the right hash.
+		entries, err = indexer.ListTokens(ctx, token1, "", "", "")
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		// That entry's outpoints should match outpoints1.
+		require.Len(t, entries[0].Outpoints, 1)
+		require.Equal(t, outpoints1[0].String(), entries[0].Outpoints[0].String())
+	})
+
+	t.Run("list filters by outpoint", func(t *testing.T) {
+		entries, err := indexer.ListTokens(ctx, "", "", testVtxoTxid+":0", "")
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+	})
+
+	t.Run("list filters by txid", func(t *testing.T) {
+		entries, err := indexer.ListTokens(ctx, "", "", "", testTxids[0])
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+	})
+
+	t.Run("list rejects invalid outpoint format", func(t *testing.T) {
+		_, err := indexer.ListTokens(ctx, "", "", "garbage", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid outpoint")
+	})
+
+	t.Run("revoke by hash removes token and list no longer returns it", func(t *testing.T) {
+		// Get the hash for outpoints3 by creating a token.
+		_, err := indexer.createAuthToken(outpoints3)
+		require.NoError(t, err)
+
+		entries, err := indexer.ListTokens(ctx, "", "", "", differentTxid)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		hash := entries[0].Hash
+
+		count, err := indexer.RevokeTokens(ctx, "", hash, "", "")
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		// Verify it's gone.
+		entries, err = indexer.ListTokens(ctx, "", hash, "", "")
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	})
+
+	t.Run("revoke by txid", func(t *testing.T) {
+		before, err := indexer.ListTokens(ctx, "", "", "", "")
+		require.NoError(t, err)
+		countBefore := len(before)
+
+		count, err := indexer.RevokeTokens(ctx, "", "", "", testTxids[0])
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		after, err := indexer.ListTokens(ctx, "", "", "", "")
+		require.NoError(t, err)
+		require.Equal(t, countBefore-1, len(after))
+	})
+
+	t.Run("revoke by token string", func(t *testing.T) {
+		// The remaining token is outpoints2.
+		entries, err := indexer.ListTokens(ctx, "", "", "", "")
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+
+		// Create a fresh token for outpoints2 — createAuthToken returns the
+		// same token since the hash already exists in the cache.
+		token2, err := indexer.createAuthToken(outpoints2)
+		require.NoError(t, err)
+
+		count, err := indexer.RevokeTokens(ctx, token2, "", "", "")
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		entries, err = indexer.ListTokens(ctx, "", "", "", "")
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	})
+
+	t.Run("revoke rejects invalid outpoint format", func(t *testing.T) {
+		_, err := indexer.RevokeTokens(ctx, "", "", "bad", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid outpoint")
+	})
+
+	t.Run("list and revoke with nil privkey errors on token filter", func(t *testing.T) {
+		publicIndexer := &indexerService{
+			authPrvkey:   nil,
+			authTokenTTL: defaultAuthTokenTTL,
+			tokenCache:   newTokenCache(defaultAuthTokenTTL),
+		}
+		t.Cleanup(publicIndexer.tokenCache.close)
+
+		_, err := publicIndexer.ListTokens(ctx, "sometoken", "", "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "public exposure")
+
+		_, err = publicIndexer.RevokeTokens(ctx, "sometoken", "", "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "public exposure")
+	})
+}
+
 // newTestIndexer builds a minimal indexerService for unit tests.
 // Pass nil for repos/wallet that the test does not need — calling an
 // unconfigured mock method will panic, surfacing unexpected calls immediately.

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -920,178 +920,199 @@ func TestStripSignerSignatures(t *testing.T) {
 	})
 }
 
-func TestListAndRevokeTokens(t *testing.T) {
+func TestListTokens(t *testing.T) {
+	outpoints1 := []Outpoint{{Txid: testTxids[0], VOut: 0}}
+	outpoints2 := []Outpoint{{Txid: testVtxoTxid, VOut: testVtxoVout}}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Run("returns tokens created via createAuthToken", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
+
+			token1, err := indexer.createAuthToken(outpoints1)
+			require.NoError(t, err)
+			_, err = indexer.createAuthToken(outpoints2)
+			require.NoError(t, err)
+
+			entries, err := indexer.ListTokens(ctx, "", "", "", "")
+			require.NoError(t, err)
+			require.Len(t, entries, 2)
+
+			// Verify filtering by the token string resolves to the right hash.
+			entries, err = indexer.ListTokens(ctx, token1, "", "", "")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+
+			// That entry's outpoints should match outpoints1.
+			require.Len(t, entries[0].Outpoints, 1)
+			require.Equal(t, outpoints1[0].String(), entries[0].Outpoints[0])
+		})
+
+		t.Run("filters by outpoint", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
+
+			_, err = indexer.createAuthToken(outpoints1)
+			require.NoError(t, err)
+			_, err = indexer.createAuthToken(outpoints2)
+			require.NoError(t, err)
+
+			entries, err := indexer.ListTokens(ctx, "", "", testVtxoTxid+":0", "")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+		})
+
+		t.Run("filters by txid", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
+
+			_, err = indexer.createAuthToken(outpoints1)
+			require.NoError(t, err)
+			_, err = indexer.createAuthToken(outpoints2)
+			require.NoError(t, err)
+
+			entries, err := indexer.ListTokens(ctx, "", "", "", testTxids[0])
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("rejects invalid outpoint format", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+
+			_, err = indexer.ListTokens(t.Context(), "", "", "garbage", "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid outpoint")
+		})
+
+		t.Run("nil privkey errors on token filter", func(t *testing.T) {
+			publicIndexer := &indexerService{
+				authPrvkey:   nil,
+				authTokenTTL: defaultAuthTokenTTL,
+				tokenCache:   newTokenCache(defaultAuthTokenTTL),
+			}
+			t.Cleanup(publicIndexer.tokenCache.close)
+
+			_, err := publicIndexer.ListTokens(t.Context(), "sometoken", "", "", "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "public exposure")
+		})
+	})
+}
+
+func TestRevokeTokens(t *testing.T) {
 	outpoints1 := []Outpoint{{Txid: testTxids[0], VOut: 0}}
 	outpoints2 := []Outpoint{{Txid: testVtxoTxid, VOut: testVtxoVout}}
 	outpoints3 := []Outpoint{{Txid: differentTxid, VOut: 0}}
 
-	t.Run("list returns tokens created via createAuthToken", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
+	t.Run("valid", func(t *testing.T) {
+		t.Run("by hash removes token", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
 
-		token1, err := indexer.createAuthToken(outpoints1)
-		require.NoError(t, err)
-		_, err = indexer.createAuthToken(outpoints2)
-		require.NoError(t, err)
+			_, err = indexer.createAuthToken(outpoints3)
+			require.NoError(t, err)
 
-		entries, err := indexer.ListTokens(ctx, "", "", "", "")
-		require.NoError(t, err)
-		require.Len(t, entries, 2)
+			entries, err := indexer.ListTokens(ctx, "", "", "", differentTxid)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+			hash := entries[0].Hash
 
-		// Verify filtering by the token string resolves to the right hash.
-		entries, err = indexer.ListTokens(ctx, token1, "", "", "")
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
+			count, err := indexer.RevokeTokens(ctx, "", hash, "", "")
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
 
-		// That entry's outpoints should match outpoints1.
-		require.Len(t, entries[0].Outpoints, 1)
-		require.Equal(t, outpoints1[0].String(), entries[0].Outpoints[0])
+			// Verify it's gone.
+			entries, err = indexer.ListTokens(ctx, "", hash, "", "")
+			require.NoError(t, err)
+			require.Empty(t, entries)
+		})
+
+		t.Run("by txid", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
+
+			_, err = indexer.createAuthToken(outpoints1)
+			require.NoError(t, err)
+			_, err = indexer.createAuthToken(outpoints2)
+			require.NoError(t, err)
+
+			count, err := indexer.RevokeTokens(ctx, "", "", "", testTxids[0])
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+
+			after, err := indexer.ListTokens(ctx, "", "", "", "")
+			require.NoError(t, err)
+			require.Len(t, after, 1)
+		})
+
+		t.Run("by token string", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+			ctx := t.Context()
+
+			_, err = indexer.createAuthToken(outpoints1)
+			require.NoError(t, err)
+			token2, err := indexer.createAuthToken(outpoints2)
+			require.NoError(t, err)
+
+			count, err := indexer.RevokeTokens(ctx, token2, "", "", "")
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+
+			entries, err := indexer.ListTokens(ctx, "", "", "", "")
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+		})
 	})
 
-	t.Run("list filters by outpoint", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("rejects invalid outpoint format", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
 
-		_, err = indexer.createAuthToken(outpoints1)
-		require.NoError(t, err)
-		_, err = indexer.createAuthToken(outpoints2)
-		require.NoError(t, err)
+			_, err = indexer.RevokeTokens(t.Context(), "", "", "bad", "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid outpoint")
+		})
 
-		entries, err := indexer.ListTokens(ctx, "", "", testVtxoTxid+":0", "")
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-	})
+		t.Run("rejects empty filters", func(t *testing.T) {
+			privkey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
 
-	t.Run("list filters by txid", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
+			_, err = indexer.RevokeTokens(t.Context(), "", "", "", "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "at least one filter")
+		})
 
-		_, err = indexer.createAuthToken(outpoints1)
-		require.NoError(t, err)
-		_, err = indexer.createAuthToken(outpoints2)
-		require.NoError(t, err)
+		t.Run("nil privkey errors on token filter", func(t *testing.T) {
+			publicIndexer := &indexerService{
+				authPrvkey:   nil,
+				authTokenTTL: defaultAuthTokenTTL,
+				tokenCache:   newTokenCache(defaultAuthTokenTTL),
+			}
+			t.Cleanup(publicIndexer.tokenCache.close)
 
-		entries, err := indexer.ListTokens(ctx, "", "", "", testTxids[0])
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-	})
-
-	t.Run("list rejects invalid outpoint format", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-
-		_, err = indexer.ListTokens(t.Context(), "", "", "garbage", "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid outpoint")
-	})
-
-	t.Run("revoke by hash removes token and list no longer returns it", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
-
-		_, err = indexer.createAuthToken(outpoints3)
-		require.NoError(t, err)
-
-		entries, err := indexer.ListTokens(ctx, "", "", "", differentTxid)
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-		hash := entries[0].Hash
-
-		count, err := indexer.RevokeTokens(ctx, "", hash, "", "")
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-
-		// Verify it's gone.
-		entries, err = indexer.ListTokens(ctx, "", hash, "", "")
-		require.NoError(t, err)
-		require.Empty(t, entries)
-	})
-
-	t.Run("revoke by txid", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
-
-		_, err = indexer.createAuthToken(outpoints1)
-		require.NoError(t, err)
-		_, err = indexer.createAuthToken(outpoints2)
-		require.NoError(t, err)
-
-		count, err := indexer.RevokeTokens(ctx, "", "", "", testTxids[0])
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-
-		after, err := indexer.ListTokens(ctx, "", "", "", "")
-		require.NoError(t, err)
-		require.Len(t, after, 1)
-	})
-
-	t.Run("revoke by token string", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-		ctx := t.Context()
-
-		_, err = indexer.createAuthToken(outpoints1)
-		require.NoError(t, err)
-		token2, err := indexer.createAuthToken(outpoints2)
-		require.NoError(t, err)
-
-		count, err := indexer.RevokeTokens(ctx, token2, "", "", "")
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-
-		entries, err := indexer.ListTokens(ctx, "", "", "", "")
-		require.NoError(t, err)
-		require.Len(t, entries, 1)
-	})
-
-	t.Run("revoke rejects invalid outpoint format", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-
-		_, err = indexer.RevokeTokens(t.Context(), "", "", "bad", "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid outpoint")
-	})
-
-	t.Run("revoke rejects empty filters", func(t *testing.T) {
-		privkey, err := btcec.NewPrivateKey()
-		require.NoError(t, err)
-		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-
-		_, err = indexer.RevokeTokens(t.Context(), "", "", "", "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "at least one filter")
-	})
-
-	t.Run("nil privkey errors on token filter", func(t *testing.T) {
-		publicIndexer := &indexerService{
-			authPrvkey:   nil,
-			authTokenTTL: defaultAuthTokenTTL,
-			tokenCache:   newTokenCache(defaultAuthTokenTTL),
-		}
-		t.Cleanup(publicIndexer.tokenCache.close)
-		ctx := t.Context()
-
-		_, err := publicIndexer.ListTokens(ctx, "sometoken", "", "", "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "public exposure")
-
-		_, err = publicIndexer.RevokeTokens(ctx, "sometoken", "", "", "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "public exposure")
+			_, err := publicIndexer.RevokeTokens(t.Context(), "sometoken", "", "", "")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "public exposure")
+		})
 	})
 }
 

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -921,18 +921,16 @@ func TestStripSignerSignatures(t *testing.T) {
 }
 
 func TestListAndRevokeTokens(t *testing.T) {
-	privkey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-
-	indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
-
 	outpoints1 := []Outpoint{{Txid: testTxids[0], VOut: 0}}
 	outpoints2 := []Outpoint{{Txid: testVtxoTxid, VOut: testVtxoVout}}
 	outpoints3 := []Outpoint{{Txid: differentTxid, VOut: 0}}
 
-	ctx := t.Context()
-
 	t.Run("list returns tokens created via createAuthToken", func(t *testing.T) {
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
+
 		token1, err := indexer.createAuthToken(outpoints1)
 		require.NoError(t, err)
 		_, err = indexer.createAuthToken(outpoints2)
@@ -953,26 +951,54 @@ func TestListAndRevokeTokens(t *testing.T) {
 	})
 
 	t.Run("list filters by outpoint", func(t *testing.T) {
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
+
+		_, err = indexer.createAuthToken(outpoints1)
+		require.NoError(t, err)
+		_, err = indexer.createAuthToken(outpoints2)
+		require.NoError(t, err)
+
 		entries, err := indexer.ListTokens(ctx, "", "", testVtxoTxid+":0", "")
 		require.NoError(t, err)
 		require.Len(t, entries, 1)
 	})
 
 	t.Run("list filters by txid", func(t *testing.T) {
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
+
+		_, err = indexer.createAuthToken(outpoints1)
+		require.NoError(t, err)
+		_, err = indexer.createAuthToken(outpoints2)
+		require.NoError(t, err)
+
 		entries, err := indexer.ListTokens(ctx, "", "", "", testTxids[0])
 		require.NoError(t, err)
 		require.Len(t, entries, 1)
 	})
 
 	t.Run("list rejects invalid outpoint format", func(t *testing.T) {
-		_, err := indexer.ListTokens(ctx, "", "", "garbage", "")
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+
+		_, err = indexer.ListTokens(t.Context(), "", "", "garbage", "")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid outpoint")
 	})
 
 	t.Run("revoke by hash removes token and list no longer returns it", func(t *testing.T) {
-		// Get the hash for outpoints3 by creating a token.
-		_, err := indexer.createAuthToken(outpoints3)
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
+
+		_, err = indexer.createAuthToken(outpoints3)
 		require.NoError(t, err)
 
 		entries, err := indexer.ListTokens(ctx, "", "", "", differentTxid)
@@ -991,9 +1017,15 @@ func TestListAndRevokeTokens(t *testing.T) {
 	})
 
 	t.Run("revoke by txid", func(t *testing.T) {
-		before, err := indexer.ListTokens(ctx, "", "", "", "")
+		privkey, err := btcec.NewPrivateKey()
 		require.NoError(t, err)
-		countBefore := len(before)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
+
+		_, err = indexer.createAuthToken(outpoints1)
+		require.NoError(t, err)
+		_, err = indexer.createAuthToken(outpoints2)
+		require.NoError(t, err)
 
 		count, err := indexer.RevokeTokens(ctx, "", "", "", testTxids[0])
 		require.NoError(t, err)
@@ -1001,17 +1033,17 @@ func TestListAndRevokeTokens(t *testing.T) {
 
 		after, err := indexer.ListTokens(ctx, "", "", "", "")
 		require.NoError(t, err)
-		require.Equal(t, countBefore-1, len(after))
+		require.Len(t, after, 1)
 	})
 
 	t.Run("revoke by token string", func(t *testing.T) {
-		// The remaining token is outpoints2.
-		entries, err := indexer.ListTokens(ctx, "", "", "", "")
+		privkey, err := btcec.NewPrivateKey()
 		require.NoError(t, err)
-		require.Len(t, entries, 1)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+		ctx := t.Context()
 
-		// Create a fresh token for outpoints2 — createAuthToken returns the
-		// same token since the hash already exists in the cache.
+		_, err = indexer.createAuthToken(outpoints1)
+		require.NoError(t, err)
 		token2, err := indexer.createAuthToken(outpoints2)
 		require.NoError(t, err)
 
@@ -1019,24 +1051,39 @@ func TestListAndRevokeTokens(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
-		entries, err = indexer.ListTokens(ctx, "", "", "", "")
+		entries, err := indexer.ListTokens(ctx, "", "", "", "")
 		require.NoError(t, err)
-		require.Empty(t, entries)
+		require.Len(t, entries, 1)
 	})
 
 	t.Run("revoke rejects invalid outpoint format", func(t *testing.T) {
-		_, err := indexer.RevokeTokens(ctx, "", "", "bad", "")
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+
+		_, err = indexer.RevokeTokens(t.Context(), "", "", "bad", "")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid outpoint")
 	})
 
-	t.Run("list and revoke with nil privkey errors on token filter", func(t *testing.T) {
+	t.Run("revoke rejects empty filters", func(t *testing.T) {
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		indexer := newTestIndexer(t, privkey, exposurePrivate, nil, nil, nil)
+
+		_, err = indexer.RevokeTokens(t.Context(), "", "", "", "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one filter")
+	})
+
+	t.Run("nil privkey errors on token filter", func(t *testing.T) {
 		publicIndexer := &indexerService{
 			authPrvkey:   nil,
 			authTokenTTL: defaultAuthTokenTTL,
 			tokenCache:   newTokenCache(defaultAuthTokenTTL),
 		}
 		t.Cleanup(publicIndexer.tokenCache.close)
+		ctx := t.Context()
 
 		_, err := publicIndexer.ListTokens(ctx, "sometoken", "", "", "")
 		require.Error(t, err)

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -949,7 +949,7 @@ func TestListAndRevokeTokens(t *testing.T) {
 
 		// That entry's outpoints should match outpoints1.
 		require.Len(t, entries[0].Outpoints, 1)
-		require.Equal(t, outpoints1[0].String(), entries[0].Outpoints[0].String())
+		require.Equal(t, outpoints1[0].String(), entries[0].Outpoints[0])
 	})
 
 	t.Run("list filters by outpoint", func(t *testing.T) {

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+type TokenEntry struct {
+	Hash      string
+	Outpoints []Outpoint
+	ExpiresAt time.Time
+}
+
 type tokenCache struct {
 	mu sync.RWMutex
 	// Stores outpoints by hash (hash of outpoints), with a shared expiration time for all
@@ -118,4 +124,128 @@ func (c *tokenCache) getTxids(hash string) (map[string]struct{}, bool) {
 		res[outpoint.Txid] = struct{}{}
 	}
 	return res, true
+}
+
+func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	now := time.Now()
+	var result []TokenEntry
+
+	for h, outpoints := range c.outpointsByHash {
+		// Check expiry.
+		var expiresAt time.Time
+		for _, exp := range outpoints {
+			expiresAt = exp
+			break
+		}
+		if now.After(expiresAt) {
+			continue
+		}
+
+		// Filter by hash.
+		if hash != "" && h != hash {
+			continue
+		}
+
+		// Collect outpoints for this entry.
+		entry := TokenEntry{
+			Hash:      h,
+			ExpiresAt: expiresAt,
+		}
+		for op := range outpoints {
+			entry.Outpoints = append(entry.Outpoints, op)
+		}
+
+		// Filter by outpoint.
+		if outpointStr != "" {
+			found := false
+			for _, op := range entry.Outpoints {
+				if op.String() == outpointStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		// Filter by txid.
+		if txid != "" {
+			found := false
+			for _, op := range entry.Outpoints {
+				if op.Txid == txid {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		result = append(result, entry)
+	}
+
+	return result
+}
+
+func (c *tokenCache) revoke(hash, outpointStr, txid string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	count := 0
+
+	for h, outpoints := range c.outpointsByHash {
+		// Check expiry.
+		var expiresAt time.Time
+		for _, exp := range outpoints {
+			expiresAt = exp
+			break
+		}
+		if now.After(expiresAt) {
+			continue
+		}
+
+		// Filter by hash.
+		if hash != "" && h != hash {
+			continue
+		}
+
+		// Filter by outpoint.
+		if outpointStr != "" {
+			found := false
+			for op := range outpoints {
+				if op.String() == outpointStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		// Filter by txid.
+		if txid != "" {
+			found := false
+			for op := range outpoints {
+				if op.Txid == txid {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		delete(c.outpointsByHash, h)
+		count++
+	}
+
+	return count
 }

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -1,9 +1,12 @@
 package application
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
+
+const maxTokenListSize = 50
 
 type TokenEntry struct {
 	Hash      string
@@ -187,6 +190,15 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 		}
 
 		result = append(result, entry)
+	}
+
+	// Sort oldest first (earliest expiry = earliest creation).
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ExpiresAt.Before(result[j].ExpiresAt)
+	})
+
+	if len(result) > maxTokenListSize {
+		result = result[:maxTokenListSize]
 	}
 
 	return result

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -1,12 +1,9 @@
 package application
 
 import (
-	"sort"
 	"sync"
 	"time"
 )
-
-const maxTokenListSize = 50
 
 type TokenEntry struct {
 	Hash      string
@@ -130,10 +127,12 @@ func (c *tokenCache) getTxids(hash string) (map[string]struct{}, bool) {
 }
 
 // list returns non-expired token entries matching the given filters.
-// Filters are ANDed: an entry must match all non-empty filters.
-// Results are sorted oldest-first and capped at maxTokenListSize to
-// bound response size.
 func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
+	// Fast path: hash is known, do a direct lookup.
+	if hash != "" {
+		return c.listByHash(hash)
+	}
+
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -148,11 +147,6 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 			break
 		}
 		if now.After(expiresAt) {
-			continue
-		}
-
-		// Filter by hash.
-		if hash != "" && h != hash {
 			continue
 		}
 
@@ -184,7 +178,6 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 			}
 		}
 
-		// Collect outpoints as sorted strings for deterministic output.
 		entry := TokenEntry{
 			Hash:      h,
 			ExpiresAt: expiresAt,
@@ -192,26 +185,48 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 		for op := range outpoints {
 			entry.Outpoints = append(entry.Outpoints, op.String())
 		}
-		sort.Strings(entry.Outpoints)
 
 		result = append(result, entry)
-	}
-
-	// Sort oldest first (earliest expiry = earliest creation).
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].ExpiresAt.Before(result[j].ExpiresAt)
-	})
-
-	if len(result) > maxTokenListSize {
-		result = result[:maxTokenListSize]
 	}
 
 	return result
 }
 
+func (c *tokenCache) listByHash(hash string) []TokenEntry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	outpoints, ok := c.outpointsByHash[hash]
+	if !ok {
+		return nil
+	}
+	var expiresAt time.Time
+	for _, exp := range outpoints {
+		expiresAt = exp
+		break
+	}
+	if time.Now().After(expiresAt) {
+		return nil
+	}
+
+	entry := TokenEntry{
+		Hash:      hash,
+		ExpiresAt: expiresAt,
+	}
+	for op := range outpoints {
+		entry.Outpoints = append(entry.Outpoints, op.String())
+	}
+	return []TokenEntry{entry}
+}
+
 // revoke deletes non-expired token entries matching the given filters
-// and returns the number of entries removed. Filters are ANDed.
+// and returns the number of entries removed.
 func (c *tokenCache) revoke(hash, outpointStr, txid string) int {
+	// Fast path: hash is known, do a direct delete.
+	if hash != "" {
+		return c.revokeByHash(hash)
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -226,11 +241,6 @@ func (c *tokenCache) revoke(hash, outpointStr, txid string) int {
 			break
 		}
 		if now.After(expiresAt) {
-			continue
-		}
-
-		// Filter by hash.
-		if hash != "" && h != hash {
 			continue
 		}
 
@@ -267,4 +277,22 @@ func (c *tokenCache) revoke(hash, outpointStr, txid string) int {
 	}
 
 	return count
+}
+
+func (c *tokenCache) revokeByHash(hash string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	outpoints, ok := c.outpointsByHash[hash]
+	if !ok {
+		return 0
+	}
+	for _, expiry := range outpoints {
+		if time.Now().After(expiry) {
+			return 0
+		}
+		break
+	}
+	delete(c.outpointsByHash, hash)
+	return 1
 }

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -184,7 +184,7 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 			}
 		}
 
-		// Collect outpoints as strings.
+		// Collect outpoints as sorted strings for deterministic output.
 		entry := TokenEntry{
 			Hash:      h,
 			ExpiresAt: expiresAt,
@@ -192,6 +192,7 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 		for op := range outpoints {
 			entry.Outpoints = append(entry.Outpoints, op.String())
 		}
+		sort.Strings(entry.Outpoints)
 
 		result = append(result, entry)
 	}

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -129,6 +129,10 @@ func (c *tokenCache) getTxids(hash string) (map[string]struct{}, bool) {
 	return res, true
 }
 
+// list returns non-expired token entries matching the given filters.
+// Filters are ANDed: an entry must match all non-empty filters.
+// Results are sorted oldest-first and capped at maxTokenListSize to
+// bound response size.
 func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -204,6 +208,8 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 	return result
 }
 
+// revoke deletes non-expired token entries matching the given filters
+// and returns the number of entries removed. Filters are ANDed.
 func (c *tokenCache) revoke(hash, outpointStr, txid string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/core/application/token_cache.go
+++ b/internal/core/application/token_cache.go
@@ -10,7 +10,7 @@ const maxTokenListSize = 50
 
 type TokenEntry struct {
 	Hash      string
-	Outpoints []Outpoint
+	Outpoints []string
 	ExpiresAt time.Time
 }
 
@@ -152,19 +152,10 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 			continue
 		}
 
-		// Collect outpoints for this entry.
-		entry := TokenEntry{
-			Hash:      h,
-			ExpiresAt: expiresAt,
-		}
-		for op := range outpoints {
-			entry.Outpoints = append(entry.Outpoints, op)
-		}
-
 		// Filter by outpoint.
 		if outpointStr != "" {
 			found := false
-			for _, op := range entry.Outpoints {
+			for op := range outpoints {
 				if op.String() == outpointStr {
 					found = true
 					break
@@ -178,7 +169,7 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 		// Filter by txid.
 		if txid != "" {
 			found := false
-			for _, op := range entry.Outpoints {
+			for op := range outpoints {
 				if op.Txid == txid {
 					found = true
 					break
@@ -187,6 +178,15 @@ func (c *tokenCache) list(hash, outpointStr, txid string) []TokenEntry {
 			if !found {
 				continue
 			}
+		}
+
+		// Collect outpoints as strings.
+		entry := TokenEntry{
+			Hash:      h,
+			ExpiresAt: expiresAt,
+		}
+		for op := range outpoints {
+			entry.Outpoints = append(entry.Outpoints, op.String())
 		}
 
 		result = append(result, entry)

--- a/internal/core/application/token_cache_test.go
+++ b/internal/core/application/token_cache_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -243,6 +244,37 @@ func TestTokenCache(t *testing.T) {
 					require.Len(t, entries, 1)
 					require.Len(t, entries[0].Outpoints, 2)
 					require.False(t, entries[0].ExpiresAt.IsZero())
+				},
+			},
+			{
+				name: "ordered by expiry oldest first",
+				setup: func(c *tokenCache) {
+					now := time.Now()
+					c.add("newer", []Outpoint{op1}, now.Add(10*time.Millisecond))
+					c.add("older", []Outpoint{op2}, now)
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", "")
+					require.Len(t, entries, 2)
+					require.Equal(t, "older", entries[0].Hash)
+					require.Equal(t, "newer", entries[1].Hash)
+				},
+			},
+			{
+				name: "capped at maxTokenListSize",
+				setup: func(c *tokenCache) {
+					now := time.Now()
+					for i := 0; i < maxTokenListSize+10; i++ {
+						op := Outpoint{
+							Txid: fmt.Sprintf("%064d", i),
+							VOut: 0,
+						}
+						c.add(fmt.Sprintf("hash%d", i), []Outpoint{op}, now)
+					}
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", "")
+					require.Len(t, entries, maxTokenListSize)
 				},
 			},
 		}

--- a/internal/core/application/token_cache_test.go
+++ b/internal/core/application/token_cache_test.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -170,47 +169,24 @@ func TestTokenCache(t *testing.T) {
 				name: "filter by outpoint",
 				setup: func(c *tokenCache) {
 					c.add("hash1", []Outpoint{op1, op2}, time.Now())
-					c.add("hash2", []Outpoint{op3}, time.Now())
+					c.add("hash2", []Outpoint{op2, op3}, time.Now())
+					c.add("hash3", []Outpoint{op1, op3}, time.Now())
 				},
 				assert: func(t *testing.T, c *tokenCache) {
 					entries := c.list("", op2.String(), "")
-					require.Len(t, entries, 1)
-					require.Equal(t, "hash1", entries[0].Hash)
+					require.Len(t, entries, 2)
 				},
 			},
 			{
 				name: "filter by txid",
 				setup: func(c *tokenCache) {
 					c.add("hash1", []Outpoint{op1}, time.Now())
-					c.add("hash2", []Outpoint{op2}, time.Now())
-				},
-				assert: func(t *testing.T, c *tokenCache) {
-					entries := c.list("", "", op1.Txid)
-					require.Len(t, entries, 1)
-					require.Equal(t, "hash1", entries[0].Hash)
-				},
-			},
-			{
-				name: "filter by txid matches multiple entries",
-				setup: func(c *tokenCache) {
-					c.add("hash1", []Outpoint{op1}, time.Now())
-					c.add("hash2", []Outpoint{op3}, time.Now()) // op3 shares txid with op1
+					c.add("hash2", []Outpoint{op1, op2}, time.Now())
+					c.add("hash3", []Outpoint{op2}, time.Now())
 				},
 				assert: func(t *testing.T, c *tokenCache) {
 					entries := c.list("", "", op1.Txid)
 					require.Len(t, entries, 2)
-				},
-			},
-			{
-				name: "combined hash and txid filter",
-				setup: func(c *tokenCache) {
-					c.add("hash1", []Outpoint{op1}, time.Now())
-					c.add("hash2", []Outpoint{op3}, time.Now()) // op3 shares txid with op1
-				},
-				assert: func(t *testing.T, c *tokenCache) {
-					entries := c.list("hash1", "", op1.Txid)
-					require.Len(t, entries, 1)
-					require.Equal(t, "hash1", entries[0].Hash)
 				},
 			},
 			{
@@ -246,37 +222,6 @@ func TestTokenCache(t *testing.T) {
 					require.False(t, entries[0].ExpiresAt.IsZero())
 				},
 			},
-			{
-				name: "ordered by expiry oldest first",
-				setup: func(c *tokenCache) {
-					now := time.Now()
-					c.add("newer", []Outpoint{op1}, now.Add(10*time.Millisecond))
-					c.add("older", []Outpoint{op2}, now)
-				},
-				assert: func(t *testing.T, c *tokenCache) {
-					entries := c.list("", "", "")
-					require.Len(t, entries, 2)
-					require.Equal(t, "older", entries[0].Hash)
-					require.Equal(t, "newer", entries[1].Hash)
-				},
-			},
-			{
-				name: "capped at maxTokenListSize",
-				setup: func(c *tokenCache) {
-					now := time.Now()
-					for i := 0; i < maxTokenListSize+10; i++ {
-						op := Outpoint{
-							Txid: fmt.Sprintf("%064d", i),
-							VOut: 0,
-						}
-						c.add(fmt.Sprintf("hash%d", i), []Outpoint{op}, now)
-					}
-				},
-				assert: func(t *testing.T, c *tokenCache) {
-					entries := c.list("", "", "")
-					require.Len(t, entries, maxTokenListSize)
-				},
-			},
 		}
 
 		for _, tc := range tests {
@@ -304,23 +249,6 @@ func TestTokenCache(t *testing.T) {
 					count := c.revoke("hash1", "", "")
 					require.Equal(t, 1, count)
 					// hash1 gone
-					_, _, ok := c.getOutpoints("hash1")
-					require.False(t, ok)
-					// hash2 still there
-					_, _, ok = c.getOutpoints("hash2")
-					require.True(t, ok)
-				},
-			},
-			{
-				name: "by outpoint",
-				setup: func(c *tokenCache) {
-					c.add("hash1", []Outpoint{op1, op2}, time.Now())
-					c.add("hash2", []Outpoint{op3}, time.Now())
-				},
-				assert: func(t *testing.T, c *tokenCache) {
-					count := c.revoke("", op2.String(), "")
-					require.Equal(t, 1, count)
-					// hash1 gone (it contained op2)
 					_, _, ok := c.getOutpoints("hash1")
 					require.False(t, ok)
 					// hash2 still there

--- a/internal/core/application/token_cache_test.go
+++ b/internal/core/application/token_cache_test.go
@@ -135,4 +135,218 @@ func TestTokenCache(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("list", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			setup  func(c *tokenCache)
+			assert func(t *testing.T, c *tokenCache)
+		}{
+			{
+				name: "no filter returns all entries",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", "")
+					require.Len(t, entries, 2)
+				},
+			},
+			{
+				name: "filter by hash",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("hash1", "", "")
+					require.Len(t, entries, 1)
+					require.Equal(t, "hash1", entries[0].Hash)
+				},
+			},
+			{
+				name: "filter by outpoint",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1, op2}, time.Now())
+					c.add("hash2", []Outpoint{op3}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", op2.String(), "")
+					require.Len(t, entries, 1)
+					require.Equal(t, "hash1", entries[0].Hash)
+				},
+			},
+			{
+				name: "filter by txid",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", op1.Txid)
+					require.Len(t, entries, 1)
+					require.Equal(t, "hash1", entries[0].Hash)
+				},
+			},
+			{
+				name: "filter by txid matches multiple entries",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op3}, time.Now()) // op3 shares txid with op1
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", op1.Txid)
+					require.Len(t, entries, 2)
+				},
+			},
+			{
+				name: "combined hash and txid filter",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op3}, time.Now()) // op3 shares txid with op1
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("hash1", "", op1.Txid)
+					require.Len(t, entries, 1)
+					require.Equal(t, "hash1", entries[0].Hash)
+				},
+			},
+			{
+				name: "no match returns empty",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("nonexistent", "", "")
+					require.Empty(t, entries)
+				},
+			},
+			{
+				name: "skips expired entries",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					time.Sleep(100 * time.Millisecond)
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("", "", "")
+					require.Empty(t, entries)
+				},
+			},
+			{
+				name: "returns outpoints and expiry",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1, op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					entries := c.list("hash1", "", "")
+					require.Len(t, entries, 1)
+					require.Len(t, entries[0].Outpoints, 2)
+					require.False(t, entries[0].ExpiresAt.IsZero())
+				},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				c := newTokenCache(50 * time.Millisecond)
+				tc.setup(c)
+				tc.assert(t, c)
+			})
+		}
+	})
+
+	t.Run("revoke", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			setup  func(c *tokenCache)
+			assert func(t *testing.T, c *tokenCache)
+		}{
+			{
+				name: "by hash",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					count := c.revoke("hash1", "", "")
+					require.Equal(t, 1, count)
+					// hash1 gone
+					_, _, ok := c.getOutpoints("hash1")
+					require.False(t, ok)
+					// hash2 still there
+					_, _, ok = c.getOutpoints("hash2")
+					require.True(t, ok)
+				},
+			},
+			{
+				name: "by outpoint",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1, op2}, time.Now())
+					c.add("hash2", []Outpoint{op3}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					count := c.revoke("", op2.String(), "")
+					require.Equal(t, 1, count)
+					// hash1 gone (it contained op2)
+					_, _, ok := c.getOutpoints("hash1")
+					require.False(t, ok)
+					// hash2 still there
+					_, _, ok = c.getOutpoints("hash2")
+					require.True(t, ok)
+				},
+			},
+			{
+				name: "by txid revokes all matching",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					c.add("hash2", []Outpoint{op3}, time.Now()) // op3 shares txid with op1
+					c.add("hash3", []Outpoint{op2}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					count := c.revoke("", "", op1.Txid)
+					require.Equal(t, 2, count)
+					_, _, ok := c.getOutpoints("hash1")
+					require.False(t, ok)
+					_, _, ok = c.getOutpoints("hash2")
+					require.False(t, ok)
+					// hash3 still there
+					_, _, ok = c.getOutpoints("hash3")
+					require.True(t, ok)
+				},
+			},
+			{
+				name: "no match returns zero",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					count := c.revoke("nonexistent", "", "")
+					require.Equal(t, 0, count)
+					// original entry untouched
+					_, _, ok := c.getOutpoints("hash1")
+					require.True(t, ok)
+				},
+			},
+			{
+				name: "skips expired entries",
+				setup: func(c *tokenCache) {
+					c.add("hash1", []Outpoint{op1}, time.Now())
+					time.Sleep(100 * time.Millisecond)
+				},
+				assert: func(t *testing.T, c *tokenCache) {
+					count := c.revoke("hash1", "", "")
+					require.Equal(t, 0, count)
+				},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				c := newTokenCache(50 * time.Millisecond)
+				tc.setup(c)
+				tc.assert(t, c)
+			})
+		}
+	})
 }

--- a/internal/core/domain/vtxo.go
+++ b/internal/core/domain/vtxo.go
@@ -23,11 +23,18 @@ func (k *Outpoint) FromString(s string) error {
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid outpoint string: %s", s)
 	}
-	k.Txid = parts[0]
+	txid := parts[0]
+	if len(txid) != 64 {
+		return fmt.Errorf("invalid txid length: expected 64 hex chars, got %d", len(txid))
+	}
+	if _, err := hex.DecodeString(txid); err != nil {
+		return fmt.Errorf("invalid txid hex: %s", txid)
+	}
 	vout, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid vout string: %s", parts[1])
 	}
+	k.Txid = txid
 	k.VOut = uint32(vout)
 	return nil
 }

--- a/internal/core/domain/vtxo.go
+++ b/internal/core/domain/vtxo.go
@@ -27,14 +27,15 @@ func (k *Outpoint) FromString(s string) error {
 	if len(txid) != 64 {
 		return fmt.Errorf("invalid txid length: expected 64 hex chars, got %d", len(txid))
 	}
-	if _, err := hex.DecodeString(txid); err != nil {
+	txidBytes, err := hex.DecodeString(txid)
+	if err != nil {
 		return fmt.Errorf("invalid txid hex: %s", txid)
 	}
 	vout, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid vout string: %s", parts[1])
 	}
-	k.Txid = txid
+	k.Txid = hex.EncodeToString(txidBytes)
 	k.VOut = uint32(vout)
 	return nil
 }

--- a/internal/core/domain/vtxo.go
+++ b/internal/core/domain/vtxo.go
@@ -24,12 +24,12 @@ func (k *Outpoint) FromString(s string) error {
 		return fmt.Errorf("invalid outpoint string: %s", s)
 	}
 	txid := parts[0]
-	if len(txid) != 64 {
-		return fmt.Errorf("invalid txid length: expected 64 hex chars, got %d", len(txid))
-	}
 	txidBytes, err := hex.DecodeString(txid)
 	if err != nil {
 		return fmt.Errorf("invalid txid hex: %s", txid)
+	}
+	if len(txidBytes) != 32 {
+		return fmt.Errorf("invalid txid length: expected 32 bytes, got %d", len(txidBytes))
 	}
 	vout, err := strconv.ParseUint(parts[1], 10, 32)
 	if err != nil {

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -530,8 +530,9 @@ func (a *adminHandler) ListTokens(
 func (a *adminHandler) RevokeTokens(
 	ctx context.Context, req *arkv1.RevokeTokensRequest,
 ) (*arkv1.RevokeTokensResponse, error) {
-	if req.GetFilter() == nil {
-		return nil, status.Error(codes.InvalidArgument, "a filter is required")
+	if req.GetToken() == "" && req.GetHash() == "" && req.GetOutpoint() == "" &&
+		req.GetTxid() == "" {
+		return nil, status.Error(codes.InvalidArgument, "at least one filter is required")
 	}
 
 	count, err := a.indexerService.RevokeTokens(

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -512,6 +513,9 @@ func (a *adminHandler) ListTokens(
 		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
 	)
 	if err != nil {
+		if errors.Is(err, application.ErrInvalidInput) {
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "%s", err.Error())
 	}
 
@@ -539,6 +543,9 @@ func (a *adminHandler) RevokeTokens(
 		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
 	)
 	if err != nil {
+		if errors.Is(err, application.ErrInvalidInput) {
+			return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
+		}
 		return nil, status.Errorf(codes.Internal, "%s", err.Error())
 	}
 

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -517,13 +517,9 @@ func (a *adminHandler) ListTokens(
 
 	protoTokens := make([]*arkv1.TokenInfo, 0, len(tokens))
 	for _, t := range tokens {
-		outpoints := make([]string, 0, len(t.Outpoints))
-		for _, op := range t.Outpoints {
-			outpoints = append(outpoints, op.String())
-		}
 		protoTokens = append(protoTokens, &arkv1.TokenInfo{
 			Hash:      t.Hash,
-			Outpoints: outpoints,
+			Outpoints: t.Outpoints,
 			ExpiresAt: t.ExpiresAt.Unix(),
 		})
 	}

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -26,16 +26,19 @@ import (
 
 type adminHandler struct {
 	adminService    application.AdminService
+	indexerService  application.IndexerService
 	macaroonSvc     *macaroons.Service
 	macaroonDatadir string
 	noteUriPrefix   string
 }
 
 func NewAdminHandler(
-	adminService application.AdminService, macaroonSvc *macaroons.Service,
+	adminService application.AdminService,
+	indexerService application.IndexerService,
+	macaroonSvc *macaroons.Service,
 	macaroonDatadir, noteUriPrefix string,
 ) arkv1.AdminServiceServer {
-	return &adminHandler{adminService, macaroonSvc, macaroonDatadir, noteUriPrefix}
+	return &adminHandler{adminService, indexerService, macaroonSvc, macaroonDatadir, noteUriPrefix}
 }
 
 func (a *adminHandler) GetRoundDetails(
@@ -500,6 +503,45 @@ func (a *adminHandler) RevokeAuth(
 	return &arkv1.RevokeAuthResponse{
 		Token: hex.EncodeToString(macBytes),
 	}, nil
+}
+
+func (a *adminHandler) ListTokens(
+	ctx context.Context, req *arkv1.ListTokensRequest,
+) (*arkv1.ListTokensResponse, error) {
+	tokens, err := a.indexerService.ListTokens(
+		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%s", err.Error())
+	}
+
+	protoTokens := make([]*arkv1.TokenInfo, 0, len(tokens))
+	for _, t := range tokens {
+		outpoints := make([]string, 0, len(t.Outpoints))
+		for _, op := range t.Outpoints {
+			outpoints = append(outpoints, op.String())
+		}
+		protoTokens = append(protoTokens, &arkv1.TokenInfo{
+			Hash:      t.Hash,
+			Outpoints: outpoints,
+			ExpiresAt: t.ExpiresAt.Unix(),
+		})
+	}
+
+	return &arkv1.ListTokensResponse{Tokens: protoTokens}, nil
+}
+
+func (a *adminHandler) RevokeTokens(
+	ctx context.Context, req *arkv1.RevokeTokensRequest,
+) (*arkv1.RevokeTokensResponse, error) {
+	count, err := a.indexerService.RevokeTokens(
+		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%s", err.Error())
+	}
+
+	return &arkv1.RevokeTokensResponse{RevokedCount: int32(count)}, nil
 }
 
 func (a *adminHandler) GetIntentFees(

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -25,9 +25,17 @@ import (
 	"gopkg.in/macaroon.v2"
 )
 
+type tokenAdminInterface interface {
+	ListTokens(
+		ctx context.Context,
+		token, hash, outpoint, txid string,
+	) ([]application.TokenEntry, error)
+	RevokeTokens(ctx context.Context, token, hash, outpoint, txid string) (int, error)
+}
+
 type adminHandler struct {
 	adminService    application.AdminService
-	indexerService  application.IndexerService
+	tokenAdminSvc   tokenAdminInterface
 	macaroonSvc     *macaroons.Service
 	macaroonDatadir string
 	noteUriPrefix   string
@@ -39,7 +47,13 @@ func NewAdminHandler(
 	macaroonSvc *macaroons.Service,
 	macaroonDatadir, noteUriPrefix string,
 ) arkv1.AdminServiceServer {
-	return &adminHandler{adminService, indexerService, macaroonSvc, macaroonDatadir, noteUriPrefix}
+	return &adminHandler{
+		adminService:    adminService,
+		tokenAdminSvc:   indexerService,
+		macaroonSvc:     macaroonSvc,
+		macaroonDatadir: macaroonDatadir,
+		noteUriPrefix:   noteUriPrefix,
+	}
 }
 
 func (a *adminHandler) GetRoundDetails(
@@ -506,10 +520,11 @@ func (a *adminHandler) RevokeAuth(
 	}, nil
 }
 
+// TODO: move ListTokens and RevokeTokens to the indexer's own admin interface when we detach it.
 func (a *adminHandler) ListTokens(
 	ctx context.Context, req *arkv1.ListTokensRequest,
 ) (*arkv1.ListTokensResponse, error) {
-	tokens, err := a.indexerService.ListTokens(
+	tokens, err := a.tokenAdminSvc.ListTokens(
 		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
 	)
 	if err != nil {
@@ -539,7 +554,7 @@ func (a *adminHandler) RevokeTokens(
 		return nil, status.Error(codes.InvalidArgument, "at least one filter is required")
 	}
 
-	count, err := a.indexerService.RevokeTokens(
+	count, err := a.tokenAdminSvc.RevokeTokens(
 		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
 	)
 	if err != nil {

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -534,6 +534,11 @@ func (a *adminHandler) ListTokens(
 func (a *adminHandler) RevokeTokens(
 	ctx context.Context, req *arkv1.RevokeTokensRequest,
 ) (*arkv1.RevokeTokensResponse, error) {
+	if req.GetToken() == "" && req.GetHash() == "" && req.GetOutpoint() == "" &&
+		req.GetTxid() == "" {
+		return nil, status.Error(codes.InvalidArgument, "at least one filter is required")
+	}
+
 	count, err := a.indexerService.RevokeTokens(
 		ctx, req.GetToken(), req.GetHash(), req.GetOutpoint(), req.GetTxid(),
 	)

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -534,9 +534,8 @@ func (a *adminHandler) ListTokens(
 func (a *adminHandler) RevokeTokens(
 	ctx context.Context, req *arkv1.RevokeTokensRequest,
 ) (*arkv1.RevokeTokensResponse, error) {
-	if req.GetToken() == "" && req.GetHash() == "" && req.GetOutpoint() == "" &&
-		req.GetTxid() == "" {
-		return nil, status.Error(codes.InvalidArgument, "at least one filter is required")
+	if req.GetFilter() == nil {
+		return nil, status.Error(codes.InvalidArgument, "a filter is required")
 	}
 
 	count, err := a.indexerService.RevokeTokens(

--- a/internal/interface/grpc/handlers/adminservice_test.go
+++ b/internal/interface/grpc/handlers/adminservice_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
@@ -13,7 +12,7 @@ import (
 func TestRevokeTokensRequiresFilter(t *testing.T) {
 	handler := &adminHandler{}
 
-	_, err := handler.RevokeTokens(context.Background(), &arkv1.RevokeTokensRequest{})
+	_, err := handler.RevokeTokens(t.Context(), &arkv1.RevokeTokensRequest{})
 	require.Error(t, err)
 
 	st, ok := status.FromError(err)

--- a/internal/interface/grpc/handlers/adminservice_test.go
+++ b/internal/interface/grpc/handlers/adminservice_test.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRevokeTokensRequiresFilter(t *testing.T) {
+	handler := &adminHandler{}
+
+	_, err := handler.RevokeTokens(context.Background(), &arkv1.RevokeTokensRequest{})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Contains(t, st.Message(), "at least one filter")
+}

--- a/internal/interface/grpc/permissions/permissions.go
+++ b/internal/interface/grpc/permissions/permissions.go
@@ -379,5 +379,13 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityAuthManager,
 			Action: "write",
 		}},
+		fmt.Sprintf("/%s/ListTokens", arkv1.AdminService_ServiceDesc.ServiceName): {{
+			Entity: EntityManager,
+			Action: "read",
+		}},
+		fmt.Sprintf("/%s/RevokeTokens", arkv1.AdminService_ServiceDesc.ServiceName): {{
+			Entity: EntityManager,
+			Action: "write",
+		}},
 	}
 }

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -333,7 +333,7 @@ func (s *service) newServer(tlsConfig *tls.Config, withPprof bool) error {
 
 	walletSvc := s.appConfig.WalletService()
 	adminHandler := handlers.NewAdminHandler(
-		s.appConfig.AdminService(), s.macaroonSvc,
+		s.appConfig.AdminService(), indexerSvc, s.macaroonSvc,
 		s.config.macaroonsDatadir(), s.appConfig.NoteUriPrefix,
 	)
 	walletHandler := handlers.NewWalletHandler(walletSvc)


### PR DESCRIPTION
closes https://github.com/arkade-os/arkd/issues/1000

  - Add ListTokens (GET /v1/admin/tokens) and RevokeTokens (POST /v1/admin/tokens/revoke) to AdminService                                                                                                  
  - Both accept optional filters: token (base64 auth token), hash (hex), outpoint (txid:vout), txid — filters are ANDed when combined
  - ListTokens returns matching entries sorted oldest-first, capped at 50 to bound response size so  a sort of DoS prevention in that we dont return a giant amount potentially                                                                                                       
  - RevokeTokens requires at least one filter to prevent accidental full-cache wipe                                                                                                                        
  - Token filter verifies schnorr signature (skips expiry so admins can inspect/revoke expired tokens)                                                                                                     
  - Outpoint filter is validated and normalized before use                                                                                                                                                 
  - Both endpoints gated behind manager entity permissions (read/write)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints to list and revoke tokens (POST /v1/admin/tokens and POST /v1/admin/tokens/revoke). Listing returns token entries including outpoints and expiry.

* **Bug Fixes**
  * Improved validation and normalization for token/hash/outpoint/txid inputs; revoke now rejects requests with no filters.

* **Tests**
  * Added comprehensive unit tests for listing, revocation, filtering, normalization, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->