### PR TITLE
FIX: auto-add dust carrier sats to asset-carrying receiver outputs

### DIFF
--- a/pkg/client-lib/send.go
+++ b/pkg/client-lib/send.go
@@ -190,6 +190,13 @@ func (a *service) createOffchainTx(
 		}
 	}
 
+	// ensure asset-carrying receivers have at least dust sats as a carrier
+	for i, receiver := range receivers {
+		if len(receiver.Assets) > 0 && receiver.Amount < a.Dust {
+			receivers[i].Amount = a.Dust
+		}
+	}
+
 	btcAmountToSelect := int64(0)
 	selectedCoins := make([]types.VtxoWithTapTree, 0)
 	assetChanges := make(map[string]uint64)


### PR DESCRIPTION
When sending only assets (no BTC amount specified), the receiver output was built with 0 sats. The server rejected this with AMOUNT_TOO_LOW.

@altafan please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed transaction handling to enforce minimum amount thresholds when sending assets, preventing improperly valued transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->