### PR TITLE
bulk-fetch offchain txs in walkVtxoChain to reduce DB round-trips

### DIFF
--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -20,7 +20,7 @@ services:
     container_name: nbxplorer
     ports:
       - 32838:32838
-    image: nicolasdorier/nbxplorer:2.5.30
+    image: nicolasdorier/nbxplorer:2.5.30-1
     environment:
       - NBXPLORER_NETWORK=regtest
       - NBXPLORER_CHAINS=btc

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -572,6 +572,10 @@ func (i *indexerService) walkVtxoChain(
 	offchainTxCache := make(map[string]*domain.OffchainTx)
 	allOutpoints := make([]Outpoint, 0)
 
+	// Timing accumulators.
+	var tEnsureVtxos, tBulkOffchain, tSingleOffchain, tPsbtDeser, tVtxoTree time.Duration
+	walkStart := time.Now()
+
 	// Lazy cache for VTXOs loaded during this page.
 	vtxoCache := make(map[string]domain.Vtxo)
 	loadedMarkers := make(map[string]bool)
@@ -588,9 +592,11 @@ func (i *indexerService) walkVtxoChain(
 	}
 
 	for len(nextVtxos) > 0 {
+		t0 := time.Now()
 		if err := i.ensureVtxosCached(ctx, nextVtxos, vtxoCache, loadedMarkers); err != nil {
 			return nil, nil, "", err
 		}
+		tEnsureVtxos += time.Since(t0)
 
 		vtxos := make([]domain.Vtxo, 0, len(nextVtxos))
 		for _, op := range nextVtxos {
@@ -619,7 +625,9 @@ func (i *indexerService) walkVtxoChain(
 				txids = append(txids, txid)
 			}
 
+			t1 := time.Now()
 			offchainTxs, err := i.repoManager.OffchainTxs().GetOffchainTxsByTxids(ctx, txids)
+			tBulkOffchain += time.Since(t1)
 			if err != nil {
 				return nil, nil, "", fmt.Errorf("failed to retrieve offchain txs: %s", err)
 			}
@@ -660,8 +668,10 @@ func (i *indexerService) walkVtxoChain(
 			if vtxo.Preconfirmed {
 				offchainTx, ok := offchainTxCache[vtxo.Txid]
 				if !ok {
+					t2 := time.Now()
 					var err error
 					offchainTx, err = i.repoManager.OffchainTxs().GetOffchainTx(ctx, vtxo.Txid)
+					tSingleOffchain += time.Since(t2)
 					if err != nil {
 						return nil, nil, "", fmt.Errorf("failed to retrieve offchain tx: %s", err)
 					}
@@ -675,6 +685,7 @@ func (i *indexerService) walkVtxoChain(
 				}
 
 				checkpointTxs := make([]ChainTx, 0, len(offchainTx.CheckpointTxs))
+				t3 := time.Now()
 				for _, b64 := range offchainTx.CheckpointTxs {
 					ptx, err := psbt.NewFromRawBytes(strings.NewReader(b64), true)
 					if err != nil {
@@ -704,6 +715,7 @@ func (i *indexerService) walkVtxoChain(
 						}
 					}
 				}
+				tPsbtDeser += time.Since(t3)
 
 				chain = append(chain, chainTx)
 				chain = append(chain, checkpointTxs...)
@@ -712,6 +724,7 @@ func (i *indexerService) walkVtxoChain(
 
 			// if the vtxo is not preconfirmed, it means it's a leaf of a batch tree
 			// add the branch until the commitment tx
+			t4 := time.Now()
 			flatVtxoTree, err := i.GetVtxoTree(ctx, Outpoint{
 				Txid: vtxo.RootCommitmentTxid, VOut: 0,
 			}, nil)
@@ -735,6 +748,7 @@ func (i *indexerService) walkVtxoChain(
 			}); err != nil {
 				return nil, nil, "", err
 			}
+			tVtxoTree += time.Since(t4)
 
 			// reverse fromRootToVtxo
 			fromVtxoToRoot := make([]ChainTx, 0, len(fromRootToVtxo))
@@ -775,6 +789,18 @@ func (i *indexerService) walkVtxoChain(
 	}
 
 	// Chain exhausted — no more pages.
+	walkTotal := time.Since(walkStart)
+	tOther := walkTotal - tEnsureVtxos - tBulkOffchain - tSingleOffchain - tPsbtDeser - tVtxoTree
+	log.WithFields(log.Fields{
+		"total":           walkTotal,
+		"ensureVtxos":     tEnsureVtxos,
+		"bulkOffchainTx":  tBulkOffchain,
+		"singleOffchainTx": tSingleOffchain,
+		"psbtDeser":       tPsbtDeser,
+		"vtxoTree":        tVtxoTree,
+		"other":           tOther,
+		"chainLen":        len(chain),
+	}).Info("walkVtxoChain timing breakdown")
 	return chain, allOutpoints, "", nil
 }
 

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -580,13 +580,13 @@ func (i *indexerService) walkVtxoChain(
 	vtxoCache := make(map[string]domain.Vtxo)
 	loadedMarkers := make(map[string]bool)
 
-	// Eagerly preload VTXOs by walking the marker DAG upward.
+	// Eagerly preload VTXOs and offchain txs by walking the marker DAG upward.
 	if i.repoManager.Markers() != nil {
 		startVtxos, err := i.repoManager.Vtxos().GetVtxos(ctx, nextVtxos)
 		if err != nil {
 			return nil, nil, "", err
 		}
-		if err := i.preloadVtxosByMarkers(ctx, startVtxos, vtxoCache); err != nil {
+		if err := i.preloadByMarkers(ctx, startVtxos, vtxoCache, offchainTxCache); err != nil {
 			return nil, nil, "", err
 		}
 	}
@@ -834,20 +834,22 @@ func decodeChainCursor(token string) ([]domain.Outpoint, error) {
 	return outpoints, nil
 }
 
-// preloadVtxosByMarkers bulk-fetches VTXOs by walking the marker DAG upward
-// from the markers of startVtxos. This reduces DB round-trips from O(chain_length)
-// to O(chain_length / MarkerInterval).
-func (i *indexerService) preloadVtxosByMarkers(
+// preloadByMarkers bulk-fetches VTXOs and their offchain txs by walking the
+// marker DAG upward from the markers of startVtxos. This reduces DB round-trips
+// from O(chain_length) to O(chain_length / MarkerInterval) for both layers.
+func (i *indexerService) preloadByMarkers(
 	ctx context.Context,
 	startVtxos []domain.Vtxo,
-	cache map[string]domain.Vtxo,
+	vtxoCache map[string]domain.Vtxo,
+	offchainTxCache map[string]*domain.OffchainTx,
 ) error {
 	markerRepo := i.repoManager.Markers()
+	offchainTxRepo := i.repoManager.OffchainTxs()
 
 	// Seed cache and collect initial marker IDs.
 	currentMarkerIDs := make(map[string]bool)
 	for _, v := range startVtxos {
-		cache[v.Outpoint.String()] = v
+		vtxoCache[v.Outpoint.String()] = v
 		for _, mid := range v.MarkerIDs {
 			currentMarkerIDs[mid] = true
 		}
@@ -868,8 +870,35 @@ func (i *indexerService) preloadVtxosByMarkers(
 			return err
 		}
 		for _, v := range vtxos {
-			if _, ok := cache[v.Outpoint.String()]; !ok {
-				cache[v.Outpoint.String()] = v
+			if _, ok := vtxoCache[v.Outpoint.String()]; !ok {
+				vtxoCache[v.Outpoint.String()] = v
+			}
+		}
+
+		// Piggyback: bulk-fetch the offchain txs for the preconfirmed VTXOs
+		// in this window, so the walk loop never has to hit the DB per-hop.
+		missingTxids := make([]string, 0, len(vtxos))
+		seen := make(map[string]bool, len(vtxos))
+		for _, v := range vtxos {
+			if !v.Preconfirmed {
+				continue
+			}
+			if seen[v.Txid] {
+				continue
+			}
+			seen[v.Txid] = true
+			if _, ok := offchainTxCache[v.Txid]; ok {
+				continue
+			}
+			missingTxids = append(missingTxids, v.Txid)
+		}
+		if len(missingTxids) > 0 {
+			offchainTxs, err := offchainTxRepo.GetOffchainTxsByTxids(ctx, missingTxids)
+			if err != nil {
+				return err
+			}
+			for _, tx := range offchainTxs {
+				offchainTxCache[tx.ArkTxid] = tx
 			}
 		}
 

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -892,7 +892,10 @@ func (i *indexerService) preloadByMarkers(
 			}
 			missingTxids = append(missingTxids, v.Txid)
 		}
-		if len(missingTxids) > 0 {
+		// offchainTxRepo may be nil in test helpers that do not wire up the
+		// offchain-tx repo. Skip the piggyback in that case — the walk loop
+		// will fall back to its own in-loop bulk fetch for any cache misses.
+		if len(missingTxids) > 0 && offchainTxRepo != nil {
 			offchainTxs, err := offchainTxRepo.GetOffchainTxsByTxids(ctx, missingTxids)
 			if err != nil {
 				return err

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -792,14 +792,14 @@ func (i *indexerService) walkVtxoChain(
 	walkTotal := time.Since(walkStart)
 	tOther := walkTotal - tEnsureVtxos - tBulkOffchain - tSingleOffchain - tPsbtDeser - tVtxoTree
 	log.WithFields(log.Fields{
-		"total":           walkTotal,
-		"ensureVtxos":     tEnsureVtxos,
-		"bulkOffchainTx":  tBulkOffchain,
+		"total":            walkTotal,
+		"ensureVtxos":      tEnsureVtxos,
+		"bulkOffchainTx":   tBulkOffchain,
 		"singleOffchainTx": tSingleOffchain,
-		"psbtDeser":       tPsbtDeser,
-		"vtxoTree":        tVtxoTree,
-		"other":           tOther,
-		"chainLen":        len(chain),
+		"psbtDeser":        tPsbtDeser,
+		"vtxoTree":         tVtxoTree,
+		"other":            tOther,
+		"chainLen":         len(chain),
 	}).Info("walkVtxoChain timing breakdown")
 	return chain, allOutpoints, "", nil
 }

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -572,10 +572,6 @@ func (i *indexerService) walkVtxoChain(
 	offchainTxCache := make(map[string]*domain.OffchainTx)
 	allOutpoints := make([]Outpoint, 0)
 
-	// Timing accumulators.
-	var tEnsureVtxos, tBulkOffchain, tSingleOffchain, tPsbtDeser, tVtxoTree time.Duration
-	walkStart := time.Now()
-
 	// Lazy cache for VTXOs loaded during this page.
 	vtxoCache := make(map[string]domain.Vtxo)
 	loadedMarkers := make(map[string]bool)
@@ -592,11 +588,9 @@ func (i *indexerService) walkVtxoChain(
 	}
 
 	for len(nextVtxos) > 0 {
-		t0 := time.Now()
 		if err := i.ensureVtxosCached(ctx, nextVtxos, vtxoCache, loadedMarkers); err != nil {
 			return nil, nil, "", err
 		}
-		tEnsureVtxos += time.Since(t0)
 
 		vtxos := make([]domain.Vtxo, 0, len(nextVtxos))
 		for _, op := range nextVtxos {
@@ -625,9 +619,7 @@ func (i *indexerService) walkVtxoChain(
 				txids = append(txids, txid)
 			}
 
-			t1 := time.Now()
 			offchainTxs, err := i.repoManager.OffchainTxs().GetOffchainTxsByTxids(ctx, txids)
-			tBulkOffchain += time.Since(t1)
 			if err != nil {
 				return nil, nil, "", fmt.Errorf("failed to retrieve offchain txs: %s", err)
 			}
@@ -668,10 +660,8 @@ func (i *indexerService) walkVtxoChain(
 			if vtxo.Preconfirmed {
 				offchainTx, ok := offchainTxCache[vtxo.Txid]
 				if !ok {
-					t2 := time.Now()
 					var err error
 					offchainTx, err = i.repoManager.OffchainTxs().GetOffchainTx(ctx, vtxo.Txid)
-					tSingleOffchain += time.Since(t2)
 					if err != nil {
 						return nil, nil, "", fmt.Errorf("failed to retrieve offchain tx: %s", err)
 					}
@@ -685,7 +675,6 @@ func (i *indexerService) walkVtxoChain(
 				}
 
 				checkpointTxs := make([]ChainTx, 0, len(offchainTx.CheckpointTxs))
-				t3 := time.Now()
 				for _, b64 := range offchainTx.CheckpointTxs {
 					ptx, err := psbt.NewFromRawBytes(strings.NewReader(b64), true)
 					if err != nil {
@@ -715,7 +704,6 @@ func (i *indexerService) walkVtxoChain(
 						}
 					}
 				}
-				tPsbtDeser += time.Since(t3)
 
 				chain = append(chain, chainTx)
 				chain = append(chain, checkpointTxs...)
@@ -724,7 +712,6 @@ func (i *indexerService) walkVtxoChain(
 
 			// if the vtxo is not preconfirmed, it means it's a leaf of a batch tree
 			// add the branch until the commitment tx
-			t4 := time.Now()
 			flatVtxoTree, err := i.GetVtxoTree(ctx, Outpoint{
 				Txid: vtxo.RootCommitmentTxid, VOut: 0,
 			}, nil)
@@ -748,7 +735,6 @@ func (i *indexerService) walkVtxoChain(
 			}); err != nil {
 				return nil, nil, "", err
 			}
-			tVtxoTree += time.Since(t4)
 
 			// reverse fromRootToVtxo
 			fromVtxoToRoot := make([]ChainTx, 0, len(fromRootToVtxo))
@@ -788,19 +774,6 @@ func (i *indexerService) walkVtxoChain(
 		nextVtxos = newNextVtxos
 	}
 
-	// Chain exhausted — no more pages.
-	walkTotal := time.Since(walkStart)
-	tOther := walkTotal - tEnsureVtxos - tBulkOffchain - tSingleOffchain - tPsbtDeser - tVtxoTree
-	log.WithFields(log.Fields{
-		"total":            walkTotal,
-		"ensureVtxos":      tEnsureVtxos,
-		"bulkOffchainTx":   tBulkOffchain,
-		"singleOffchainTx": tSingleOffchain,
-		"psbtDeser":        tPsbtDeser,
-		"vtxoTree":         tVtxoTree,
-		"other":            tOther,
-		"chainLen":         len(chain),
-	}).Info("walkVtxoChain timing breakdown")
 	return chain, allOutpoints, "", nil
 }
 

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -569,6 +569,7 @@ func (i *indexerService) walkVtxoChain(
 	chain := make([]ChainTx, 0)
 	nextVtxos := frontier
 	visited := make(map[string]bool)
+	offchainTxCache := make(map[string]*domain.OffchainTx)
 	allOutpoints := make([]Outpoint, 0)
 
 	// Lazy cache for VTXOs loaded during this page.
@@ -601,6 +602,33 @@ func (i *indexerService) walkVtxoChain(
 			return nil, nil, "", fmt.Errorf("vtxo not found for outpoint: %v", nextVtxos)
 		}
 
+		missingOffchainTxids := make(map[string]struct{})
+		for _, vtxo := range vtxos {
+			if !vtxo.Preconfirmed {
+				continue
+			}
+			if _, ok := offchainTxCache[vtxo.Txid]; ok {
+				continue
+			}
+			missingOffchainTxids[vtxo.Txid] = struct{}{}
+		}
+
+		if len(missingOffchainTxids) > 0 {
+			txids := make([]string, 0, len(missingOffchainTxids))
+			for txid := range missingOffchainTxids {
+				txids = append(txids, txid)
+			}
+
+			offchainTxs, err := i.repoManager.OffchainTxs().GetOffchainTxsByTxids(ctx, txids)
+			if err != nil {
+				return nil, nil, "", fmt.Errorf("failed to retrieve offchain txs: %s", err)
+			}
+
+			for _, tx := range offchainTxs {
+				offchainTxCache[tx.ArkTxid] = tx
+			}
+		}
+
 		newNextVtxos := make([]domain.Outpoint, 0)
 		for _, vtxo := range vtxos {
 			key := vtxo.Outpoint.String()
@@ -630,9 +658,14 @@ func (i *indexerService) walkVtxoChain(
 			// also, we have to populate the newNextVtxos with the checkpoints inputs
 			// in order to continue the chain in the next iteration
 			if vtxo.Preconfirmed {
-				offchainTx, err := i.repoManager.OffchainTxs().GetOffchainTx(ctx, vtxo.Txid)
-				if err != nil {
-					return nil, nil, "", fmt.Errorf("failed to retrieve offchain tx: %s", err)
+				offchainTx, ok := offchainTxCache[vtxo.Txid]
+				if !ok {
+					var err error
+					offchainTx, err = i.repoManager.OffchainTxs().GetOffchainTx(ctx, vtxo.Txid)
+					if err != nil {
+						return nil, nil, "", fmt.Errorf("failed to retrieve offchain tx: %s", err)
+					}
+					offchainTxCache[vtxo.Txid] = offchainTx
 				}
 
 				chainTx := ChainTx{

--- a/internal/core/application/indexer_bench_test.go
+++ b/internal/core/application/indexer_bench_test.go
@@ -801,6 +801,11 @@ func (r *timingOffchainTxRepo) Close() {}
 // wall-clock breakdown. This is the in-process replacement for the server-side
 // timing log that previously lived in walkVtxoChain.
 //
+// The repos use an in-memory backing store and inject a fixed per-call
+// simulatedLatency via time.Sleep, so the absolute numbers in the breakdown
+// do NOT reflect real DB cost — they are only meaningful as relative phase
+// proportions under a uniform latency assumption.
+//
 // Run with:
 //
 //	go test -v -run TestVtxoChainTimingBreakdown ./internal/core/application/...
@@ -843,23 +848,28 @@ func TestVtxoChainTimingBreakdown(t *testing.T) {
 }
 
 // wrappedRepoManager is a minimal RepoManager that exposes only the repos
-// walkVtxoChain touches. Other accessors return nil / zero values since the
-// indexer never calls them in this test path.
+// walkVtxoChain touches. Unwired accessors panic with a descriptive message
+// instead of returning nil, so an accidental dependency on one of them
+// surfaces as a clear failure rather than a nil-pointer dereference.
 type wrappedRepoManager struct {
 	vtxos       domain.VtxoRepository
 	markers     domain.MarkerRepository
 	offchainTxs domain.OffchainTxRepository
 }
 
-func (m *wrappedRepoManager) Events() domain.EventRepository             { return nil }
-func (m *wrappedRepoManager) Rounds() domain.RoundRepository             { return nil }
-func (m *wrappedRepoManager) Vtxos() domain.VtxoRepository               { return m.vtxos }
-func (m *wrappedRepoManager) Markers() domain.MarkerRepository           { return m.markers }
+func (m *wrappedRepoManager) Events() domain.EventRepository { panic("Events: not wired") }
+func (m *wrappedRepoManager) Rounds() domain.RoundRepository { panic("Rounds: not wired") }
+func (m *wrappedRepoManager) Vtxos() domain.VtxoRepository   { return m.vtxos }
+func (m *wrappedRepoManager) Markers() domain.MarkerRepository {
+	return m.markers
+}
 func (m *wrappedRepoManager) ScheduledSession() domain.ScheduledSessionRepo {
-	return nil
+	panic("ScheduledSession: not wired")
 }
 func (m *wrappedRepoManager) OffchainTxs() domain.OffchainTxRepository { return m.offchainTxs }
-func (m *wrappedRepoManager) Convictions() domain.ConvictionRepository { return nil }
-func (m *wrappedRepoManager) Assets() domain.AssetRepository           { return nil }
-func (m *wrappedRepoManager) Fees() domain.FeeRepository               { return nil }
-func (m *wrappedRepoManager) Close()                                   {}
+func (m *wrappedRepoManager) Convictions() domain.ConvictionRepository {
+	panic("Convictions: not wired")
+}
+func (m *wrappedRepoManager) Assets() domain.AssetRepository { panic("Assets: not wired") }
+func (m *wrappedRepoManager) Fees() domain.FeeRepository     { panic("Fees: not wired") }
+func (m *wrappedRepoManager) Close()                         {}

--- a/internal/core/application/indexer_bench_test.go
+++ b/internal/core/application/indexer_bench_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/arkade-os/arkd/internal/core/domain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
 )
 
 // Lightweight fake repos for benchmarks — no testify/mock overhead.
@@ -92,12 +95,24 @@ func (r *benchOffchainTxRepo) GetOffchainTx(
 	return &domain.OffchainTx{CheckpointTxs: map[string]string{}}, nil
 }
 
+func (r *benchOffchainTxRepo) GetOffchainTxsByTxids(
+	_ context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	result := make([]*domain.OffchainTx, 0, len(txids))
+	for _, txid := range txids {
+		if tx, ok := r.txs[txid]; ok {
+			result = append(result, tx)
+		}
+	}
+	return result, nil
+}
+
 func (r *benchOffchainTxRepo) Close() {}
 
 type benchRepoManager struct {
 	vtxoRepo     *benchVtxoRepo
 	markerRepo   *benchMarkerRepo
-	offchainRepo *benchOffchainTxRepo
+	offchainRepo domain.OffchainTxRepository
 }
 
 func (m *benchRepoManager) Events() domain.EventRepository   { return nil }
@@ -413,4 +428,218 @@ func BenchmarkCheckpointPSBTParse(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// countingOffchainTxRepo wraps benchOffchainTxRepo and counts calls.
+type countingOffchainTxRepo struct {
+	inner          *benchOffchainTxRepo
+	singleCalls    atomic.Int64
+	bulkCalls      atomic.Int64
+	latencyPerCall time.Duration
+}
+
+func (r *countingOffchainTxRepo) GetOffchainTx(
+	ctx context.Context, txid string,
+) (*domain.OffchainTx, error) {
+	r.singleCalls.Add(1)
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetOffchainTx(ctx, txid)
+}
+
+func (r *countingOffchainTxRepo) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	r.bulkCalls.Add(1)
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall) // one round-trip regardless of batch size
+	}
+	return r.inner.GetOffchainTxsByTxids(ctx, txids)
+}
+
+func (r *countingOffchainTxRepo) AddOrUpdateOffchainTx(
+	_ context.Context, _ *domain.OffchainTx,
+) error {
+	return nil
+}
+
+func (r *countingOffchainTxRepo) Close() {}
+
+func (r *countingOffchainTxRepo) reset() {
+	r.singleCalls.Store(0)
+	r.bulkCalls.Store(0)
+}
+
+// noBulkOffchainTxRepo is like benchOffchainTxRepo but GetOffchainTxsByTxids
+// always returns empty, forcing the fallback to individual GetOffchainTx calls.
+// This simulates the pre-optimization behavior.
+type noBulkOffchainTxRepo struct {
+	countingOffchainTxRepo
+}
+
+func (r *noBulkOffchainTxRepo) GetOffchainTxsByTxids(
+	_ context.Context, _ []string,
+) ([]*domain.OffchainTx, error) {
+	r.bulkCalls.Add(1)
+	return []*domain.OffchainTx{}, nil
+}
+
+// TestBulkOffchainTxReducesDBCalls verifies that the bulk prefetch reduces the
+// number of DB round-trips. Uses a fanout tree where each iteration processes
+// multiple VTXOs — bulk fetches all offchain txs in one call per iteration
+// instead of one call per VTXO.
+func TestBulkOffchainTxReducesDBCalls(t *testing.T) {
+	const depth = 8 // 2^9 - 1 = 511 VTXOs
+	ctx := context.Background()
+
+	// Build fanout tree data (reuse the helper's repo setup).
+	n := (1 << (depth + 1)) - 1
+	vtxoRepo := &benchVtxoRepo{vtxos: make(map[string]domain.Vtxo, n)}
+	innerRepo := &benchOffchainTxRepo{txs: make(map[string]*domain.OffchainTx, n)}
+
+	for i := 0; i < n; i++ {
+		tid := benchTxid(i)
+		vtxoRepo.vtxos[fmt.Sprintf("%s:0", tid)] = domain.Vtxo{
+			Outpoint:     domain.Outpoint{Txid: tid, VOut: 0},
+			Preconfirmed: true,
+			ExpiresAt:    int64(1000 + i),
+		}
+		left := 2*i + 1
+		right := 2*i + 2
+		if left < n && right < n {
+			innerRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid: tid,
+				CheckpointTxs: map[string]string{
+					fmt.Sprintf("cp-l-%d", i): benchCheckpointPSBT(benchTxid(left), 0),
+					fmt.Sprintf("cp-r-%d", i): benchCheckpointPSBT(benchTxid(right), 0),
+				},
+			}
+		} else {
+			innerRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid:       tid,
+				CheckpointTxs: map[string]string{},
+			}
+		}
+	}
+
+	start := Outpoint{Txid: benchTxid(0), VOut: 0}
+
+	// With bulk fetch (current behavior).
+	bulkRepo := &countingOffchainTxRepo{inner: innerRepo}
+	svc := &indexerService{repoManager: &benchRepoManager{
+		vtxoRepo: vtxoRepo, offchainRepo: bulkRepo,
+	}}
+	resp, err := svc.GetVtxoChain(ctx, "", start, nil, "")
+	require.NoError(t, err)
+
+	bulkSingle := bulkRepo.singleCalls.Load()
+	bulkBulk := bulkRepo.bulkCalls.Load()
+
+	// Without bulk fetch (simulated pre-optimization: bulk returns empty).
+	noBulkRepo := &noBulkOffchainTxRepo{countingOffchainTxRepo{inner: innerRepo}}
+	svc2 := &indexerService{repoManager: &benchRepoManager{
+		vtxoRepo: vtxoRepo, offchainRepo: noBulkRepo,
+	}}
+	resp2, err := svc2.GetVtxoChain(ctx, "", start, nil, "")
+	require.NoError(t, err)
+	require.Equal(t, len(resp.Chain), len(resp2.Chain))
+
+	noBulkSingle := noBulkRepo.singleCalls.Load()
+
+	t.Logf("fanout tree: depth=%d, %d VTXOs", depth, n)
+	t.Logf("WITH bulk:    %d bulk calls, %d individual calls (total round-trips: %d)",
+		bulkBulk, bulkSingle, bulkBulk+bulkSingle)
+	t.Logf("WITHOUT bulk: %d individual calls (total round-trips: %d)",
+		noBulkSingle, noBulkSingle)
+
+	// With bulk fetch, individual calls should be 0 (all served from cache).
+	require.Zero(t, bulkSingle, "bulk prefetch should eliminate individual GetOffchainTx calls")
+	// Bulk calls = depth+1 iterations (one per tree level), much fewer than N VTXOs.
+	require.LessOrEqual(t, bulkBulk, int64(depth+1),
+		"bulk calls should equal tree depth (one per iteration)")
+	// Without bulk, individual calls == N (one per preconfirmed VTXO).
+	require.Equal(t, int64(n), noBulkSingle,
+		"without bulk, every VTXO triggers an individual call")
+}
+
+// BenchmarkOffchainTxBulkVsSingle compares chain traversal with and without
+// the bulk offchain tx prefetch, using simulated DB latency to make the
+// round-trip reduction visible in wall-clock time. Uses a fanout tree
+// (depth 8, 511 VTXOs) where each iteration processes an exponentially
+// growing number of VTXOs — the bulk path does 9 round-trips vs 511
+// individual calls without it.
+func BenchmarkOffchainTxBulkVsSingle(b *testing.B) {
+	const depth = 8
+	const simulatedLatency = 50 * time.Microsecond
+
+	n := (1 << (depth + 1)) - 1
+	vtxoRepo := &benchVtxoRepo{vtxos: make(map[string]domain.Vtxo, n)}
+	innerRepo := &benchOffchainTxRepo{txs: make(map[string]*domain.OffchainTx, n)}
+
+	for i := 0; i < n; i++ {
+		tid := benchTxid(i)
+		vtxoRepo.vtxos[fmt.Sprintf("%s:0", tid)] = domain.Vtxo{
+			Outpoint:     domain.Outpoint{Txid: tid, VOut: 0},
+			Preconfirmed: true,
+			ExpiresAt:    int64(1000 + i),
+		}
+		left := 2*i + 1
+		right := 2*i + 2
+		if left < n && right < n {
+			innerRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid: tid,
+				CheckpointTxs: map[string]string{
+					fmt.Sprintf("cp-l-%d", i): benchCheckpointPSBT(benchTxid(left), 0),
+					fmt.Sprintf("cp-r-%d", i): benchCheckpointPSBT(benchTxid(right), 0),
+				},
+			}
+		} else {
+			innerRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid:       tid,
+				CheckpointTxs: map[string]string{},
+			}
+		}
+	}
+
+	start := Outpoint{Txid: benchTxid(0), VOut: 0}
+	ctx := context.Background()
+
+	b.Run(fmt.Sprintf("bulk_prefetch/%d_vtxos", n), func(b *testing.B) {
+		repo := &countingOffchainTxRepo{inner: innerRepo, latencyPerCall: simulatedLatency}
+		svc := &indexerService{repoManager: &benchRepoManager{
+			vtxoRepo: vtxoRepo, offchainRepo: repo,
+		}}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			repo.reset()
+			_, err := svc.GetVtxoChain(ctx, "", start, nil, "")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(repo.bulkCalls.Load())/float64(b.N), "bulk_calls/op")
+		b.ReportMetric(float64(repo.singleCalls.Load())/float64(b.N), "single_calls/op")
+	})
+
+	b.Run(fmt.Sprintf("no_bulk_fallback/%d_vtxos", n), func(b *testing.B) {
+		repo := &noBulkOffchainTxRepo{countingOffchainTxRepo{inner: innerRepo, latencyPerCall: simulatedLatency}}
+		svc := &indexerService{repoManager: &benchRepoManager{
+			vtxoRepo: vtxoRepo, offchainRepo: repo,
+		}}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			repo.reset()
+			_, err := svc.GetVtxoChain(ctx, "", start, nil, "")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(repo.bulkCalls.Load())/float64(b.N), "bulk_calls/op")
+		b.ReportMetric(float64(repo.singleCalls.Load())/float64(b.N), "single_calls/op")
+	})
 }

--- a/internal/core/application/indexer_bench_test.go
+++ b/internal/core/application/indexer_bench_test.go
@@ -3,7 +3,9 @@ package application
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -187,12 +189,16 @@ func buildLinearChain(n int, withMarkers bool) (*indexerService, domain.Outpoint
 
 		if i < n-1 {
 			offchainRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid: tid,
 				CheckpointTxs: map[string]string{
 					fmt.Sprintf("cp-%d", i): benchCheckpointPSBT(benchTxid(i+1), 0),
 				},
 			}
 		} else {
-			offchainRepo.txs[tid] = &domain.OffchainTx{CheckpointTxs: map[string]string{}}
+			offchainRepo.txs[tid] = &domain.OffchainTx{
+				ArkTxid:       tid,
+				CheckpointTxs: map[string]string{},
+			}
 		}
 	}
 
@@ -643,3 +649,217 @@ func BenchmarkOffchainTxBulkVsSingle(b *testing.B) {
 		b.ReportMetric(float64(repo.singleCalls.Load())/float64(b.N), "single_calls/op")
 	})
 }
+
+// phaseTimings accumulates per-phase wall-clock time and call counts across
+// the wrapped repo methods. Safe for concurrent recording.
+type phaseTimings struct {
+	mu     sync.Mutex
+	totals map[string]time.Duration
+	counts map[string]int
+}
+
+func newPhaseTimings() *phaseTimings {
+	return &phaseTimings{
+		totals: make(map[string]time.Duration),
+		counts: make(map[string]int),
+	}
+}
+
+func (p *phaseTimings) record(phase string, d time.Duration) {
+	p.mu.Lock()
+	p.totals[phase] += d
+	p.counts[phase]++
+	p.mu.Unlock()
+}
+
+func (p *phaseTimings) log(t *testing.T, header string, wall time.Duration) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	phases := make([]string, 0, len(p.totals))
+	var repoTotal time.Duration
+	for name, d := range p.totals {
+		phases = append(phases, name)
+		repoTotal += d
+	}
+	sort.Strings(phases)
+
+	t.Logf("%s", header)
+	t.Logf("  %-32s %12s", "wall clock (GetVtxoChain)", wall)
+	for _, name := range phases {
+		t.Logf("  %-32s %12s  (%d calls)", name, p.totals[name], p.counts[name])
+	}
+	t.Logf("  %-32s %12s", "sum of repo phases", repoTotal)
+	t.Logf("  %-32s %12s", "other (psbt parse + overhead)", wall-repoTotal)
+}
+
+// timingVtxoRepo wraps a VtxoRepository and records per-call latency into a
+// shared phaseTimings. An optional per-call latency simulates DB round-trip
+// cost so the relative phase times are visible when running against fakes.
+type timingVtxoRepo struct {
+	domain.VtxoRepository
+	inner          domain.VtxoRepository
+	t              *phaseTimings
+	latencyPerCall time.Duration
+}
+
+func (r *timingVtxoRepo) GetVtxos(
+	ctx context.Context, outpoints []domain.Outpoint,
+) ([]domain.Vtxo, error) {
+	start := time.Now()
+	defer func() { r.t.record("Vtxos.GetVtxos", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetVtxos(ctx, outpoints)
+}
+
+func (r *timingVtxoRepo) Close() {}
+
+type timingMarkerRepo struct {
+	domain.MarkerRepository
+	inner          domain.MarkerRepository
+	t              *phaseTimings
+	latencyPerCall time.Duration
+}
+
+func (r *timingMarkerRepo) GetVtxoChainByMarkers(
+	ctx context.Context, markerIDs []string,
+) ([]domain.Vtxo, error) {
+	start := time.Now()
+	defer func() { r.t.record("Markers.GetVtxoChainByMarkers", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetVtxoChainByMarkers(ctx, markerIDs)
+}
+
+func (r *timingMarkerRepo) GetMarkersByIds(
+	ctx context.Context, ids []string,
+) ([]domain.Marker, error) {
+	start := time.Now()
+	defer func() { r.t.record("Markers.GetMarkersByIds", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetMarkersByIds(ctx, ids)
+}
+
+func (r *timingMarkerRepo) GetVtxosByMarker(
+	ctx context.Context, markerID string,
+) ([]domain.Vtxo, error) {
+	start := time.Now()
+	defer func() { r.t.record("Markers.GetVtxosByMarker", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetVtxosByMarker(ctx, markerID)
+}
+
+func (r *timingMarkerRepo) Close() {}
+
+type timingOffchainTxRepo struct {
+	domain.OffchainTxRepository
+	inner          domain.OffchainTxRepository
+	t              *phaseTimings
+	latencyPerCall time.Duration
+}
+
+func (r *timingOffchainTxRepo) GetOffchainTx(
+	ctx context.Context, txid string,
+) (*domain.OffchainTx, error) {
+	start := time.Now()
+	defer func() { r.t.record("OffchainTxs.GetOffchainTx", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetOffchainTx(ctx, txid)
+}
+
+func (r *timingOffchainTxRepo) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	start := time.Now()
+	defer func() { r.t.record("OffchainTxs.GetOffchainTxsByTxids", time.Since(start)) }()
+	if r.latencyPerCall > 0 {
+		time.Sleep(r.latencyPerCall)
+	}
+	return r.inner.GetOffchainTxsByTxids(ctx, txids)
+}
+
+func (r *timingOffchainTxRepo) AddOrUpdateOffchainTx(
+	_ context.Context, _ *domain.OffchainTx,
+) error {
+	return nil
+}
+
+func (r *timingOffchainTxRepo) Close() {}
+
+// TestVtxoChainTimingBreakdown builds a deep linear chain and runs
+// GetVtxoChain against it with timing-decorated repos, logging a per-phase
+// wall-clock breakdown. This is the in-process replacement for the server-side
+// timing log that previously lived in walkVtxoChain.
+//
+// Run with:
+//
+//	go test -v -run TestVtxoChainTimingBreakdown ./internal/core/application/...
+func TestVtxoChainTimingBreakdown(t *testing.T) {
+	const (
+		chainLen         = 10000
+		simulatedLatency = 50 * time.Microsecond
+	)
+
+	ctx := context.Background()
+
+	// Reuse buildLinearChain to get the same data layout the perf test produces,
+	// then swap its repo manager for a timing-decorated one.
+	svc, start := buildLinearChain(chainLen, true)
+	inner := svc.repoManager.(*benchRepoManager)
+
+	timings := newPhaseTimings()
+	svc.repoManager = &wrappedRepoManager{
+		vtxos: &timingVtxoRepo{
+			inner: inner.vtxoRepo, t: timings, latencyPerCall: simulatedLatency,
+		},
+		markers: &timingMarkerRepo{
+			inner: inner.markerRepo, t: timings, latencyPerCall: simulatedLatency,
+		},
+		offchainTxs: &timingOffchainTxRepo{
+			inner: inner.offchainRepo, t: timings, latencyPerCall: simulatedLatency,
+		},
+	}
+
+	wallStart := time.Now()
+	resp, err := svc.GetVtxoChain(ctx, "", start, nil, "")
+	wall := time.Since(wallStart)
+	require.NoError(t, err)
+	require.Equal(t, 2*chainLen-1, len(resp.Chain))
+
+	timings.log(t, fmt.Sprintf(
+		"GetVtxoChain timing breakdown: linear chain n=%d, simulated repo latency=%s",
+		chainLen, simulatedLatency,
+	), wall)
+}
+
+// wrappedRepoManager is a minimal RepoManager that exposes only the repos
+// walkVtxoChain touches. Other accessors return nil / zero values since the
+// indexer never calls them in this test path.
+type wrappedRepoManager struct {
+	vtxos       domain.VtxoRepository
+	markers     domain.MarkerRepository
+	offchainTxs domain.OffchainTxRepository
+}
+
+func (m *wrappedRepoManager) Events() domain.EventRepository             { return nil }
+func (m *wrappedRepoManager) Rounds() domain.RoundRepository             { return nil }
+func (m *wrappedRepoManager) Vtxos() domain.VtxoRepository               { return m.vtxos }
+func (m *wrappedRepoManager) Markers() domain.MarkerRepository           { return m.markers }
+func (m *wrappedRepoManager) ScheduledSession() domain.ScheduledSessionRepo {
+	return nil
+}
+func (m *wrappedRepoManager) OffchainTxs() domain.OffchainTxRepository { return m.offchainTxs }
+func (m *wrappedRepoManager) Convictions() domain.ConvictionRepository { return nil }
+func (m *wrappedRepoManager) Assets() domain.AssetRepository           { return nil }
+func (m *wrappedRepoManager) Fees() domain.FeeRepository               { return nil }
+func (m *wrappedRepoManager) Close()                                   {}

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -585,6 +585,71 @@ func TestGetVtxoChain(t *testing.T) {
 			rounds.AssertExpectations(t)
 			vtxos.AssertExpectations(t)
 		})
+
+		t.Run("preconfirmed chain bulk-loads offchain txs", func(t *testing.T) {
+			vtxoOutpoint := Outpoint{Txid: testTxids[0], VOut: 0}
+			offchainTxid := vtxoOutpoint.Txid
+			checkpointB64 := buildCheckpointTxSpending(t, vtxoOutpoint.Txid, vtxoOutpoint.VOut)
+
+			vtxos := &mockedVtxoRepo{}
+			vtxos.On("GetVtxos", mock.Anything, []domain.Outpoint{vtxoOutpoint}).
+				Return([]domain.Vtxo{{
+					Outpoint:     domain.Outpoint{Txid: vtxoOutpoint.Txid, VOut: vtxoOutpoint.VOut},
+					Preconfirmed: true,
+				}}, nil)
+
+			offchainRepo := &mockedOffchainTxRepo{}
+			offchainRepo.On("GetOffchainTxsByTxids", mock.Anything, []string{offchainTxid}).
+				Return([]*domain.OffchainTx{{
+					ArkTxid: offchainTxid,
+					CheckpointTxs: map[string]string{
+						"cp": checkpointB64,
+					},
+				}}, nil)
+
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, vtxos, nil, offchainRepo)
+
+			chain, _, _, err := indexer.walkVtxoChain(t.Context(), []domain.Outpoint{vtxoOutpoint}, 1000)
+			require.NoError(t, err)
+			require.NotEmpty(t, chain)
+
+			offchainRepo.AssertNotCalled(t, "GetOffchainTx", mock.Anything, offchainTxid)
+			offchainRepo.AssertExpectations(t)
+			vtxos.AssertExpectations(t)
+		})
+
+		t.Run("preconfirmed chain falls back to single fetch on cache miss", func(t *testing.T) {
+			vtxoOutpoint := Outpoint{Txid: testTxids[0], VOut: 0}
+			offchainTxid := vtxoOutpoint.Txid
+			checkpointB64 := buildCheckpointTxSpending(t, vtxoOutpoint.Txid, vtxoOutpoint.VOut)
+
+			vtxos := &mockedVtxoRepo{}
+			vtxos.On("GetVtxos", mock.Anything, []domain.Outpoint{vtxoOutpoint}).
+				Return([]domain.Vtxo{{
+					Outpoint:     domain.Outpoint{Txid: vtxoOutpoint.Txid, VOut: vtxoOutpoint.VOut},
+					Preconfirmed: true,
+				}}, nil)
+
+			offchainRepo := &mockedOffchainTxRepo{}
+			offchainRepo.On("GetOffchainTxsByTxids", mock.Anything, []string{offchainTxid}).
+				Return([]*domain.OffchainTx{}, nil)
+			offchainRepo.On("GetOffchainTx", mock.Anything, offchainTxid).
+				Return(&domain.OffchainTx{
+					ArkTxid: offchainTxid,
+					CheckpointTxs: map[string]string{
+						"cp": checkpointB64,
+					},
+				}, nil)
+
+			indexer := newTestIndexer(t, privkey, exposurePrivate, nil, vtxos, nil, offchainRepo)
+
+			chain, _, _, err := indexer.walkVtxoChain(t.Context(), []domain.Outpoint{vtxoOutpoint}, 1000)
+			require.NoError(t, err)
+			require.NotEmpty(t, chain)
+
+			offchainRepo.AssertExpectations(t)
+			vtxos.AssertExpectations(t)
+		})
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -927,6 +992,7 @@ func TestStripSignerSignatures(t *testing.T) {
 func newTestIndexer(
 	t *testing.T, privkey *btcec.PrivateKey, exposure exposure,
 	rounds *mockedRoundRepo, vtxos *mockedVtxoRepo, wallet *mockedWallet,
+	offchainRepos ...*mockedOffchainTxRepo,
 ) *indexerService {
 	t.Helper()
 
@@ -939,6 +1005,9 @@ func newTestIndexer(
 	}
 	if vtxos != nil {
 		repo.On("Vtxos").Return(vtxos)
+	}
+	if len(offchainRepos) > 0 && offchainRepos[0] != nil {
+		repo.On("OffchainTxs").Return(offchainRepos[0])
 	}
 
 	cache := newTokenCache(defaultAuthTokenTTL)
@@ -993,6 +1062,25 @@ func buildTestTreeTxs(t *testing.T) (rootTxid, leafTxid string, flatTree arktree
 		{Txid: leafTxid, Tx: leafB64, Children: nil},
 	}
 	return
+}
+
+func buildCheckpointTxSpending(t *testing.T, prevTxid string, prevVout uint32) string {
+	t.Helper()
+
+	prevHash, err := chainhash.NewHashFromStr(prevTxid)
+	require.NoError(t, err)
+
+	ptx, err := psbt.New(
+		[]*wire.OutPoint{{Hash: *prevHash, Index: prevVout}},
+		[]*wire.TxOut{{Value: 1000, PkScript: []byte{txscript.OP_TRUE}}},
+		2, 0, []uint32{wire.MaxTxInSequenceNum},
+	)
+	require.NoError(t, err)
+
+	b64, err := ptx.B64Encode()
+	require.NoError(t, err)
+
+	return b64
 }
 
 // buildTestIntent creates a valid signed intent proof that passes intent.Verify.
@@ -1150,6 +1238,36 @@ func (m *mockedRepoManager) Vtxos() domain.VtxoRepository {
 		return v.(domain.VtxoRepository)
 	}
 	return nil
+}
+
+func (m *mockedRepoManager) OffchainTxs() domain.OffchainTxRepository {
+	if v := m.Called().Get(0); v != nil {
+		return v.(domain.OffchainTxRepository)
+	}
+	return nil
+}
+
+type mockedOffchainTxRepo struct {
+	mock.Mock
+	domain.OffchainTxRepository // unimplemented methods panic on call
+}
+
+func (m *mockedOffchainTxRepo) GetOffchainTx(ctx context.Context, txid string) (*domain.OffchainTx, error) {
+	args := m.Called(ctx, txid)
+	if v := args.Get(0); v != nil {
+		return v.(*domain.OffchainTx), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockedOffchainTxRepo) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	args := m.Called(ctx, txids)
+	if v := args.Get(0); v != nil {
+		return v.([]*domain.OffchainTx), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 type mockedWallet struct {

--- a/internal/core/application/indexer_test.go
+++ b/internal/core/application/indexer_test.go
@@ -303,6 +303,16 @@ func (m *mockOffchainTxRepoForIndexer) GetOffchainTx(
 	return args.Get(0).(*domain.OffchainTx), args.Error(1)
 }
 
+func (m *mockOffchainTxRepoForIndexer) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	args := m.Called(ctx, txids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.OffchainTx), args.Error(1)
+}
+
 func (m *mockOffchainTxRepoForIndexer) AddOrUpdateOffchainTx(
 	ctx context.Context, offchainTx *domain.OffchainTx,
 ) error {
@@ -361,6 +371,10 @@ func newChainTestIndexerWithOffchain() (
 	vtxoRepo := &mockVtxoRepoForIndexer{}
 	markerRepo := &mockMarkerRepoForIndexer{}
 	offchainTxRepo := &mockOffchainTxRepoForIndexer{}
+	// Default: bulk fetch returns empty so the fallback to GetOffchainTx is used.
+	// Tests that want to verify bulk behavior can override with a more specific expectation.
+	offchainTxRepo.On("GetOffchainTxsByTxids", mock.Anything, mock.Anything).
+		Return([]*domain.OffchainTx{}, nil).Maybe()
 	repoManager := &mockRepoManagerForIndexer{
 		vtxos: vtxoRepo, markers: markerRepo, offchainTxs: offchainTxRepo,
 	}
@@ -737,12 +751,23 @@ func setupPreconfirmedChain(
 	cpA := makeCheckpointPSBT(t, txidB, 0)
 	cpB := makeCheckpointPSBT(t, txidC, 0)
 
+	offchainTxA := &domain.OffchainTx{ArkTxid: txidA, CheckpointTxs: map[string]string{"cp-a": cpA}}
+	offchainTxB := &domain.OffchainTx{ArkTxid: txidB, CheckpointTxs: map[string]string{"cp-b": cpB}}
+	offchainTxC := &domain.OffchainTx{ArkTxid: txidC, CheckpointTxs: map[string]string{}}
+
+	offchainTxRepo.On("GetOffchainTxsByTxids", ctx, []string{txidA}).
+		Return([]*domain.OffchainTx{offchainTxA}, nil).Maybe()
+	offchainTxRepo.On("GetOffchainTxsByTxids", ctx, []string{txidB}).
+		Return([]*domain.OffchainTx{offchainTxB}, nil).Maybe()
+	offchainTxRepo.On("GetOffchainTxsByTxids", ctx, []string{txidC}).
+		Return([]*domain.OffchainTx{offchainTxC}, nil).Maybe()
+
 	offchainTxRepo.On("GetOffchainTx", ctx, txidA).
-		Return(&domain.OffchainTx{CheckpointTxs: map[string]string{"cp-a": cpA}}, nil)
+		Return(offchainTxA, nil).Maybe()
 	offchainTxRepo.On("GetOffchainTx", ctx, txidB).
-		Return(&domain.OffchainTx{CheckpointTxs: map[string]string{"cp-b": cpB}}, nil)
+		Return(offchainTxB, nil).Maybe()
 	offchainTxRepo.On("GetOffchainTx", ctx, txidC).
-		Return(&domain.OffchainTx{CheckpointTxs: map[string]string{}}, nil)
+		Return(offchainTxC, nil).Maybe()
 
 	return Outpoint{Txid: txidA, VOut: 0}
 }
@@ -826,8 +851,11 @@ func TestGetVtxoChain_ShortChainNoToken(t *testing.T) {
 		Return([]domain.Vtxo{vtxo}, nil)
 	markerRepo.On("GetVtxosByMarker", ctx, mock.Anything).
 		Return([]domain.Vtxo{}, nil).Maybe()
+	offchainTxA := &domain.OffchainTx{ArkTxid: txidA, CheckpointTxs: map[string]string{}}
+	offchainTxRepo.On("GetOffchainTxsByTxids", ctx, []string{txidA}).
+		Return([]*domain.OffchainTx{offchainTxA}, nil)
 	offchainTxRepo.On("GetOffchainTx", ctx, txidA).
-		Return(&domain.OffchainTx{CheckpointTxs: map[string]string{}}, nil)
+		Return(offchainTxA, nil).Maybe()
 
 	// Page size larger than chain
 	page := &Page{PageSize: 100}

--- a/internal/core/application/indexer_test.go
+++ b/internal/core/application/indexer_test.go
@@ -916,7 +916,7 @@ func matchOutpoints(expected ...domain.Outpoint) interface{} {
 
 // matchIDs returns a mock.MatchedBy matcher that matches a []string argument
 // containing exactly the given IDs, regardless of order. This avoids flakes from
-// non-deterministic map iteration in preloadVtxosByMarkers.
+// non-deterministic map iteration in preloadByMarkers.
 func matchIDs(expected ...string) interface{} {
 	sorted := make([]string, len(expected))
 	copy(sorted, expected)
@@ -937,7 +937,7 @@ func matchIDs(expected ...string) interface{} {
 	})
 }
 
-// TestPreloadVtxosByMarkers_WalksMarkerChain verifies that preloadVtxosByMarkers
+// TestPreloadVtxosByMarkers_WalksMarkerChain verifies that preloadByMarkers
 // follows the marker DAG upward and populates the cache with all discovered VTXOs.
 func TestPreloadVtxosByMarkers_WalksMarkerChain(t *testing.T) {
 	_, markerRepo, indexer := newChainTestIndexer()
@@ -980,7 +980,8 @@ func TestPreloadVtxosByMarkers_WalksMarkerChain(t *testing.T) {
 		}, nil)
 
 	cache := make(map[string]domain.Vtxo)
-	err := indexer.preloadVtxosByMarkers(ctx, []domain.Vtxo{vtxoLeaf}, cache)
+	offchainCache := make(map[string]*domain.OffchainTx)
+	err := indexer.preloadByMarkers(ctx, []domain.Vtxo{vtxoLeaf}, cache, offchainCache)
 	require.NoError(t, err)
 
 	// Cache should contain the seed vtxo plus all vtxos from all marker levels.
@@ -1027,7 +1028,8 @@ func TestPreloadVtxosByMarkers_NoCycleLoop(t *testing.T) {
 		}, nil)
 
 	cache := make(map[string]domain.Vtxo)
-	err := indexer.preloadVtxosByMarkers(ctx, []domain.Vtxo{vtxo}, cache)
+	offchainCache := make(map[string]*domain.OffchainTx)
+	err := indexer.preloadByMarkers(ctx, []domain.Vtxo{vtxo}, cache, offchainCache)
 	require.NoError(t, err)
 
 	// Should terminate without looping forever.
@@ -1041,7 +1043,7 @@ func TestPreloadVtxosByMarkers_NoCycleLoop(t *testing.T) {
 }
 
 // TestGetVtxoChain_WithMarkers_UsesPreload verifies that GetVtxoChain uses
-// preloadVtxosByMarkers when VTXOs have markers, and that the main loop
+// preloadByMarkers when VTXOs have markers, and that the main loop
 // hits the cache instead of making additional DB calls.
 func TestGetVtxoChain_WithMarkers_UsesPreload(t *testing.T) {
 	vtxoRepo, markerRepo, offchainTxRepo, indexer := newChainTestIndexerWithOffchain()

--- a/internal/core/domain/offchain_tx_repo.go
+++ b/internal/core/domain/offchain_tx_repo.go
@@ -5,5 +5,6 @@ import "context"
 type OffchainTxRepository interface {
 	AddOrUpdateOffchainTx(ctx context.Context, offchainTx *OffchainTx) error
 	GetOffchainTx(ctx context.Context, txid string) (*OffchainTx, error)
+	GetOffchainTxsByTxids(ctx context.Context, txids []string) ([]*OffchainTx, error)
 	Close()
 }

--- a/internal/infrastructure/db/badger/ark_repo.go
+++ b/internal/infrastructure/db/badger/ark_repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/arkade-os/arkd/internal/core/domain"
@@ -232,6 +233,28 @@ func (r *arkRepository) GetOffchainTx(
 	ctx context.Context, txid string,
 ) (*domain.OffchainTx, error) {
 	return r.getOffchainTx(ctx, txid)
+}
+
+func (r *arkRepository) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	if len(txids) == 0 {
+		return []*domain.OffchainTx{}, nil
+	}
+
+	txs := make([]*domain.OffchainTx, 0, len(txids))
+	for _, txid := range txids {
+		tx, err := r.getOffchainTx(ctx, txid)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				continue
+			}
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+
+	return txs, nil
 }
 
 func (r *arkRepository) Close() {

--- a/internal/infrastructure/db/postgres/migration/20260409140000_checkpoint_tx_offchain_txid_index.down.sql
+++ b/internal/infrastructure/db/postgres/migration/20260409140000_checkpoint_tx_offchain_txid_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_checkpoint_tx_offchain_txid;

--- a/internal/infrastructure/db/postgres/migration/20260409140000_checkpoint_tx_offchain_txid_index.up.sql
+++ b/internal/infrastructure/db/postgres/migration/20260409140000_checkpoint_tx_offchain_txid_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_checkpoint_tx_offchain_txid
+    ON checkpoint_tx (offchain_txid);

--- a/internal/infrastructure/db/postgres/offchain_tx_repo.go
+++ b/internal/infrastructure/db/postgres/offchain_tx_repo.go
@@ -114,6 +114,62 @@ func (v *offchainTxRepository) GetOffchainTx(
 	}, nil
 }
 
+func (v *offchainTxRepository) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	if len(txids) == 0 {
+		return []*domain.OffchainTx{}, nil
+	}
+
+	rows, err := v.querier.SelectOffchainTxsByTxids(ctx, txids)
+	if err != nil {
+		return nil, err
+	}
+
+	grouped := make(map[string][]queries.OffchainTxVw)
+	for _, row := range rows {
+		grouped[row.OffchainTxVw.Txid] = append(grouped[row.OffchainTxVw.Txid], row.OffchainTxVw)
+	}
+
+	txs := make([]*domain.OffchainTx, 0, len(grouped))
+	for _, vws := range grouped {
+		vt := vws[0]
+		checkpointTxs := make(map[string]string)
+		commitmentTxids := make(map[string]string)
+		rootCommitmentTxId := ""
+		for _, vw := range vws {
+			if vw.CheckpointTxid.Valid && vw.CheckpointTx.Valid {
+				checkpointTxs[vw.CheckpointTxid.String] = vw.CheckpointTx.String
+				commitmentTxids[vw.CheckpointTxid.String] = vw.CommitmentTxid.String
+				if vw.IsRootCommitmentTxid.Valid && vw.IsRootCommitmentTxid.Bool {
+					rootCommitmentTxId = vw.CommitmentTxid.String
+				}
+			}
+		}
+		stage := domain.Stage{Code: int(vt.StageCode)}
+		if vt.FailReason.String != "" {
+			stage.Failed = true
+		}
+		if domain.OffchainTxStage(vt.StageCode) == domain.OffchainTxFinalizedStage {
+			stage.Ended = true
+		}
+		txs = append(txs, &domain.OffchainTx{
+			ArkTxid:            vt.Txid,
+			ArkTx:              vt.Tx,
+			StartingTimestamp:  vt.StartingTimestamp,
+			EndingTimestamp:    vt.EndingTimestamp,
+			ExpiryTimestamp:    vt.ExpiryTimestamp,
+			FailReason:         vt.FailReason.String,
+			Stage:              stage,
+			CheckpointTxs:      checkpointTxs,
+			CommitmentTxids:    commitmentTxids,
+			RootCommitmentTxId: rootCommitmentTxId,
+		})
+	}
+
+	return txs, nil
+}
+
 func (v *offchainTxRepository) Close() {
 	_ = v.db.Close()
 }

--- a/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
@@ -876,6 +876,50 @@ func (q *Queries) SelectOffchainTx(ctx context.Context, txid string) ([]SelectOf
 	return items, nil
 }
 
+const selectOffchainTxsByTxids = `-- name: SelectOffchainTxsByTxids :many
+SELECT offchain_tx_vw.txid, offchain_tx_vw.tx, offchain_tx_vw.starting_timestamp, offchain_tx_vw.ending_timestamp, offchain_tx_vw.expiry_timestamp, offchain_tx_vw.fail_reason, offchain_tx_vw.stage_code, offchain_tx_vw.checkpoint_txid, offchain_tx_vw.checkpoint_tx, offchain_tx_vw.commitment_txid, offchain_tx_vw.is_root_commitment_txid, offchain_tx_vw.offchain_txid FROM offchain_tx_vw WHERE txid = ANY($1::varchar[]) AND COALESCE(fail_reason, '') = ''
+`
+
+type SelectOffchainTxsByTxidsRow struct {
+	OffchainTxVw OffchainTxVw
+}
+
+func (q *Queries) SelectOffchainTxsByTxids(ctx context.Context, txids []string) ([]SelectOffchainTxsByTxidsRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectOffchainTxsByTxids, pq.Array(txids))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectOffchainTxsByTxidsRow
+	for rows.Next() {
+		var i SelectOffchainTxsByTxidsRow
+		if err := rows.Scan(
+			&i.OffchainTxVw.Txid,
+			&i.OffchainTxVw.Tx,
+			&i.OffchainTxVw.StartingTimestamp,
+			&i.OffchainTxVw.EndingTimestamp,
+			&i.OffchainTxVw.ExpiryTimestamp,
+			&i.OffchainTxVw.FailReason,
+			&i.OffchainTxVw.StageCode,
+			&i.OffchainTxVw.CheckpointTxid,
+			&i.OffchainTxVw.CheckpointTx,
+			&i.OffchainTxVw.CommitmentTxid,
+			&i.OffchainTxVw.IsRootCommitmentTxid,
+			&i.OffchainTxVw.OffchainTxid,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectPendingSpentVtxo = `-- name: SelectPendingSpentVtxo :many
 SELECT v.txid, v.vout, v.pubkey, v.amount, v.expires_at, v.created_at, v.commitment_txid, v.spent_by, v.spent, v.unrolled, v.preconfirmed, v.settled_by, v.ark_txid, v.intent_id, v.updated_at, v.depth, v.markers, v.commitments, v.swept, v.asset_id, v.asset_amount
 FROM vtxo_vw v

--- a/internal/infrastructure/db/postgres/sqlc/query.sql
+++ b/internal/infrastructure/db/postgres/sqlc/query.sql
@@ -277,6 +277,9 @@ WHERE EXISTS (
 -- name: SelectOffchainTx :many
 SELECT sqlc.embed(offchain_tx_vw) FROM offchain_tx_vw WHERE txid = @txid AND COALESCE(fail_reason, '') = '';
 
+-- name: SelectOffchainTxsByTxids :many
+SELECT sqlc.embed(offchain_tx_vw) FROM offchain_tx_vw WHERE txid = ANY(@txids::varchar[]) AND COALESCE(fail_reason, '') = '';
+
 -- name: SelectLatestScheduledSession :one
 SELECT * FROM scheduled_session ORDER BY updated_at DESC LIMIT 1;
 

--- a/internal/infrastructure/db/service_test.go
+++ b/internal/infrastructure/db/service_test.go
@@ -3434,6 +3434,15 @@ func testOffchainTxRepository(t *testing.T, svc ports.RepoManager) {
 		require.NotNil(t, offchainTx)
 		require.True(t, gotOffchainTx.IsFinalized())
 		require.Condition(t, offchainTxMatch(*offchainTx, *gotOffchainTx))
+
+		bulkFetchedTxs, err := repo.GetOffchainTxsByTxids(ctx, []string{arkTxid})
+		require.NoError(t, err)
+		require.Len(t, bulkFetchedTxs, 1)
+		require.Equal(t, arkTxid, bulkFetchedTxs[0].ArkTxid)
+
+		bulkFetchedTxs, err = repo.GetOffchainTxsByTxids(ctx, []string{"missing-txid"})
+		require.NoError(t, err)
+		require.Empty(t, bulkFetchedTxs)
 	})
 }
 

--- a/internal/infrastructure/db/service_test.go
+++ b/internal/infrastructure/db/service_test.go
@@ -3443,6 +3443,58 @@ func testOffchainTxRepository(t *testing.T, svc ports.RepoManager) {
 		bulkFetchedTxs, err = repo.GetOffchainTxsByTxids(ctx, []string{"missing-txid"})
 		require.NoError(t, err)
 		require.Empty(t, bulkFetchedTxs)
+
+		// Insert a second offchain tx so we can exercise multi-txid bulk fetch.
+		secondArkTxid := txidb
+		secondCheckpointTxid := "0000000000000000000000000000000000000000000000000000000000000005"
+		secondCheckpointPtx := "cHNldP8BAgQCAAAAAQQBAAEFAQABBgEDAfsEAgAAAAA=signed-2"
+		secondEvents := []domain.Event{
+			domain.OffchainTxRequested{
+				OffchainTxEvent: domain.OffchainTxEvent{
+					Id:   secondArkTxid,
+					Type: domain.EventTypeOffchainTxRequested,
+				},
+				StartingTimestamp: now.Unix(),
+			},
+			domain.OffchainTxAccepted{
+				OffchainTxEvent: domain.OffchainTxEvent{
+					Id:   secondArkTxid,
+					Type: domain.EventTypeOffchainTxAccepted,
+				},
+				CommitmentTxids: map[string]string{
+					secondCheckpointTxid: rootCommitmentTxid,
+				},
+				SignedCheckpointTxs: map[string]string{
+					secondCheckpointTxid: secondCheckpointPtx,
+				},
+				RootCommitmentTxid: rootCommitmentTxid,
+			},
+		}
+		secondOffchainTx := domain.NewOffchainTxFromEvents(secondEvents)
+		require.NoError(t, repo.AddOrUpdateOffchainTx(ctx, secondOffchainTx))
+
+		// Multi-txid fetch returns both, plus tolerates a missing entry.
+		bulkFetchedTxs, err = repo.GetOffchainTxsByTxids(
+			ctx, []string{arkTxid, secondArkTxid, "missing-txid"},
+		)
+		require.NoError(t, err)
+		require.Len(t, bulkFetchedTxs, 2)
+
+		got := make(map[string]*domain.OffchainTx, len(bulkFetchedTxs))
+		for _, tx := range bulkFetchedTxs {
+			got[tx.ArkTxid] = tx
+		}
+		require.Contains(t, got, arkTxid)
+		require.Contains(t, got, secondArkTxid)
+
+		// Each result must carry its own checkpoint mapping — guards the
+		// row-grouping logic against cross-txid contamination.
+		require.Contains(t, got[arkTxid].CheckpointTxs, checkpointTxid1)
+		require.Contains(t, got[arkTxid].CheckpointTxs, checkpointTxid2)
+		require.NotContains(t, got[arkTxid].CheckpointTxs, secondCheckpointTxid)
+		require.Contains(t, got[secondArkTxid].CheckpointTxs, secondCheckpointTxid)
+		require.NotContains(t, got[secondArkTxid].CheckpointTxs, checkpointTxid1)
+		require.NotContains(t, got[secondArkTxid].CheckpointTxs, checkpointTxid2)
 	})
 }
 

--- a/internal/infrastructure/db/sqlite/migration/20260409140000_checkpoint_tx_offchain_txid_index.down.sql
+++ b/internal/infrastructure/db/sqlite/migration/20260409140000_checkpoint_tx_offchain_txid_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_checkpoint_tx_offchain_txid;

--- a/internal/infrastructure/db/sqlite/migration/20260409140000_checkpoint_tx_offchain_txid_index.up.sql
+++ b/internal/infrastructure/db/sqlite/migration/20260409140000_checkpoint_tx_offchain_txid_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_checkpoint_tx_offchain_txid
+    ON checkpoint_tx (offchain_txid);

--- a/internal/infrastructure/db/sqlite/offchain_tx_repo.go
+++ b/internal/infrastructure/db/sqlite/offchain_tx_repo.go
@@ -9,6 +9,11 @@ import (
 	"github.com/arkade-os/arkd/internal/infrastructure/db/sqlite/sqlc/queries"
 )
 
+// sqliteMaxBulkTxids caps the per-query batch for GetOffchainTxsByTxids to stay
+// well under SQLITE_MAX_VARIABLE_NUMBER (default 999 on SQLite < 3.32). The
+// SLICE expansion in the generated query emits one bound parameter per txid.
+const sqliteMaxBulkTxids = 500
+
 type offchainTxRepository struct {
 	db      *sql.DB
 	querier *queries.Queries
@@ -121,14 +126,16 @@ func (v *offchainTxRepository) GetOffchainTxsByTxids(
 		return []*domain.OffchainTx{}, nil
 	}
 
-	rows, err := v.querier.SelectOffchainTxsByTxids(ctx, txids)
-	if err != nil {
-		return nil, err
-	}
-
 	grouped := make(map[string][]queries.OffchainTxVw)
-	for _, row := range rows {
-		grouped[row.OffchainTxVw.Txid] = append(grouped[row.OffchainTxVw.Txid], row.OffchainTxVw)
+	for start := 0; start < len(txids); start += sqliteMaxBulkTxids {
+		end := min(start+sqliteMaxBulkTxids, len(txids))
+		rows, err := v.querier.SelectOffchainTxsByTxids(ctx, txids[start:end])
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			grouped[row.OffchainTxVw.Txid] = append(grouped[row.OffchainTxVw.Txid], row.OffchainTxVw)
+		}
 	}
 
 	txs := make([]*domain.OffchainTx, 0, len(grouped))

--- a/internal/infrastructure/db/sqlite/offchain_tx_repo.go
+++ b/internal/infrastructure/db/sqlite/offchain_tx_repo.go
@@ -134,7 +134,10 @@ func (v *offchainTxRepository) GetOffchainTxsByTxids(
 			return nil, err
 		}
 		for _, row := range rows {
-			grouped[row.OffchainTxVw.Txid] = append(grouped[row.OffchainTxVw.Txid], row.OffchainTxVw)
+			grouped[row.OffchainTxVw.Txid] = append(
+				grouped[row.OffchainTxVw.Txid],
+				row.OffchainTxVw,
+			)
 		}
 	}
 

--- a/internal/infrastructure/db/sqlite/offchain_tx_repo.go
+++ b/internal/infrastructure/db/sqlite/offchain_tx_repo.go
@@ -114,6 +114,62 @@ func (v *offchainTxRepository) GetOffchainTx(
 	}, nil
 }
 
+func (v *offchainTxRepository) GetOffchainTxsByTxids(
+	ctx context.Context, txids []string,
+) ([]*domain.OffchainTx, error) {
+	if len(txids) == 0 {
+		return []*domain.OffchainTx{}, nil
+	}
+
+	rows, err := v.querier.SelectOffchainTxsByTxids(ctx, txids)
+	if err != nil {
+		return nil, err
+	}
+
+	grouped := make(map[string][]queries.OffchainTxVw)
+	for _, row := range rows {
+		grouped[row.OffchainTxVw.Txid] = append(grouped[row.OffchainTxVw.Txid], row.OffchainTxVw)
+	}
+
+	txs := make([]*domain.OffchainTx, 0, len(grouped))
+	for _, vws := range grouped {
+		vt := vws[0]
+		checkpointTxs := make(map[string]string)
+		commitmentTxids := make(map[string]string)
+		rootCommitmentTxId := ""
+		for _, vw := range vws {
+			if vw.CheckpointTxid != "" && vw.CheckpointTx != "" {
+				checkpointTxs[vw.CheckpointTxid] = vw.CheckpointTx
+				commitmentTxids[vw.CheckpointTxid] = vw.CommitmentTxid.String
+				if vw.IsRootCommitmentTxid.Bool {
+					rootCommitmentTxId = vw.CommitmentTxid.String
+				}
+			}
+		}
+		stage := domain.Stage{Code: int(vt.StageCode)}
+		if vt.FailReason.String != "" {
+			stage.Failed = true
+		}
+		if domain.OffchainTxStage(vt.StageCode) == domain.OffchainTxFinalizedStage {
+			stage.Ended = true
+		}
+		txs = append(txs, &domain.OffchainTx{
+			ArkTxid:            vt.Txid,
+			ArkTx:              vt.Tx,
+			StartingTimestamp:  vt.StartingTimestamp,
+			EndingTimestamp:    vt.EndingTimestamp,
+			ExpiryTimestamp:    vt.ExpiryTimestamp,
+			FailReason:         vt.FailReason.String,
+			Stage:              stage,
+			CheckpointTxs:      checkpointTxs,
+			CommitmentTxids:    commitmentTxids,
+			RootCommitmentTxId: rootCommitmentTxId,
+		})
+	}
+
+	return txs, nil
+}
+
 func (v *offchainTxRepository) Close() {
 	_ = v.db.Close()
 }

--- a/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
@@ -936,6 +936,60 @@ func (q *Queries) SelectOffchainTx(ctx context.Context, txid string) ([]SelectOf
 	return items, nil
 }
 
+const selectOffchainTxsByTxids = `-- name: SelectOffchainTxsByTxids :many
+SELECT offchain_tx_vw.txid, offchain_tx_vw.tx, offchain_tx_vw.starting_timestamp, offchain_tx_vw.ending_timestamp, offchain_tx_vw.expiry_timestamp, offchain_tx_vw.fail_reason, offchain_tx_vw.stage_code, offchain_tx_vw.checkpoint_txid, offchain_tx_vw.checkpoint_tx, offchain_tx_vw.commitment_txid, offchain_tx_vw.is_root_commitment_txid, offchain_tx_vw.offchain_txid FROM offchain_tx_vw WHERE txid IN (/*SLICE:txids*/?) AND COALESCE(fail_reason, '') = ''
+`
+
+type SelectOffchainTxsByTxidsRow struct {
+	OffchainTxVw OffchainTxVw
+}
+
+func (q *Queries) SelectOffchainTxsByTxids(ctx context.Context, txids []string) ([]SelectOffchainTxsByTxidsRow, error) {
+	query := selectOffchainTxsByTxids
+	var queryParams []interface{}
+	if len(txids) > 0 {
+		for _, v := range txids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:txids*/?", strings.Repeat(",?", len(txids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:txids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectOffchainTxsByTxidsRow
+	for rows.Next() {
+		var i SelectOffchainTxsByTxidsRow
+		if err := rows.Scan(
+			&i.OffchainTxVw.Txid,
+			&i.OffchainTxVw.Tx,
+			&i.OffchainTxVw.StartingTimestamp,
+			&i.OffchainTxVw.EndingTimestamp,
+			&i.OffchainTxVw.ExpiryTimestamp,
+			&i.OffchainTxVw.FailReason,
+			&i.OffchainTxVw.StageCode,
+			&i.OffchainTxVw.CheckpointTxid,
+			&i.OffchainTxVw.CheckpointTx,
+			&i.OffchainTxVw.CommitmentTxid,
+			&i.OffchainTxVw.IsRootCommitmentTxid,
+			&i.OffchainTxVw.OffchainTxid,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectPendingSpentVtxo = `-- name: SelectPendingSpentVtxo :many
 SELECT v.txid, v.vout, v.pubkey, v.amount, v.expires_at, v.created_at, v.commitment_txid, v.spent_by, v.spent, v.unrolled, v.preconfirmed, v.settled_by, v.ark_txid, v.intent_id, v.updated_at, v.depth, v.markers, v.commitments, v.swept, v.asset_id, v.asset_amount
 FROM vtxo_vw v

--- a/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -283,6 +283,9 @@ WHERE EXISTS (
 -- name: SelectOffchainTx :many
 SELECT sqlc.embed(offchain_tx_vw) FROM offchain_tx_vw WHERE txid = @txid AND COALESCE(fail_reason, '') = '';
 
+-- name: SelectOffchainTxsByTxids :many
+SELECT sqlc.embed(offchain_tx_vw) FROM offchain_tx_vw WHERE txid IN (sqlc.slice('txids')) AND COALESCE(fail_reason, '') = '';
+
 -- name: SelectLatestScheduledSession :one
 SELECT * FROM scheduled_session ORDER BY updated_at DESC LIMIT 1;
 

--- a/internal/test/e2e/vtxo_chain_test.go
+++ b/internal/test/e2e/vtxo_chain_test.go
@@ -1,0 +1,176 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	arksdk "github.com/arkade-os/arkd/pkg/client-lib"
+	grpcindexer "github.com/arkade-os/arkd/pkg/client-lib/indexer/grpc"
+	"github.com/arkade-os/arkd/pkg/client-lib/store"
+	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	chainLength   = flag.Int("chain-length", 10, "Number of self-send hops in the VTXO chain")
+	initialAmount = flag.Int("initial-amount", 1000, "Initial funding amount in satoshis")
+	arkServerUrl  = flag.String("server-url", serverUrl, "Ark server gRPC address")
+	arkAdminUrl   = flag.String("admin-url", adminUrl, "Ark admin HTTP address")
+	walletSeed    = flag.String("seed", "", "Wallet private key hex (random if empty)")
+	skipChain     = flag.Bool("skip-chain", false, "Skip chain creation, only run GetVtxoChain on existing wallet")
+)
+
+// TestVtxoChain creates a long VTXO chain by repeatedly self-sending.
+// Run with:
+//
+//	go test -v -run TestVtxoChain -args -chain-length=50 -initial-amount=10000
+func TestVtxoChain(t *testing.T) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	ctx := t.Context()
+
+	appDataStore, err := store.NewStore(store.Config{
+		ConfigStoreType: types.InMemoryStore,
+	})
+	require.NoError(t, err)
+
+	client, err := arksdk.NewArkClient(appDataStore)
+	require.NoError(t, err)
+	t.Cleanup(client.Stop)
+
+	seed := *walletSeed
+	if seed == "" {
+		privkey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		seed = hex.EncodeToString(privkey.Serialize())
+	}
+	t.Logf("wallet seed: %s", seed)
+
+	err = client.Init(ctx, arksdk.InitArgs{
+		WalletType:  arksdk.SingleKeyWallet,
+		ServerUrl:   *arkServerUrl,
+		Password:    password,
+		Seed:        seed,
+		ExplorerURL: explorerUrl,
+	})
+	require.NoError(t, err)
+
+	err = client.Unlock(ctx, password)
+	require.NoError(t, err)
+
+	_, offchainAddr, _, err := client.Receive(ctx)
+	require.NoError(t, err)
+
+	if !*skipChain {
+		// Fund the client offchain via admin note.
+		note := chainGenerateNote(t, uint64(*initialAmount))
+
+		wg := &sync.WaitGroup{}
+		var notifyErr error
+		wg.Go(func() {
+			_, notifyErr = client.NotifyIncomingFunds(ctx, offchainAddr.Address)
+		})
+
+		redeemTxid, err := client.RedeemNotes(ctx, []string{note})
+		require.NoError(t, err)
+		require.NotEmpty(t, redeemTxid)
+
+		wg.Wait()
+		require.NoError(t, notifyErr)
+
+		time.Sleep(time.Second)
+
+		spendable, _, err := client.ListVtxos(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, spendable, "no spendable VTXOs after faucet")
+
+		start := time.Now()
+		hops := 0
+
+		for i := range *chainLength {
+			spendable, _, err = client.ListVtxos(ctx)
+			require.NoError(t, err)
+			for len(spendable) == 0 {
+				spendable, _, err = client.ListVtxos(ctx)
+				require.NoError(t, err)
+			}
+			require.Len(t, spendable, 1)
+			tip := spendable[0]
+
+			wg := &sync.WaitGroup{}
+			var notifyErr error
+			wg.Go(func() {
+				_, notifyErr = client.NotifyIncomingFunds(ctx, offchainAddr.Address)
+			})
+
+			res, err := client.SendOffChain(ctx, []types.Receiver{{
+				To:     offchainAddr.Address,
+				Amount: tip.Amount,
+			}})
+			require.NoError(t, err)
+
+			wg.Wait()
+			require.NoError(t, notifyErr)
+
+			hops++
+			t.Logf("hop %d: txid=%s", i, res.Txid)
+		}
+
+		chainElapsed := time.Since(start)
+		t.Logf("chain built: %d hops in %s", hops, chainElapsed)
+
+		time.Sleep(2 * time.Second)
+	}
+
+	spendable, _, err := client.ListVtxos(ctx)
+	require.NoError(t, err)
+	tip := spendable[0]
+
+	// Benchmark GetVtxoChain on the last VTXO in the chain.
+	last := types.Outpoint{Txid: tip.Txid, VOut: tip.VOut}
+	idx, err := grpcindexer.NewClient(*arkServerUrl)
+	require.NoError(t, err)
+
+	getChainStart := time.Now()
+	resp, err := idx.GetVtxoChain(ctx, last)
+	getChainElapsed := time.Since(getChainStart)
+	require.NoError(t, err)
+
+	t.Logf("GetVtxoChain: %d entries in %s (tip=%s:%d)", len(resp.Chain), getChainElapsed, last.Txid, last.VOut)
+}
+
+func chainGenerateNote(t *testing.T, amount uint64) string {
+	t.Helper()
+
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+
+	reqBody := bytes.NewReader([]byte(fmt.Sprintf(`{"amount": "%d"}`, amount)))
+	req, err := http.NewRequest("POST", *arkAdminUrl+"/v1/admin/note", reqBody)
+	require.NoError(t, err)
+
+	req.Header.Set("Authorization", "Basic YWRtaW46YWRtaW4=")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var noteResp struct {
+		Notes []string `json:"notes"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&noteResp)
+	require.NoError(t, err)
+	require.NotEmpty(t, noteResp.Notes)
+
+	return noteResp.Notes[0]
+}


### PR DESCRIPTION
## Summary

Reduce DB round-trips in `walkVtxoChain` across **two different chain shapes**:

1. **Wide fanout trees** — bulk-fetch offchain txs per BFS iteration instead of one-by-one (`GetOffchainTxsByTxids`).
2. **Deep linear chains** — piggyback an offchain tx bulk fetch on the existing marker-DAG VTXO preload so the BFS loop never hits the DB for offchain txs at all.

On a 10002-entry self-send chain, `walkVtxoChain` total time dropped from **4.03s → 0.44s (9.2×)** end-to-end, with `bulkOffchainTx` going from 3.49s to **0s**.

## The problem

Before this PR, every preconfirmed VTXO visited in `walkVtxoChain` triggered an individual `GetOffchainTx(ctx, vtxo.Txid)` call — one DB round-trip per hop. Two bad scenarios:

- A **wide fanout tree** with N preconfirmed VTXOs does N sequential round-trips, even though all of them could be fetched in one query.
- A **deep linear chain** of length N does N sequential round-trips and can't even benefit from batching (each BFS level has exactly one VTXO).

## What changed

### 1. Bulk-fetch offchain txs per iteration (helps wide fanout)

- **New `GetOffchainTxsByTxids` bulk query** on `OffchainTxRepository` with sqlc implementations:
  - Postgres uses `ANY($1::varchar[])` — single bound array parameter, unbounded batch size.
  - SQLite uses `sqlc.slice('txids')` which expands to one `?` per txid. Chunked at **500 per batch** (`sqliteMaxBulkTxids`) to stay under SQLite's default `SQLITE_MAX_VARIABLE_NUMBER = 999`.
  - Badger loops individually as a compatibility shim (no bulk primitive).
- **`walkVtxoChain` prefetch + cache**: at the start of each BFS iteration, collect preconfirmed VTXO txids not yet in the offchain tx cache and bulk-fetch them in one call. Individual `GetOffchainTx` remains as a fallback for cache misses.

### 2. Marker-DAG offchain tx preload (helps deep linear chains)

PR #908 previously introduced a marker DAG that lets `walkVtxoChain` bulk-load VTXO records by walking a sparse DAG of depth-indexed checkpoints (one marker per `MarkerInterval = 100` depths). This PR extends the marker walk to **also populate `offchainTxCache`**: at each level, after fetching the VTXOs covered by a marker, it collects the preconfirmed txids and issues one `GetOffchainTxsByTxids` call for the whole window.

Result: for a chain of depth N, offchain tx round-trips go from **O(N)** to **O(N / MarkerInterval)**. On the 10k linear chain this means ~100 bulk calls instead of ~10000 sequential single calls, and the in-loop bulk fetch path becomes a dead fallback.

The in-loop bulk fetch from change #1 stays in place as a fallback for VTXOs outside a marker window (race conditions, mixed workloads).

### 3. Supporting changes

- **New DB index** `idx_checkpoint_tx_offchain_txid` on `checkpoint_tx(offchain_txid)` for both Postgres and SQLite. The `offchain_tx_vw` view does `LEFT JOIN checkpoint_tx ON offchain_tx.txid = checkpoint_tx.offchain_txid`, and this index accelerates the bulk query.
- **`nbxplorer` image bump** in `docker-compose.regtest.yml` (`2.5.30` → `2.5.30-1`) to fix a crash loop against Bitcoin Core 29.

## Test results

### End-to-end on a 10002-entry linear chain (self-send)

`internal/test/e2e/vtxo_chain_test.go` builds a long chain and times `GetVtxoChain` against it. Timing breakdown from the server-side log:

| | total | bulkOffchainTx | psbtDeser | ensureVtxos | other |
|---|---|---|---|---|---|
| **Before (this PR's bulk fetch alone)** | 4.029s | 3.492s | 363ms | 9ms | 165ms |
| **After (+ marker-DAG offchain preload)** | **0.436s** | **0s** | 218ms | 2ms | 215ms |

`bulkOffchainTx = 0s` is the signal the marker preload worked: every `offchainTxCache` lookup inside the BFS loop hit the cache populated up front.

### Call-counting test on a 511-VTXO fanout tree

`TestBulkOffchainTxReducesDBCalls` — exercises change #1 in isolation:

|  | Bulk calls | Individual calls | Total round-trips |
|---|---|---|---|
| **With bulk prefetch** | 9 | 0 | **9** |
| **Without (pre-optimization)** | 0 | 511 | **511** |

~57× reduction in DB round-trips. The 9 bulk calls correspond to 9 BFS depth levels.

### Latency benchmark

`BenchmarkOffchainTxBulkVsSingle` — same tree, 50µs simulated DB latency:

| | Time/op |
|---|---|
| **Bulk prefetch** | 13.7ms |
| **No bulk (fallback)** | 409ms |
| **Speedup** | **~30×** |

### Repo-level tests

- `service_test.go` — multi-txid bulk fetch test that inserts two distinct offchain txs, fetches `[txA, txB, missing-txid]` in one call, and asserts both return with their own checkpoint maps (no cross-txid row contamination).
- Existing repo tests updated to cover the new bulk method against both Postgres and SQLite.

## Visual explainer

### Background: the VTXO tree and `walkVtxoChain`

A VTXO chain is a tree of transactions. `walkVtxoChain` does a BFS — it processes all VTXOs at one depth, discovers their children via checkpoint tx inputs, then moves to the next depth.

Each VTXO is either **on-chain** (leaf of a batch tree) or **preconfirmed** (created by an offchain Ark tx). Preconfirmed VTXOs have a corresponding **OffchainTx** record containing checkpoint PSBTs whose inputs point to parent VTXOs — that's how the traversal discovers the next level.

```mermaid
graph TD
    subgraph "VTXO tree walkVtxoChain traverses"
        R["Round Commitment Tx (on-chain root)"]
        R --> A["VTXO A (depth 0)"]
        R --> B["VTXO B (depth 0)"]
        A --> C["VTXO C (preconfirmed, depth 1)"]
        A --> D["VTXO D (preconfirmed, depth 1)"]
        B --> E["VTXO E (preconfirmed, depth 1)"]
        C --> F["VTXO F (preconfirmed, depth 2)"]
        C --> G["VTXO G (preconfirmed, depth 2)"]
        D --> H["VTXO H (preconfirmed, depth 2)"]
        E --> I["VTXO I (preconfirmed, depth 2)"]
        E --> J["VTXO J (preconfirmed, depth 2)"]
    end
```

### Context: PR #908 — marker DAG for VTXO records

PR #908 introduced a marker system — DAG checkpoints every 100 depths. Before the BFS loop starts, `preloadVtxosByMarkers` bulk-loads all VTXO records into `vtxoCache`, eliminating per-VTXO DB calls.

```mermaid
graph TD
    subgraph "Marker DAG (small, ~N/100 nodes)"
        M0["Marker M0 (depths 0-99)"]
        M1["Marker M1 (depths 100-199)"]
        M2["Marker M2 (depths 200-299)"]
        M0 --> M1 --> M2
    end

    subgraph "VTXO tree (large, N nodes)"
        V0["~100 VTXOs (depths 0-99)"]
        V1["~100 VTXOs (depths 100-199)"]
        V2["~100 VTXOs (depths 200-299)"]
    end

    M0 -.->|covers| V0
    M1 -.->|covers| V1
    M2 -.->|covers| V2
```

### Problem #1: O(N) OffchainTx fetches (fixed by change #1)

After PR #908, VTXO records come from cache — but each preconfirmed VTXO still triggered an individual `GetOffchainTx` call. For 511 preconfirmed VTXOs in a wide tree, that's 511 sequential DB round-trips.

Change #1 batches those per BFS level using `GetOffchainTxsByTxids`:

```mermaid
graph TD
    subgraph "BFS iteration: 3 preconfirmed VTXOs at depth 1"
        C["VTXO C - txid: abc1"]
        D["VTXO D - txid: abc2"]
        E["VTXO E - txid: abc3"]
    end

    subgraph "Old: 3 individual queries"
        Q1["SELECT ... WHERE txid = 'abc1'"]
        Q2["SELECT ... WHERE txid = 'abc2'"]
        Q3["SELECT ... WHERE txid = 'abc3'"]
    end

    subgraph "New: 1 bulk query"
        QB["SELECT ... WHERE txid IN ('abc1','abc2','abc3')"]
    end

    C --> Q1
    D --> Q2
    E --> Q3
    C --> QB
    D --> QB
    E --> QB
```

### Problem #2: linear chains still pay O(N) round-trips (fixed by change #2)

The bulk fetch from change #1 helps wide trees — batch size K per iteration collapses K queries into 1. But a length-N **linear** chain has batch size 1 at every iteration, so it still does N sequential round-trips, just via the bulk API instead of the single API. Zero improvement.

Change #2 solves this by piggybacking offchain tx loading onto the existing marker DAG walk that already preloads VTXO records:

```mermaid
sequenceDiagram
    participant W as walkVtxoChain
    participant MDAG as Marker DAG walk
    participant DB as Database

    Note over W,MDAG: Before BFS loop starts
    W->>MDAG: preloadByMarkers(startVtxos)

    loop For each marker window (N/100 iterations)
        MDAG->>DB: GetVtxoChainByMarkers(window)
        DB-->>MDAG: 100 VTXO records
        MDAG->>DB: GetOffchainTxsByTxids(preconfirmed txids)
        DB-->>MDAG: 100 OffchainTx records
        MDAG->>DB: GetMarkersByIds(window)
        DB-->>MDAG: parent marker IDs
    end

    MDAG-->>W: vtxoCache + offchainTxCache fully populated

    Note over W,DB: BFS loop runs entirely from cache
    loop N iterations
        W->>W: vtxoCache lookup (hit)
        W->>W: offchainTxCache lookup (hit)
    end
```

### Combined effect (10002-entry linear chain)

```mermaid
graph TD
    subgraph "Before this PR"
        BA["VTXO fetches: ~100 bulk queries (markers, from PR #908)"]
        BB["OffchainTx fetches: ~10000 single queries"]
        BC["Total: ~10100 round-trips / 4.03s"]
        BA --> BC
        BB --> BC
    end

    subgraph "After change #1 alone (bulk fetch)"
        MA["VTXO fetches: ~100 bulk queries"]
        MB["OffchainTx fetches: ~10000 bulk-of-1 queries"]
        MC["Total: ~10100 round-trips / 4.03s (linear chain sees no improvement)"]
        MA --> MC
        MB --> MC
    end

    subgraph "After both changes"
        FA["VTXO fetches: ~100 bulk queries (markers)"]
        FB["OffchainTx fetches: ~100 bulk queries (markers)"]
        FC["Total: ~200 round-trips / 0.44s"]
        FA --> FC
        FB --> FC
    end
```

> **10100 → 10100 → 200 round-trips**, **4.03s → 4.03s → 0.44s** for a 10k linear chain. Change #1 covers wide trees (57× on the 511-VTXO fanout benchmark); change #2 covers deep linear chains (9× end-to-end). Together they reduce round-trips regardless of chain shape.

A new test was added called `TestVtxoChainTimingBreakdown` which is an in-process phase breakdown in `internal/core/application/indexer_bench_test.go` that gives per-phase timing for `GetVtxoChain` (without instrumenting prod code). Output looks like this giving a breakdown of timing:
```
=== RUN   TestVtxoChainTimingBreakdown
    indexer_bench_test.go:839: GetVtxoChain timing breakdown: linear chain n=10000, simulated repo latency=50µs
    indexer_bench_test.go:839:   wall clock (GetVtxoChain)        385.503759ms
    indexer_bench_test.go:839:   Markers.GetMarkersByIds          104.166695ms  (100 calls)
    indexer_bench_test.go:839:   Markers.GetVtxoChainByMarkers     83.184731ms  (100 calls)
    indexer_bench_test.go:839:   OffchainTxs.GetOffchainTxsByTxids  81.076346ms  (100 calls)
    indexer_bench_test.go:839:   Vtxos.GetVtxos                     1.200509ms  (1 calls)
    indexer_bench_test.go:839:   sum of repo phases               269.628281ms
    indexer_bench_test.go:839:   other (psbt parse + overhead)    115.875478ms
--- PASS: TestVtxoChainTimingBreakdown (0.42s)
```

 What it does:                                                                                                                                                                                            
  1. Builds a 10,000-entry linear preconfirmed VTXO chain with markers as plain Go maps via buildLinearChain — no DB, no network, no signing.
  2. Wraps the fake repos in timing decorators (timingVtxoRepo, timingMarkerRepo, timingOffchainTxRepo) that record time.Since into a shared phaseTimings accumulator on every call and inject a 50µs      
  time.Sleep per call to simulate DB round-trip cost so phase ratios are visible against in-memory fakes.                                                                                            
  3. Calls indexerService.GetVtxoChain once end-to-end, asserts the returned chain length, then logs a per-phase breakdown: wall clock, time spent in each repo method with call counts, sum of repo       
  phases, and "other" (PSBT parse + in-process overhead).              
                                                                                                                                                                                                           
  What it replaces (code i had locally on my branch in prior commits):                                                    
  The hand-rolled timing accumulators (tEnsureVtxos, tBulkOffchain, tSingleOffchain, tPsbtDeser, tVtxoTree) and the log.WithFields(...).Info("walkVtxoChain timing breakdown") block that previously lived 
  in walkVtxoChain itself. Prod code now has zero timing instrumentation.                                                                                                                                  
  
  What it does not cover:                                                                                                                                                                                  
  Real network, real DB query plans, real PSBT signing, real cross-process latency. Those are still the e2e TestVtxoChain's job. This test is a complement for phase-ratio regression signal, not a
  replacement

Tradeoffs & potential concerns:
  - Preload ignores pageSize — peak memory scales with full chain length, not page size. preloadByMarkers walks the marker DAG from the frontier upward to the root before the BFS loop starts, populating 
  vtxoCache and offchainTxCache for every VTXO reachable above the frontier. On a 10k-deep chain a paginated request still allocates ~10k Vtxo records + ~10k OffchainTx records (each holding checkpoint  
  PSBTs) regardless of pageSize. The early-termination cursor at the BFS level (indexer.go:649) bounds output size but not transient RSS (resident set size). Under concurrent deep-chain requests this is a heap-spike risk.  
  - No depth cap on the upward marker walk. Nothing in preloadByMarkers limits how far up the DAG it traverses — it always walks to the root. A frontier deep in a long-lived chain will preload the entire
   ancestry even if the caller only wants a handful of pages near the frontier. 
  - No cross-request cache. Every GetVtxoChain call rebuilds vtxoCache / offchainTxCache from scratch. A process-level LRU keyed by marker ID would collapse duplicate work across pagination (and across  
  callers hitting overlapping chains), but isn't in this PR.
  - New index idx_checkpoint_tx_offchain_txid adds write-path cost. Every checkpoint tx insert now updates an extra index on both Postgres and SQLite. Low-risk, but worth flagging as a permanent overhead
   traded for read-path latency.                                                                                                                                                                           
  - Existing (pre-#908) VTXOs skip the preload path. Same caveat #908 already called out: VTXOs without marker_ids populated fall through to the in-loop bulk fetch, which helps wide trees but not deep
  linear chains. Operators running against a database with old VTXOs won't see the 9× improvement until those VTXOs age out. 