### PR TITLE
Hd wallet interface prep

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -1251,13 +1251,14 @@ func TestDelegateRefresh(t *testing.T) {
 
 	aliceClient := alice.Transport()
 
-	_, alicePubkey, err := alice.Wallet().GetKeyPair(ctx, "")
-	require.NoError(t, err)
-	require.NotNil(t, alicePubkey)
-
 	_, aliceAddr, _, err := alice.Receive(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, aliceAddr)
+	require.NotEmpty(t, aliceAddr.KeyID)
+
+	aliceKey, err := alice.Wallet().GetKey(ctx, aliceAddr.KeyID)
+	require.NoError(t, err)
+	require.NotNil(t, aliceKey.PubKey)
 
 	aliceArkAddr, err := arklib.DecodeAddressV0(aliceAddr.Address)
 	require.NoError(t, err)
@@ -1281,7 +1282,7 @@ func TestDelegateRefresh(t *testing.T) {
 		Locktime: delegateLocktime,
 		MultisigClosure: script.MultisigClosure{
 			// both alice and bob must sign the transaction
-			PubKeys: []*btcec.PublicKey{alicePubkey, bobPubKey, signerPubKey},
+			PubKeys: []*btcec.PublicKey{aliceKey.PubKey, bobPubKey, signerPubKey},
 		},
 	}
 
@@ -1296,13 +1297,13 @@ func TestDelegateRefresh(t *testing.T) {
 			collaborativeAliceBobClosure,
 			// classic collaborative closure, alice only
 			&script.MultisigClosure{
-				PubKeys: []*btcec.PublicKey{alicePubkey, signerPubKey},
+				PubKeys: []*btcec.PublicKey{aliceKey.PubKey, signerPubKey},
 			},
 			// alice exit script
 			&script.CSVMultisigClosure{
 				Locktime: exitLocktime,
 				MultisigClosure: script.MultisigClosure{
-					PubKeys: []*btcec.PublicKey{alicePubkey},
+					PubKeys: []*btcec.PublicKey{aliceKey.PubKey},
 				},
 			},
 		},

--- a/pkg/client-lib/asset.go
+++ b/pkg/client-lib/asset.go
@@ -9,6 +9,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
 	"github.com/arkade-os/arkd/pkg/client-lib/client"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 )
 
@@ -20,7 +21,7 @@ func (a *service) IssueAsset(
 		return nil, err
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +44,7 @@ func (a *service) IssueAsset(
 	}
 
 	receiver := types.Receiver{
-		To: offchainAddrs[0].Address, Amount: a.Dust,
+		To: changeAddr.Address, Amount: a.Dust,
 		Assets: receiverAsset,
 	}
 
@@ -228,7 +229,7 @@ func (a *service) ReissueAsset(
 		return nil, err
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (a *service) ReissueAsset(
 	defer a.txLock.Unlock()
 
 	receiver := types.Receiver{
-		To: offchainAddrs[0].Address, Amount: a.Dust,
+		To: changeAddr.Address, Amount: a.Dust,
 		Assets: []types.Asset{{
 			AssetId: controlAssetId,
 			Amount:  1, // TODO: should send all denominated amount of the asset vtxo
@@ -400,11 +401,11 @@ func (a *service) BurnAsset(
 		return nil, fmt.Errorf("amount must be > 0")
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
 	if err != nil {
 		return nil, err
 	}
-	if len(offchainAddrs) <= 0 {
+	if len(changeAddr.Address) <= 0 {
 		return nil, fmt.Errorf("no offchain addresses")
 	}
 
@@ -412,7 +413,7 @@ func (a *service) BurnAsset(
 	defer a.txLock.Unlock()
 
 	burnReceiver := types.Receiver{
-		To:     offchainAddrs[0].Address,
+		To:     changeAddr.Address,
 		Amount: a.Dust,
 		Assets: []types.Asset{{
 			AssetId: assetId,

--- a/pkg/client-lib/batch_session.go
+++ b/pkg/client-lib/batch_session.go
@@ -18,6 +18,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
@@ -93,7 +94,7 @@ func (a *service) RedeemNotes(
 		amount += uint64(v.Value)
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +102,13 @@ func (a *service) RedeemNotes(
 		return nil, fmt.Errorf("no funds detected")
 	}
 
+	_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
+	if err != nil {
+		return nil, err
+	}
+
 	receiversOutput := []types.Receiver{{
-		To:     offchainAddrs[0].Address,
+		To:     changeAddr.Address,
 		Amount: amount,
 	}}
 
@@ -242,7 +248,7 @@ func (a *service) getFundsToSettle(
 	ctx context.Context,
 	outputs []types.Receiver, feeEstimator *arkfee.Estimator, opts getVtxosFilter,
 ) ([]types.Utxo, []types.VtxoWithTapTree, []types.Receiver, error) {
-	_, offchainAddrs, boardingAddrs, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, boardingAddrs, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -303,8 +309,13 @@ func (a *service) getFundsToSettle(
 			})
 		}
 
+		_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 		outputs = []types.Receiver{{
-			To:     offchainAddrs[0].Address,
+			To:     changeAddr.Address,
 			Amount: 0,
 			Assets: assets,
 		}}
@@ -344,8 +355,13 @@ func (a *service) getFundsToSettle(
 	}
 
 	if changeAmount > 0 {
+		_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
 		outputs = append(outputs, types.Receiver{
-			To:     offchainAddrs[0].Address,
+			To:     changeAddr.Address,
 			Amount: changeAmount,
 		})
 	}

--- a/pkg/client-lib/funding.go
+++ b/pkg/client-lib/funding.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/indexer"
 	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
@@ -25,7 +26,7 @@ func (a *service) Receive(ctx context.Context) (
 		return "", nil, nil, fmt.Errorf("wallet not initialized")
 	}
 
-	onchainAddr, offchainAddr, boardingAddr, err = a.newAddress(ctx)
+	onchainAddr, offchainAddr, boardingAddr, err = a.newAddress(ctx, wallet.KeyBranchReceive)
 	if err != nil {
 		return "", nil, nil, err
 	}
@@ -68,7 +69,7 @@ func (a *service) Balance(ctx context.Context) (*Balance, error) {
 		return nil, fmt.Errorf("wallet not initialized")
 	}
 
-	onchainAddrs, offchainAddrs, boardingAddrs, redeemAddrs, err := a.getAddresses(ctx)
+	onchainAddrs, offchainAddrs, boardingAddrs, redeemAddrs, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -297,90 +298,88 @@ func (a *service) NotifyIncomingFunds(ctx context.Context, addr string) ([]types
 	}
 }
 
-func (a *service) newAddress(ctx context.Context) (string, *types.Address, *types.Address, error) {
-	_, pubkey, err := a.wallet.NewKeyPair(ctx)
+func (a *service) newAddress(
+	ctx context.Context, branch wallet.KeyBranch,
+) (string, *types.Address, *types.Address, error) {
+	key, err := a.wallet.NewKey(ctx, branch)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
-	netParams := utils.ToBitcoinNetwork(a.Network)
-
-	defaultVtxoScript := script.NewDefaultVtxoScript(
-		pubkey, a.SignerPubKey, a.UnilateralExitDelay,
-	)
-	vtxoTapKey, _, err := defaultVtxoScript.TapTree()
+	onchainAddr, offchainAddr, boardingAddr, _, err := a.deriveDefaultAddresses(key)
 	if err != nil {
 		return "", nil, nil, err
 	}
 
-	offchainAddress := &arklib.Address{
-		HRP:        a.Network.Addr,
-		Signer:     a.SignerPubKey,
-		VtxoTapKey: vtxoTapKey,
-	}
-	encodedOffchainAddr, err := offchainAddress.EncodeV0()
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	tapscripts, err := defaultVtxoScript.Encode()
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	boardingVtxoScript := script.NewDefaultVtxoScript(
-		pubkey, a.SignerPubKey, a.BoardingExitDelay,
-	)
-	boardingTapKey, _, err := boardingVtxoScript.TapTree()
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	boardingAddr, err := btcutil.NewAddressTaproot(
-		schnorr.SerializePubKey(boardingTapKey), &netParams,
-	)
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	boardingTapscripts, err := boardingVtxoScript.Encode()
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	onchainTapKey := txscript.ComputeTaprootKeyNoScript(pubkey)
-	onchainAddr, err := btcutil.NewAddressTaproot(
-		schnorr.SerializePubKey(onchainTapKey), &netParams,
-	)
-	if err != nil {
-		return "", nil, nil, err
-	}
-
-	return onchainAddr.EncodeAddress(), &types.Address{
-			Tapscripts: tapscripts,
-			Address:    encodedOffchainAddr,
-		}, &types.Address{
-			Tapscripts: boardingTapscripts,
-			Address:    boardingAddr.EncodeAddress(),
-		}, nil
+	return onchainAddr, &offchainAddr, &boardingAddr, nil
 }
 
 func (a *service) getAddresses(
 	ctx context.Context,
 ) ([]string, []types.Address, []types.Address, []types.Address, error) {
-	_, pubkey, err := a.wallet.GetKeyPair(ctx, "")
-	if err != nil {
-		return nil, nil, nil, nil, err
+	return a.getAddressesForBranches(ctx, wallet.KeyBranchReceive)
+}
+
+func (a *service) getOwnedAddresses(
+	ctx context.Context,
+) ([]string, []types.Address, []types.Address, []types.Address, error) {
+	return a.getAddressesForBranches(
+		ctx, wallet.KeyBranchReceive, wallet.KeyBranchChange,
+	)
+}
+
+func (a *service) getAddressesForBranches(
+	ctx context.Context, branches ...wallet.KeyBranch,
+) ([]string, []types.Address, []types.Address, []types.Address, error) {
+	keys := make([]wallet.KeyRef, 0)
+	seenKeys := make(map[string]struct{})
+
+	for _, branch := range branches {
+		branchKeys, err := a.wallet.ListKeys(ctx, branch)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+
+		for _, key := range branchKeys {
+			if _, ok := seenKeys[key.ID]; ok {
+				continue
+			}
+			seenKeys[key.ID] = struct{}{}
+			keys = append(keys, key)
+		}
 	}
 
+	onchainAddrs := make([]string, 0, len(keys))
+	offchainAddrs := make([]types.Address, 0, len(keys))
+	boardingAddrs := make([]types.Address, 0, len(keys))
+	redemptionAddrs := make([]types.Address, 0, len(keys))
+
+	for _, key := range keys {
+		onchainAddr, offchainAddr, boardingAddr, redemptionAddr, err := a.deriveDefaultAddresses(key)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+
+		onchainAddrs = append(onchainAddrs, onchainAddr)
+		offchainAddrs = append(offchainAddrs, offchainAddr)
+		boardingAddrs = append(boardingAddrs, boardingAddr)
+		redemptionAddrs = append(redemptionAddrs, redemptionAddr)
+	}
+
+	return onchainAddrs, offchainAddrs, boardingAddrs, redemptionAddrs, nil
+}
+
+func (a *service) deriveDefaultAddresses(
+	key wallet.KeyRef,
+) (string, types.Address, types.Address, types.Address, error) {
 	netParams := utils.ToBitcoinNetwork(a.Network)
 
 	defaultVtxoScript := script.NewDefaultVtxoScript(
-		pubkey, a.SignerPubKey, a.UnilateralExitDelay,
+		key.PubKey, a.SignerPubKey, a.UnilateralExitDelay,
 	)
 	vtxoTapKey, _, err := defaultVtxoScript.TapTree()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	offchainAddress := &arklib.Address{
@@ -390,60 +389,62 @@ func (a *service) getAddresses(
 	}
 	encodedOffchainAddr, err := offchainAddress.EncodeV0()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	tapscripts, err := defaultVtxoScript.Encode()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	boardingVtxoScript := script.NewDefaultVtxoScript(
-		pubkey, a.SignerPubKey, a.BoardingExitDelay,
+		key.PubKey, a.SignerPubKey, a.BoardingExitDelay,
 	)
 	boardingTapKey, _, err := boardingVtxoScript.TapTree()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	boardingAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(boardingTapKey), &netParams,
 	)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	boardingTapscripts, err := boardingVtxoScript.Encode()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
 	redemptionAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(vtxoTapKey), &netParams,
 	)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
-	onchainTapKey := txscript.ComputeTaprootKeyNoScript(pubkey)
+	onchainTapKey := txscript.ComputeTaprootKeyNoScript(key.PubKey)
 	onchainAddr, err := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(onchainTapKey), &netParams,
 	)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return "", types.Address{}, types.Address{}, types.Address{}, err
 	}
 
-	offchainAddrs := []types.Address{
-		{Tapscripts: tapscripts, Address: encodedOffchainAddr},
-	}
-	boardingAddrs := []types.Address{
-		{Tapscripts: boardingTapscripts, Address: boardingAddr.EncodeAddress()},
-	}
-	redemptionAddrs := []types.Address{
-		{Tapscripts: tapscripts, Address: redemptionAddr.EncodeAddress()},
-	}
-
-	return []string{onchainAddr.EncodeAddress()}, offchainAddrs, boardingAddrs, redemptionAddrs, nil
+	return onchainAddr.EncodeAddress(), types.Address{
+			KeyID:      key.ID,
+			Tapscripts: tapscripts,
+			Address:    encodedOffchainAddr,
+		}, types.Address{
+			KeyID:      key.ID,
+			Tapscripts: boardingTapscripts,
+			Address:    boardingAddr.EncodeAddress(),
+		}, types.Address{
+			KeyID:      key.ID,
+			Tapscripts: tapscripts,
+			Address:    redemptionAddr.EncodeAddress(),
+		}, nil
 }
 
 func (a *service) getOffchainBalance(ctx context.Context) (
@@ -514,7 +515,7 @@ func (a *service) getBoardingTxs(ctx context.Context) ([]types.Transaction, erro
 }
 
 func (a *service) getAllBoardingUtxos(ctx context.Context) ([]types.Utxo, error) {
-	_, _, boardingAddrs, _, err := a.getAddresses(ctx)
+	_, _, boardingAddrs, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client-lib/send.go
+++ b/pkg/client-lib/send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/client"
 	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
@@ -124,7 +125,7 @@ func (a *service) createOffchainTx(
 		return "", nil, nil, nil, fmt.Errorf("missing receivers")
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return "", nil, nil, nil, err
 	}
@@ -344,8 +345,13 @@ func (a *service) createOffchainTx(
 	}
 
 	if changeAmount > 0 {
+		_, changeAddr, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
+		if err != nil {
+			return "", nil, nil, nil, err
+		}
+
 		changeReceiver = &types.Receiver{
-			To: offchainAddrs[0].Address, Amount: changeAmount,
+			To: changeAddr.Address, Amount: changeAmount,
 		}
 		if len(assetChanges) > 0 {
 			for assetID, amount := range assetChanges {

--- a/pkg/client-lib/service.go
+++ b/pkg/client-lib/service.go
@@ -305,7 +305,7 @@ func (a *service) getVtxos(
 		return nil, nil, ErrNotInitialized
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return
 	}
@@ -417,7 +417,7 @@ func (a *service) fetchPendingSpentVtxos(ctx context.Context) ([]types.Vtxo, err
 		return nil, ErrNotInitialized
 	}
 
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (a *service) fetchPendingSpentVtxos(ctx context.Context) ([]types.Vtxo, err
 func (a *service) populateVtxosWithTapscripts(
 	ctx context.Context, vtxos []types.Vtxo,
 ) ([]types.VtxoWithTapTree, error) {
-	_, offchainAddrs, _, _, err := a.getAddresses(ctx)
+	_, offchainAddrs, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client-lib/types/types.go
+++ b/pkg/client-lib/types/types.go
@@ -76,6 +76,10 @@ type DeprecatedSigner struct {
 }
 
 type Address struct {
+	// KeyID identifies which wallet key produced this address.
+	// Single-key wallets populate it with their fixed key handle; HD wallets can
+	// use the derivation path.
+	KeyID      string
 	Tapscripts []string
 	Address    string
 }

--- a/pkg/client-lib/unroll.go
+++ b/pkg/client-lib/unroll.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/explorer"
 	"github.com/arkade-os/arkd/pkg/client-lib/redemption"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -134,7 +135,7 @@ func (a *service) CompleteUnroll(ctx context.Context, to string) (string, error)
 	}
 
 	if len(to) == 0 {
-		newAddr, _, _, err := a.newAddress(ctx)
+		newAddr, _, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
 		if err != nil {
 			return "", err
 		}
@@ -170,7 +171,7 @@ func (a *service) OnboardAgainAllExpiredBoardings(ctx context.Context) (string, 
 		return "", fmt.Errorf("operation not allowed by the server")
 	}
 
-	_, _, boardingAddr, err := a.newAddress(ctx)
+	_, _, boardingAddr, err := a.newAddress(ctx, wallet.KeyBranchChange)
 	if err != nil {
 		return "", err
 	}
@@ -207,7 +208,7 @@ func (a *service) bumpAnchorTx(ctx context.Context, parent *wire.MsgTx) (string,
 
 	fees := uint64(math.Ceil(float64(packageSize) * feeRate))
 
-	addresses, _, _, _, err := a.getAddresses(ctx)
+	addresses, _, _, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return "", "", err
 	}
@@ -237,7 +238,7 @@ func (a *service) bumpAnchorTx(ctx context.Context, parent *wire.MsgTx) (string,
 
 	changeAmount := selectedAmount - fees
 
-	newAddr, _, _, err := a.newAddress(ctx)
+	newAddr, _, _, err := a.newAddress(ctx, wallet.KeyBranchChange)
 	if err != nil {
 		return "", "", err
 	}
@@ -477,7 +478,7 @@ func (a *service) sendExpiredBoardingUtxos(ctx context.Context, to string) (stri
 func (a *service) getExpiredBoardingUtxos(
 	ctx context.Context, opts *getVtxosFilter,
 ) ([]types.Utxo, error) {
-	_, _, boardingAddrs, _, err := a.getAddresses(ctx)
+	_, _, boardingAddrs, _, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -533,18 +534,12 @@ func (a *service) getExpiredBoardingUtxos(
 func (a *service) addInputs(
 	ctx context.Context, updater *psbt.Updater, utxos []types.Utxo,
 ) error {
-	// TODO works only with single-key wallet
-	_, offchain, _, err := a.newAddress(ctx)
-	if err != nil {
-		return err
-	}
-
-	vtxoScript, err := script.ParseVtxoScript(offchain.Tapscripts)
-	if err != nil {
-		return err
-	}
-
 	for _, utxo := range utxos {
+		vtxoScript, err := script.ParseVtxoScript(utxo.Tapscripts)
+		if err != nil {
+			return err
+		}
+
 		previousHash, err := chainhash.NewHashFromStr(utxo.Txid)
 		if err != nil {
 			return err
@@ -601,7 +596,7 @@ func (a *service) addInputs(
 }
 
 func (a *service) getMatureUtxos(ctx context.Context) ([]types.Utxo, error) {
-	_, _, _, redemptionAddrs, err := a.getAddresses(ctx)
+	_, _, _, redemptionAddrs, err := a.getOwnedAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
+++ b/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
@@ -28,6 +28,8 @@ type bitcoinWallet struct {
 	*singlekeyWallet
 }
 
+const singleKeyID = "single"
+
 func NewBitcoinWallet(
 	configStore types.ConfigStore, walletStore walletstore.WalletStore,
 ) (wallet.WalletService, error) {
@@ -44,28 +46,47 @@ func NewBitcoinWallet(
 	}, nil
 }
 
-func (w *bitcoinWallet) GetKeyPair(
-	ctx context.Context, _ string,
-) (*btcec.PrivateKey, *btcec.PublicKey, error) {
+func (w *bitcoinWallet) GetKey(
+	ctx context.Context, id string,
+) (wallet.KeyRef, error) {
 	if w.walletData == nil {
-		return nil, nil, fmt.Errorf("wallet not initialized")
+		return wallet.KeyRef{}, fmt.Errorf("wallet not initialized")
 	}
 	if w.IsLocked() {
-		return nil, nil, fmt.Errorf("wallet is locked")
+		return wallet.KeyRef{}, fmt.Errorf("wallet is locked")
 	}
-	return w.privateKey, w.privateKey.PubKey(), nil
+	if len(id) > 0 && id != singleKeyID {
+		return wallet.KeyRef{}, fmt.Errorf("unknown key id %q", id)
+	}
+	return wallet.KeyRef{
+		ID:     singleKeyID,
+		PubKey: w.privateKey.PubKey(),
+	}, nil
 }
 
-func (w *bitcoinWallet) NewKeyPair(
-	ctx context.Context,
-) (*btcec.PrivateKey, *btcec.PublicKey, error) {
+func (w *bitcoinWallet) NewKey(
+	ctx context.Context, _ wallet.KeyBranch,
+) (wallet.KeyRef, error) {
 	if w.walletData == nil {
-		return nil, nil, fmt.Errorf("wallet not initialized")
+		return wallet.KeyRef{}, fmt.Errorf("wallet not initialized")
 	}
 	if w.IsLocked() {
-		return nil, nil, fmt.Errorf("wallet is locked")
+		return wallet.KeyRef{}, fmt.Errorf("wallet is locked")
 	}
-	return w.privateKey, w.privateKey.PubKey(), nil
+	return wallet.KeyRef{
+		ID:     singleKeyID,
+		PubKey: w.privateKey.PubKey(),
+	}, nil
+}
+
+func (w *bitcoinWallet) ListKeys(
+	ctx context.Context, _ wallet.KeyBranch,
+) ([]wallet.KeyRef, error) {
+	key, err := w.GetKey(ctx, singleKeyID)
+	if err != nil {
+		return nil, err
+	}
+	return []wallet.KeyRef{key}, nil
 }
 
 func (w *bitcoinWallet) GetAddresses(
@@ -98,18 +119,21 @@ func (w *bitcoinWallet) GetAddresses(
 
 	offchainAddrs := []types.Address{
 		{
+			KeyID:      singleKeyID,
 			Tapscripts: offchainAddr.Tapscripts,
 			Address:    encodedOffchainAddr,
 		},
 	}
 	boardingAddrs := []types.Address{
 		{
+			KeyID:      singleKeyID,
 			Tapscripts: boardingAddr.Tapscripts,
 			Address:    boardingAddr.Address,
 		},
 	}
 	redemptionAddrs := []types.Address{
 		{
+			KeyID:      singleKeyID,
 			Tapscripts: offchainAddr.Tapscripts,
 			Address:    redemptionAddr.EncodeAddress(),
 		},
@@ -142,6 +166,7 @@ func (w *bitcoinWallet) NewAddress(
 	}
 
 	return onchainAddr.EncodeAddress(), &types.Address{
+		KeyID:      singleKeyID,
 		Tapscripts: offchainAddr.Tapscripts,
 		Address:    encodedOffchainAddr,
 	}, boardingAddr, nil
@@ -168,10 +193,12 @@ func (w *bitcoinWallet) NewAddresses(
 		}
 
 		offchainAddrs = append(offchainAddrs, types.Address{
+			KeyID:      singleKeyID,
 			Tapscripts: offchainAddr.Tapscripts,
 			Address:    encodedOffchainAddr,
 		})
 		boardingAddrs = append(boardingAddrs, types.Address{
+			KeyID:      singleKeyID,
 			Tapscripts: boardingAddr.Tapscripts,
 			Address:    boardingAddr.Address,
 		})
@@ -586,6 +613,7 @@ func (w *bitcoinWallet) getArkAddresses(
 			Tapscripts: tapscripts,
 		},
 		&types.Address{
+			KeyID:      singleKeyID,
 			Tapscripts: boardingTapscripts,
 			Address:    boardingAddr.EncodeAddress(),
 		},

--- a/pkg/client-lib/wallet/wallet.go
+++ b/pkg/client-lib/wallet/wallet.go
@@ -12,16 +12,30 @@ const (
 	SingleKeyWallet = "singlekey"
 )
 
+type KeyBranch string
+
+const (
+	KeyBranchReceive KeyBranch = "receive"
+	KeyBranchChange  KeyBranch = "change"
+)
+
+type KeyRef struct {
+	// ID is the stable wallet-local handle for this key.
+	// Single-key wallets use a fixed constant; HD wallets can use a derivation
+	// path or another persistent key identifier.
+	ID     string
+	PubKey *btcec.PublicKey
+}
+
 type WalletService interface {
 	GetType() string
 	Create(ctx context.Context, password, seed string) (walletSeed string, err error)
 	Lock(ctx context.Context) (err error)
 	Unlock(ctx context.Context, password string) (alreadyUnlocked bool, err error)
 	IsLocked() bool
-	GetKeyPair(
-		ctx context.Context, path string,
-	) (prvkey *btcec.PrivateKey, pubkey *btcec.PublicKey, err error)
-	NewKeyPair(ctx context.Context) (prvkey *btcec.PrivateKey, pubkey *btcec.PublicKey, err error)
+	GetKey(ctx context.Context, id string) (key KeyRef, err error)
+	NewKey(ctx context.Context, branch KeyBranch) (key KeyRef, err error)
+	ListKeys(ctx context.Context, branch KeyBranch) (keys []KeyRef, err error)
 	SignTransaction(
 		ctx context.Context, explorerSvc explorer.Explorer, tx string,
 	) (signedTx string, err error)

--- a/pkg/client-lib/wallet/wallet_test.go
+++ b/pkg/client-lib/wallet/wallet_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
 	singlekeywallet "github.com/arkade-os/arkd/pkg/client-lib/wallet/singlekey"
 	inmemorywalletstore "github.com/arkade-os/arkd/pkg/client-lib/wallet/singlekey/store/inmemory"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,14 +60,18 @@ func TestLockUnlock(t *testing.T) {
 	})
 }
 
-func TestGetKeyPair(t *testing.T) {
+func TestGetKey(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		walletSvc, seed := newUnlockedTestWallet(t)
-		prvkey, pubkey, err := walletSvc.GetKeyPair(t.Context(), "")
+		key, err := walletSvc.GetKey(t.Context(), "single")
 		require.NoError(t, err)
-		require.NotNil(t, prvkey)
-		require.NotNil(t, pubkey)
-		require.Equal(t, seed, hex.EncodeToString(prvkey.Serialize()))
+		require.Equal(t, "single", key.ID)
+		require.NotNil(t, key.PubKey)
+
+		prvkeyBytes, err := hex.DecodeString(seed)
+		require.NoError(t, err)
+		expectedPrvkey, _ := btcec.PrivKeyFromBytes(prvkeyBytes)
+		require.True(t, key.PubKey.IsEqual(expectedPrvkey.PubKey()))
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -93,23 +98,27 @@ func TestGetKeyPair(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				prvkey, pubkey, err := tt.setup(t).GetKeyPair(t.Context(), "")
+				key, err := tt.setup(t).GetKey(t.Context(), "single")
 				require.ErrorContains(t, err, tt.expErr)
-				require.Nil(t, prvkey)
-				require.Nil(t, pubkey)
+				require.Empty(t, key.ID)
+				require.Nil(t, key.PubKey)
 			})
 		}
 	})
 }
 
-func TestNewKeyPair(t *testing.T) {
+func TestNewKey(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		walletSvc, seed := newUnlockedTestWallet(t)
-		prvkey, pubkey, err := walletSvc.NewKeyPair(t.Context())
+		key, err := walletSvc.NewKey(t.Context(), wallet.KeyBranchReceive)
 		require.NoError(t, err)
-		require.NotNil(t, prvkey)
-		require.NotNil(t, pubkey)
-		require.Equal(t, seed, hex.EncodeToString(prvkey.Serialize()))
+		require.Equal(t, "single", key.ID)
+		require.NotNil(t, key.PubKey)
+
+		prvkeyBytes, err := hex.DecodeString(seed)
+		require.NoError(t, err)
+		expectedPrvkey, _ := btcec.PrivKeyFromBytes(prvkeyBytes)
+		require.True(t, key.PubKey.IsEqual(expectedPrvkey.PubKey()))
 	})
 
 	t.Run("invalid", func(t *testing.T) {
@@ -136,12 +145,29 @@ func TestNewKeyPair(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				prvkey, pubkey, err := tt.setup(t).NewKeyPair(t.Context())
+				key, err := tt.setup(t).NewKey(t.Context(), wallet.KeyBranchReceive)
 				require.ErrorContains(t, err, tt.expErr)
-				require.Nil(t, prvkey)
-				require.Nil(t, pubkey)
+				require.Empty(t, key.ID)
+				require.Nil(t, key.PubKey)
 			})
 		}
+	})
+}
+
+func TestListKeys(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		walletSvc, seed := newUnlockedTestWallet(t)
+
+		keys, err := walletSvc.ListKeys(t.Context(), wallet.KeyBranchReceive)
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		require.Equal(t, "single", keys[0].ID)
+		require.NotNil(t, keys[0].PubKey)
+
+		prvkeyBytes, err := hex.DecodeString(seed)
+		require.NoError(t, err)
+		expectedPrvkey, _ := btcec.PrivKeyFromBytes(prvkeyBytes)
+		require.True(t, keys[0].PubKey.IsEqual(expectedPrvkey.PubKey()))
 	})
 }
 


### PR DESCRIPTION
This PR is stacked on top of #1008.

The goal here is not to implement the HD wallet yet, but to remove the interface assumptions that would force another wallet-interface churn once HD support lands.

## Why

#1008 moves address derivation out of the wallet and into the client service, which is the right direction.

However, for HD support we still need a few things the current interface does not provide:
- a stable key handle for each allocated key
- explicit receive vs change key allocation
- a way to enumerate already allocated keys for address discovery/tracking
- removal of remaining single-key assumptions in internal flows

This PR adds those pieces while keeping the current default-script behavior unchanged.

## What changed

### Wallet interface
- replace `GetKeyPair` / `NewKeyPair` with:
  - `GetKey`
  - `NewKey`
  - `ListKeys`
- add `KeyRef`
- add `KeyBranch` with `receive` and `change`

### Address/key binding
- add `KeyID` to `types.Address`
- returned addresses now carry the stable wallet-local key handle that produced them

### Service-side default address derivation
- keep default address/script derivation in the service
- make it branch-aware:
  - `Receive()` allocates a `receive` key
  - internal self-funding/change paths allocate a `change` key
- add internal owned-address enumeration using both receive and change branches

### Remove single-key-only assumptions
- stop using one freshly derived address as a proxy for all owned tapscripts in unroll flows
- use each UTXO's own tapscripts instead

### Single-key implementation
- adapt the single-key wallet to the new interface
- use a fixed stable key handle (`single`)
- implement `ListKeys` in the trivial single-key way

## Why this helps HD

With this in place, an HD wallet can be added without changing the client service again:

- `NewKey(receive)` -> allocate next receive derivation
- `NewKey(change)` -> allocate next change derivation
- `ListKeys(branch)` -> rediscover allocated keys for tracking
- `GetKey(id)` -> resolve the exact key again for signing/tree signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced wallet key management with new key-based API methods for retrieving, creating, and listing wallet keys by branch (receive/change).

* **Improvements**
  * Address types now include key identifiers for improved address tracking and management.
  * Refactored internal address derivation logic for better consistency and reliability across asset operations.

* **Tests**
  * Updated end-to-end test suite to use unified client setup and modern wallet key APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->