### PR TITLE
[client-lib] Add default pagination for GetVtxos and GetVirtualTxs

### DIFF
--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -708,7 +708,7 @@ func paginatedFetch[T any](
 		all = append(all, items...)
 		reqCount++
 
-		if page == nil || page.GetNext() == page.GetTotal() {
+		if page == nil || page.GetNext() >= page.GetTotal() {
 			break
 		}
 		if reqCount >= maxPages {

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -22,6 +22,7 @@ import (
 const (
 	maxPageSize   = 1000
 	maxReqsPerSec = 20
+	maxPages      = 100
 )
 
 type grpcClient struct {
@@ -311,7 +312,7 @@ func (a *grpcClient) GetVtxos(
 		return nil, fmt.Errorf("missing opts")
 	}
 
-	if len(o.Scripts) > maxPageSize || len(o.Outpoints) > maxPageSize {
+	if o.Page == nil && (len(o.Scripts)+len(o.Outpoints) > maxPageSize) {
 		return a.paginatedGetVtxos(ctx, opts...)
 	}
 
@@ -407,14 +408,15 @@ func (a *grpcClient) GetVtxoChain(
 func (a *grpcClient) GetVirtualTxs(
 	ctx context.Context, txids []string, opts ...indexer.PageOption,
 ) (*indexer.VirtualTxsResponse, error) {
-	if len(txids) > maxPageSize {
-		return a.paginatedGetVirtualTxs(ctx, txids)
-	}
-
 	o, err := indexer.ApplyPageOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
+
+	if o.Page == nil && len(txids) > maxPageSize {
+		return a.paginatedGetVirtualTxs(ctx, txids)
+	}
+
 	var page *arkv1.IndexerPageRequest
 	if o.Page != nil {
 		page = &arkv1.IndexerPageRequest{
@@ -709,11 +711,18 @@ func paginatedFetch[T any](
 		if page == nil || page.GetNext() == page.GetTotal() {
 			break
 		}
+		if reqCount >= maxPages {
+			return nil, fmt.Errorf("too many pages (%d), aborting", maxPages)
+		}
 		pageIndex = page.GetNext()
 
 		// Throttle to avoid hitting the rate limit (20 req/sec).
 		if reqCount%maxReqsPerSec == 0 {
-			time.Sleep(time.Second)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Second):
+			}
 		}
 	}
 	return all, nil

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	maxPageSize   = 1000
-	maxReqsPerSec = 20
+	maxReqsPerSec = 10
 	maxPages      = 100
 )
 

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -19,6 +19,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	maxPageSize   = 1000
+	maxReqsPerSec = 20
+)
+
 type grpcClient struct {
 	conn   *grpc.ClientConn
 	connMu *sync.RWMutex
@@ -306,6 +311,10 @@ func (a *grpcClient) GetVtxos(
 		return nil, fmt.Errorf("missing opts")
 	}
 
+	if len(o.Scripts) > maxPageSize || len(o.Outpoints) > maxPageSize {
+		return a.paginatedGetVtxos(ctx, opts...)
+	}
+
 	var page *arkv1.IndexerPageRequest
 	if o.Page != nil {
 		page = &arkv1.IndexerPageRequest{
@@ -398,6 +407,10 @@ func (a *grpcClient) GetVtxoChain(
 func (a *grpcClient) GetVirtualTxs(
 	ctx context.Context, txids []string, opts ...indexer.PageOption,
 ) (*indexer.VirtualTxsResponse, error) {
+	if len(txids) > maxPageSize {
+		return a.paginatedGetVirtualTxs(ctx, txids)
+	}
+
 	o, err := indexer.ApplyPageOptions(opts...)
 	if err != nil {
 		return nil, err
@@ -613,6 +626,97 @@ func (a *grpcClient) svc() arkv1.IndexerServiceClient {
 	a.connMu.RLock()
 	defer a.connMu.RUnlock()
 	return arkv1.NewIndexerServiceClient(a.conn)
+}
+
+func (a *grpcClient) paginatedGetVtxos(
+	ctx context.Context, opts ...indexer.GetVtxosOption,
+) (*indexer.VtxosResponse, error) {
+	// nolint
+	o, _ := indexer.ApplyGetVtxosOptions(opts...)
+	svc := a.svc()
+
+	vtxos, err := paginatedFetch(ctx, func(
+		ctx context.Context, page *arkv1.IndexerPageRequest,
+	) ([]types.Vtxo, *arkv1.IndexerPageResponse, error) {
+		resp, err := svc.GetVtxos(ctx, &arkv1.GetVtxosRequest{
+			Scripts:         o.Scripts,
+			Outpoints:       o.FormattedOutpoints(),
+			SpendableOnly:   o.SpendableOnly,
+			SpentOnly:       o.SpentOnly,
+			RecoverableOnly: o.RecoverableOnly,
+			PendingOnly:     o.PendingOnly,
+			After:           o.After,
+			Before:          o.Before,
+			Page:            page,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return newIndexerVtxos(resp.GetVtxos()), resp.GetPage(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &indexer.VtxosResponse{Vtxos: vtxos}, nil
+}
+
+func (a *grpcClient) paginatedGetVirtualTxs(
+	ctx context.Context, txids []string,
+) (*indexer.VirtualTxsResponse, error) {
+	svc := a.svc()
+
+	txs, err := paginatedFetch(ctx, func(
+		ctx context.Context, page *arkv1.IndexerPageRequest,
+	) ([]string, *arkv1.IndexerPageResponse, error) {
+		resp, err := svc.GetVirtualTxs(ctx, &arkv1.GetVirtualTxsRequest{
+			Txids: txids,
+			Page:  page,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return resp.GetTxs(), resp.GetPage(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &indexer.VirtualTxsResponse{Txs: txs}, nil
+}
+
+// paginatedFetch fetches all pages from a paginated endpoint, throttling
+// requests to stay under the rate limit (20 req/sec).
+func paginatedFetch[T any](
+	ctx context.Context,
+	fetch func(
+		ctx context.Context, page *arkv1.IndexerPageRequest,
+	) ([]T, *arkv1.IndexerPageResponse, error),
+) ([]T, error) {
+	var all []T
+	pageIndex := int32(0)
+	reqCount := 0
+	for {
+		items, page, err := fetch(ctx, &arkv1.IndexerPageRequest{
+			Size:  maxPageSize,
+			Index: pageIndex,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, items...)
+		reqCount++
+
+		if page == nil || page.GetNext() == page.GetTotal() {
+			break
+		}
+		pageIndex = page.GetNext()
+
+		// Throttle to avoid hitting the rate limit (20 req/sec).
+		if reqCount%maxReqsPerSec == 0 {
+			time.Sleep(time.Second)
+		}
+	}
+	return all, nil
 }
 
 func toStreamConnectionState(

--- a/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
+++ b/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
@@ -105,12 +105,44 @@ func TestPaginatedFetch(t *testing.T) {
 				},
 				wantErr: "context canceled",
 			},
+			{
+				name: "exceeds max pages",
+				ctx:  context.Background(),
+				fetch: func(_ context.Context, page *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error) {
+					idx := page.GetIndex()
+					return []int{int(idx)}, &arkv1.IndexerPageResponse{
+						Current: idx, Next: idx + 1, Total: int32(maxPages + 10),
+					}, nil
+				},
+				wantErr: "too many pages",
+			},
+			{
+				name: "context cancelled during throttle",
+				ctx: func() context.Context {
+					ctx, cancel := context.WithCancel(context.Background())
+					// Cancel after a short delay so the throttle sleep gets interrupted.
+					go func() {
+						time.Sleep(50 * time.Millisecond)
+						cancel()
+					}()
+					return ctx
+				}(),
+				fetch: func(_ context.Context, page *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error) {
+					idx := page.GetIndex()
+					return []int{int(idx)}, &arkv1.IndexerPageResponse{
+						Current: idx, Next: idx + 1, Total: int32(maxReqsPerSec + 5),
+					}, nil
+				},
+				wantErr: "context canceled",
+			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				_, err := paginatedFetch(tt.ctx, tt.fetch)
+				resp, err := paginatedFetch(tt.ctx, tt.fetch)
+				require.Error(t, err)
 				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, resp)
 			})
 		}
 	})

--- a/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
+++ b/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
@@ -1,0 +1,117 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginatedFetch(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			totalPages int32
+			wantItems  []int
+			wantMinDur time.Duration
+		}{
+			{
+				name:       "single page",
+				totalPages: 1,
+				wantItems:  []int{0},
+			},
+			{
+				name:       "multiple pages",
+				totalPages: 3,
+				wantItems:  []int{0, 1, 2},
+			},
+			{
+				name:       "nil page response stops after first page",
+				totalPages: 0, // unused, fetch returns nil page
+				wantItems:  []int{0},
+			},
+			{
+				name:       "throttles after maxReqsPerSec requests",
+				totalPages: int32(maxReqsPerSec + 2),
+				wantItems: func() []int {
+					items := make([]int, maxReqsPerSec+2)
+					for i := range items {
+						items[i] = i
+					}
+					return items
+				}(),
+				wantMinDur: 900 * time.Millisecond,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				start := time.Now()
+
+				items, err := paginatedFetch(context.Background(), func(
+					ctx context.Context, page *arkv1.IndexerPageRequest,
+				) ([]int, *arkv1.IndexerPageResponse, error) {
+					require.Equal(t, int32(maxPageSize), page.GetSize())
+					idx := page.GetIndex()
+					if tt.totalPages == 0 {
+						return []int{int(idx)}, nil, nil
+					}
+					return []int{int(idx)}, &arkv1.IndexerPageResponse{
+						Current: idx, Next: idx + 1, Total: tt.totalPages,
+					}, nil
+				})
+
+				require.NoError(t, err)
+				require.Equal(t, tt.wantItems, items)
+				if tt.wantMinDur > 0 {
+					require.GreaterOrEqual(t, time.Since(start), tt.wantMinDur)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			ctx     context.Context
+			fetch   func(context.Context, *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error)
+			wantErr string
+		}{
+			{
+				name: "fetch error propagates",
+				ctx:  context.Background(),
+				fetch: func(_ context.Context, page *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error) {
+					if page.GetIndex() == 1 {
+						return nil, nil, fmt.Errorf("server error")
+					}
+					return []int{1}, &arkv1.IndexerPageResponse{
+						Current: 0, Next: 1, Total: 3,
+					}, nil
+				},
+				wantErr: "server error",
+			},
+			{
+				name: "context cancellation",
+				ctx: func() context.Context {
+					ctx, cancel := context.WithCancel(context.Background())
+					cancel()
+					return ctx
+				}(),
+				fetch: func(ctx context.Context, _ *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error) {
+					return nil, nil, ctx.Err()
+				},
+				wantErr: "context canceled",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := paginatedFetch(tt.ctx, tt.fetch)
+				require.ErrorContains(t, err, tt.wantErr)
+			})
+		}
+	})
+}


### PR DESCRIPTION
Adds default pagination to client-lib's indexer client for GetVtxos and GetVirtualTxs apis. The request is paginated by default if more than 1000 items are requests in a single api.

Please @louisinger review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pagination for large data requests with aggregated results across multiple pages
  * Rate limiting for paginated requests and safe termination when pagination exceeds allowed limits

* **Tests**
  * Added tests for pagination behavior: multi-page aggregation, rate-limiting enforcement, error propagation, and cancellation handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->