### PR TITLE
Refactor indexer client handling of subscriptions

### DIFF
--- a/pkg/client-lib/client/grpc/client.go
+++ b/pkg/client-lib/client/grpc/client.go
@@ -259,8 +259,9 @@ func (a *grpcClient) GetEventStream(
 		Connect: func(ctx context.Context) (arkv1.ArkService_GetEventStreamClient, error) {
 			return a.svc().GetEventStream(ctx, req)
 		},
-		Reconnect: func(ctx context.Context) (arkv1.ArkService_GetEventStreamClient, error) {
-			return a.svc().GetEventStream(ctx, req)
+		Reconnect: func(ctx context.Context) (string, arkv1.ArkService_GetEventStreamClient, error) {
+			stream, err := a.svc().GetEventStream(ctx, req)
+			return "", stream, err
 		},
 		Recv: func(stream arkv1.ArkService_GetEventStreamClient) (**arkv1.GetEventStreamResponse, error) {
 			str, err := stream.Recv()
@@ -387,8 +388,9 @@ func (c *grpcClient) GetTransactionsStream(
 		},
 		Reconnect: func(
 			ctx context.Context,
-		) (arkv1.ArkService_GetTransactionsStreamClient, error) {
-			return c.svc().GetTransactionsStream(ctx, req)
+		) (string, arkv1.ArkService_GetTransactionsStreamClient, error) {
+			stream, err := c.svc().GetTransactionsStream(ctx, req)
+			return "", stream, err
 		},
 		Recv: func(
 			stream arkv1.ArkService_GetTransactionsStreamClient,

--- a/pkg/client-lib/funding.go
+++ b/pkg/client-lib/funding.go
@@ -276,20 +276,11 @@ func (a *service) NotifyIncomingFunds(ctx context.Context, addr string) ([]types
 	}
 
 	scripts := []string{hex.EncodeToString(vtxoScript)}
-	subId, err := a.indexer.SubscribeForScripts(ctx, "", scripts)
+	_, eventCh, closeFn, err := a.indexer.NewSubscription(ctx, scripts)
 	if err != nil {
 		return nil, err
 	}
-
-	eventCh, closeFn, err := a.indexer.GetSubscription(ctx, subId)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		// nolint
-		a.indexer.UnsubscribeForScripts(ctx, subId, scripts)
-		closeFn()
-	}()
+	defer closeFn()
 
 	for {
 		event, ok := <-eventCh

--- a/pkg/client-lib/indexer/grpc/cache.go
+++ b/pkg/client-lib/indexer/grpc/cache.go
@@ -72,6 +72,41 @@ func (s *scriptsCache) removeSubscription(id string) {
 		return
 	}
 	delete(s.scriptsBySubId, subId)
+
+	// Walk the replacement chain in both directions starting from the given id and
+	// delete every entry — both downstream hops (id -> ... -> resolved) and any
+	// upstream hops (older ids that were replaced into this one) — to avoid
+	// unbounded growth of the replacements map across repeated reconnections.
+	cur := id
+	for {
+		next, ok := s.replacements[cur]
+		if !ok {
+			break
+		}
+		delete(s.replacements, cur)
+		cur = next
+	}
+	cur = id
+	for {
+		prev, ok := s.findAncestor(cur)
+		if !ok {
+			break
+		}
+		delete(s.replacements, prev)
+		cur = prev
+	}
+}
+
+// findAncestor returns the key in replacements that maps to id, if any.
+// Each id appears at most once as a value (enforced by replace()), so the
+// lookup is unambiguous.
+func (s *scriptsCache) findAncestor(id string) (string, bool) {
+	for k, v := range s.replacements {
+		if v == id {
+			return k, true
+		}
+	}
+	return "", false
 }
 
 func (s *scriptsCache) replace(oldId, newId string) {

--- a/pkg/client-lib/indexer/grpc/cache.go
+++ b/pkg/client-lib/indexer/grpc/cache.go
@@ -8,38 +8,103 @@ import (
 
 // TODO: drop me in https://github.com/arkade-os/arkd/pull/951
 type scriptsCache struct {
-	lock    *sync.Mutex
-	scripts map[string]struct{}
+	lock           *sync.Mutex
+	scriptsBySubId map[string]map[string]struct{}
+	replacements   map[string]string
 }
 
 func newScriptsCache() *scriptsCache {
 	return &scriptsCache{
-		lock:    &sync.Mutex{},
-		scripts: make(map[string]struct{}),
+		lock:           &sync.Mutex{},
+		scriptsBySubId: make(map[string]map[string]struct{}),
+		replacements:   make(map[string]string),
 	}
 }
 
-func (s *scriptsCache) get() []string {
+func (s *scriptsCache) get(id string) []string {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	return slices.Collect((maps.Keys(s.scripts)))
+	subId := s.resolveId(id)
+	scripts, ok := s.scriptsBySubId[subId]
+	if !ok {
+		return nil
+	}
+	return slices.Collect((maps.Keys(scripts)))
 }
 
-func (s *scriptsCache) add(scripts []string) {
+func (s *scriptsCache) add(id string, scripts []string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	subId := s.resolveId(id)
+	if _, ok := s.scriptsBySubId[subId]; !ok {
+		s.scriptsBySubId[subId] = make(map[string]struct{})
+	}
 	for _, script := range scripts {
-		s.scripts[script] = struct{}{}
+		s.scriptsBySubId[subId][script] = struct{}{}
 	}
 }
 
-func (s *scriptsCache) remove(scripts []string) {
+func (s *scriptsCache) removeScripts(id string, scripts []string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	for _, script := range scripts {
-		delete(s.scripts, script)
+	subId := s.resolveId(id)
+	if _, ok := s.scriptsBySubId[subId]; !ok {
+		return
 	}
+	for _, script := range scripts {
+		delete(s.scriptsBySubId[subId], script)
+	}
+}
+
+func (s *scriptsCache) removeSubscription(id string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	subId := s.resolveId(id)
+	if _, ok := s.scriptsBySubId[subId]; !ok {
+		return
+	}
+	delete(s.scriptsBySubId, subId)
+}
+
+func (s *scriptsCache) replace(oldId, newId string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Prevent replacing the oldId with itself in the replacement chain to avoid infinite loops
+	if oldId == newId {
+		return
+	}
+	// Prevent replacing the oldId with a new one already existing in the replacement chain to
+	// avoid infinite loops
+	if _, exists := s.replacements[newId]; exists {
+		return
+	}
+	// Prevent replacing the oldId with a newId that already has scripts to avoid data loss
+	if _, exists := s.scriptsBySubId[newId]; exists {
+		return
+	}
+
+	subId := s.resolveId(oldId)
+	scripts, ok := s.scriptsBySubId[subId]
+	if !ok {
+		return
+	}
+	delete(s.scriptsBySubId, subId)
+	s.scriptsBySubId[newId] = scripts
+	s.replacements[subId] = newId
+}
+
+func (s *scriptsCache) resolveId(id string) string {
+	subId := id
+	for {
+		if _, ok := s.replacements[subId]; !ok {
+			break
+		}
+		subId = s.replacements[subId]
+	}
+	return subId
 }

--- a/pkg/client-lib/indexer/grpc/cache.go
+++ b/pkg/client-lib/indexer/grpc/cache.go
@@ -25,11 +25,20 @@ func newScriptsCache() *scriptsCache {
 	}
 }
 
+func (s *scriptsCache) exists(id string) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	subId := s.resolveIdLocked(id)
+	_, ok := s.scriptsBySubId[subId]
+	return ok
+}
+
 func (s *scriptsCache) get(id string) []string {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	subId := s.resolveId(id)
+	subId := s.resolveIdLocked(id)
 	scripts, ok := s.scriptsBySubId[subId]
 	if !ok {
 		return nil
@@ -41,7 +50,7 @@ func (s *scriptsCache) add(id string, scripts []string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	subId := s.resolveId(id)
+	subId := s.resolveIdLocked(id)
 	if _, ok := s.scriptsBySubId[subId]; !ok {
 		s.scriptsBySubId[subId] = make(map[string]struct{})
 	}
@@ -54,7 +63,7 @@ func (s *scriptsCache) removeScripts(id string, scripts []string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	subId := s.resolveId(id)
+	subId := s.resolveIdLocked(id)
 	if _, ok := s.scriptsBySubId[subId]; !ok {
 		return
 	}
@@ -67,7 +76,7 @@ func (s *scriptsCache) removeSubscription(id string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	subId := s.resolveId(id)
+	subId := s.resolveIdLocked(id)
 	if _, ok := s.scriptsBySubId[subId]; !ok {
 		return
 	}
@@ -99,7 +108,7 @@ func (s *scriptsCache) removeSubscription(id string) {
 
 // findAncestor returns the key in replacements that maps to id, if any.
 // Each id appears at most once as a value (enforced by replace()), so the
-// lookup is unambiguous.
+// lookup is unambiguous. Caller must hold s.lock.
 func (s *scriptsCache) findAncestor(id string) (string, bool) {
 	for k, v := range s.replacements {
 		if v == id {
@@ -127,7 +136,7 @@ func (s *scriptsCache) replace(oldId, newId string) {
 		return
 	}
 
-	subId := s.resolveId(oldId)
+	subId := s.resolveIdLocked(oldId)
 	scripts, ok := s.scriptsBySubId[subId]
 	if !ok {
 		return
@@ -137,13 +146,22 @@ func (s *scriptsCache) replace(oldId, newId string) {
 	s.replacements[subId] = newId
 }
 
+// resolveId walks the replacement chain to the tip. Safe for external callers.
 func (s *scriptsCache) resolveId(id string) string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.resolveIdLocked(id)
+}
+
+// resolveIdLocked is the internal, unlocked variant of resolveId. Caller must hold s.lock.
+func (s *scriptsCache) resolveIdLocked(id string) string {
 	subId := id
 	for {
-		if _, ok := s.replacements[subId]; !ok {
-			break
+		next, ok := s.replacements[subId]
+		if !ok {
+			return subId
 		}
-		subId = s.replacements[subId]
+		subId = next
 	}
-	return subId
 }

--- a/pkg/client-lib/indexer/grpc/cache.go
+++ b/pkg/client-lib/indexer/grpc/cache.go
@@ -8,9 +8,13 @@ import (
 
 // TODO: drop me in https://github.com/arkade-os/arkd/pull/951
 type scriptsCache struct {
-	lock           *sync.Mutex
+	lock *sync.Mutex
+	// Keeps track of the scripts watched by every subscriptions
+	// subscription id -> (indexed) scripts
 	scriptsBySubId map[string]map[string]struct{}
-	replacements   map[string]string
+	// Keeps track of subs replacements after reconnection
+	// old subscription id -> new subscription id
+	replacements map[string]string
 }
 
 func newScriptsCache() *scriptsCache {

--- a/pkg/client-lib/indexer/grpc/cache_test.go
+++ b/pkg/client-lib/indexer/grpc/cache_test.go
@@ -147,6 +147,92 @@ func TestScriptsCache(t *testing.T) {
 		})
 	})
 
+	t.Run("exists", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name  string
+				setup func(*scriptsCache)
+				id    string
+			}{
+				{
+					name: "subscription with scripts exists",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id: "sub1",
+				},
+				{
+					name: "subscription with no scripts still exists",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.removeScripts("sub1", []string{"script1"})
+					},
+					id: "sub1",
+				},
+				{
+					name: "subscription exists via replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					id: "sub1",
+				},
+				{
+					name: "subscription exists via multi-hop replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id: "sub1",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					require.True(t, c.exists(tc.id))
+				})
+			}
+		})
+
+		t.Run("invalid", func(t *testing.T) {
+			testCases := []struct {
+				name  string
+				setup func(*scriptsCache)
+				id    string
+			}{
+				{
+					name:  "empty cache",
+					setup: func(_ *scriptsCache) {},
+					id:    "sub1",
+				},
+				{
+					name: "non-existent subscription",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id: "sub2",
+				},
+				{
+					name: "removed subscription does not exist",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.removeSubscription("sub1")
+					},
+					id: "sub1",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					require.False(t, c.exists(tc.id))
+				})
+			}
+		})
+	})
+
 	t.Run("removeScripts", func(t *testing.T) {
 		t.Run("valid", func(t *testing.T) {
 			testCases := []struct {
@@ -452,5 +538,84 @@ func TestScriptsCache(t *testing.T) {
 			}()
 		}
 		wg.Wait()
+	})
+
+	// Run every mutating method concurrently against the same cache. The cache is protected by a
+	// single mutex, so this test ensures there are no data races and that no invariant-breaking
+	// interleaving blows up — e.g. replace() racing with removeSubscription() while the underlying
+	// scriptsBySubId / replacements maps are being walked in two directions.
+	t.Run("concurrent access with replace and removeSubscription", func(t *testing.T) {
+		t.Run("distinct subscription ids", func(t *testing.T) {
+			c := newScriptsCache()
+
+			const workers = 50
+			var wg sync.WaitGroup
+			wg.Add(workers)
+			for i := range workers {
+				go func() {
+					defer wg.Done()
+					oldId := fmt.Sprintf("sub_%d", i)
+					newId := fmt.Sprintf("sub_%d_replaced", i)
+					script := fmt.Sprintf("script_%d", i)
+
+					c.add(oldId, []string{script})
+					c.get(oldId)
+					c.replace(oldId, newId)
+					c.get(newId)
+					c.add(newId, []string{script + "_extra"})
+					c.removeScripts(newId, []string{script})
+					c.removeSubscription(oldId)
+				}()
+			}
+			wg.Wait()
+
+			// After all goroutines complete, every subscription should have been removed
+			// and the replacements map should be fully drained.
+			require.Empty(t, c.scriptsBySubId)
+			require.Empty(t, c.replacements)
+		})
+
+		// Hammer every mutating method on the same shared id concurrently. Unlike the previous
+		// test (distinct ids per worker), here all 50 goroutines contend on "sub1", so the final
+		// state is non-deterministic. We assert internal consistency rather than an exact final
+		// state: no self-replacements and no dangling chain tails.
+		t.Run("same subscription id", func(t *testing.T) {
+			c := newScriptsCache()
+			c.add("sub1", []string{"seed"})
+
+			const workers = 50
+			var wg sync.WaitGroup
+			wg.Add(workers)
+			for i := range workers {
+				go func() {
+					defer wg.Done()
+					id := "sub1"
+					script := fmt.Sprintf("script_%d", i)
+					newId := fmt.Sprintf("sub1_replaced_%d", i)
+
+					c.add(id, []string{script})
+					c.get(id)
+					c.exists(id)
+					c.replace(id, newId)
+					c.removeScripts(id, []string{script})
+					c.removeSubscription(id)
+				}()
+			}
+			wg.Wait()
+
+			// Every surviving entry in replacements must point at something still
+			// reachable — either a live scriptsBySubId bucket or a further
+			// replacement hop. No self-replacements are allowed.
+			for oldId, newId := range c.replacements {
+				require.NotEqual(t, oldId, newId, "self-replacement leaked into chain")
+				_, directHit := c.scriptsBySubId[newId]
+				_, viaChain := c.replacements[newId]
+				require.True(
+					t, directHit || viaChain,
+					"replacement %q -> %q dangles: newId has no scripts entry and no further replacement",
+					oldId, newId,
+				)
+			}
+		})
 	})
 }

--- a/pkg/client-lib/indexer/grpc/cache_test.go
+++ b/pkg/client-lib/indexer/grpc/cache_test.go
@@ -1,0 +1,436 @@
+package indexer
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScriptsCache(t *testing.T) {
+	t.Run("add", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name     string
+				setup    func(*scriptsCache)
+				id       string
+				scripts  []string
+				expected []string
+			}{
+				{
+					name:     "add scripts to new subscription",
+					setup:    func(c *scriptsCache) { c.add("sub1", []string{"script1"}) },
+					id:       "sub2",
+					scripts:  []string{"script2"},
+					expected: []string{"script2"},
+				},
+				{
+					name: "add scripts to existing subscription",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id:       "sub1",
+					scripts:  []string{"script2", "script3"},
+					expected: []string{"script1", "script2", "script3"},
+				},
+				{
+					name: "add and duplicate scripts",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+					},
+					id:       "sub1",
+					scripts:  []string{"script2", "script3"},
+					expected: []string{"script1", "script2", "script3"},
+				},
+				{
+					name: "add after replace adds to resolved id",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					id:       "sub1",
+					scripts:  []string{"script2"},
+					expected: []string{"script1", "script2"},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					c.add(tc.id, tc.scripts)
+					got := c.get(tc.id)
+					sort.Strings(got)
+					sort.Strings(tc.expected)
+					require.Equal(t, tc.expected, got)
+				})
+			}
+		})
+	})
+
+	t.Run("get", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name     string
+				setup    func(*scriptsCache)
+				id       string
+				expected []string
+			}{
+				{
+					name: "get existing scripts",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+					},
+					id:       "sub1",
+					expected: []string{"script1", "script2"},
+				},
+				{
+					name: "get scripts via replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					id:       "sub1",
+					expected: []string{"script1"},
+				},
+				{
+					name: "get scripts via multi-hop replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id:       "sub1",
+					expected: []string{"script1"},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					got := c.get(tc.id)
+					sort.Strings(got)
+					sort.Strings(tc.expected)
+					require.Equal(t, tc.expected, got)
+				})
+			}
+		})
+
+		t.Run("invalid", func(t *testing.T) {
+			testCases := []struct {
+				name  string
+				setup func(*scriptsCache)
+				id    string
+			}{
+				{
+					name:  "get from empty cache",
+					setup: func(_ *scriptsCache) {},
+					id:    "sub1",
+				},
+				{
+					name: "get non-existent subscription",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id: "sub2",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					got := c.get(tc.id)
+					require.Nil(t, got)
+				})
+			}
+		})
+	})
+
+	t.Run("removeScripts", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name     string
+				setup    func(*scriptsCache)
+				id       string
+				scripts  []string
+				expected []string
+			}{
+				{
+					name: "remove some scripts",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2", "script3"})
+					},
+					id:       "sub1",
+					scripts:  []string{"script2"},
+					expected: []string{"script1", "script3"},
+				},
+				{
+					name: "remove all scripts",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+					},
+					id:       "sub1",
+					scripts:  []string{"script1", "script2"},
+					expected: nil,
+				},
+				{
+					name: "remove via replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+						c.replace("sub1", "sub2")
+					},
+					id:       "sub1",
+					scripts:  []string{"script1"},
+					expected: []string{"script2"},
+				},
+				{
+					name: "remove scripts via multi-hop replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id:       "sub1",
+					scripts:  []string{"script1"},
+					expected: []string{"script2"},
+				},
+				{
+					name:     "remove from non-existent subscription is no-op",
+					setup:    func(_ *scriptsCache) {},
+					id:       "sub1",
+					scripts:  []string{"script1"},
+					expected: nil,
+				},
+				{
+					name: "remove non-existent scripts is no-op",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id:       "sub1",
+					scripts:  []string{"script99"},
+					expected: []string{"script1"},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					c.removeScripts(tc.id, tc.scripts)
+					got := c.get(tc.id)
+					sort.Strings(got)
+					sort.Strings(tc.expected)
+					require.Equal(t, tc.expected, got)
+				})
+			}
+		})
+	})
+
+	t.Run("removeSubscription", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name         string
+				setup        func(*scriptsCache)
+				id           string
+				otherID      string
+				otherScripts []string
+			}{
+				{
+					name: "remove subscription",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					id: "sub1",
+				},
+				{
+					name: "remove via replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					id: "sub1",
+				},
+				{
+					name: "remove via multi-hop replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id: "sub1",
+				},
+				{
+					name: "remove does not affect other subscriptions",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.add("sub2", []string{"script2"})
+					},
+					id:           "sub1",
+					otherID:      "sub2",
+					otherScripts: []string{"script2"},
+				},
+				{
+					name:  "remove non-existent subscription is no-op",
+					setup: func(_ *scriptsCache) {},
+					id:    "sub1",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					c.removeSubscription(tc.id)
+					got := c.get(tc.id)
+					require.Nil(t, got)
+					if tc.otherID != "" {
+						got := c.get(tc.otherID)
+						sort.Strings(got)
+						sort.Strings(tc.otherScripts)
+						require.Equal(t, tc.otherScripts, got)
+					}
+				})
+			}
+		})
+	})
+
+	t.Run("replace", func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testCases := []struct {
+				name          string
+				setup         func(*scriptsCache)
+				oldID         string
+				newID         string
+				expectedNewID []string
+			}{
+				{
+					name: "replace subscription id",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1", "script2"})
+					},
+					oldID:         "sub1",
+					newID:         "sub2",
+					expectedNewID: []string{"script1", "script2"},
+				},
+				{
+					name: "replace with existing replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					oldID:         "sub2",
+					newID:         "sub3",
+					expectedNewID: []string{"script1"},
+				},
+				{
+					name: "old id resolves via replacement chain",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					oldID:         "sub1",
+					newID:         "sub3",
+					expectedNewID: []string{"script1"},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					c.replace(tc.oldID, tc.newID)
+					got := c.get(tc.newID)
+					sort.Strings(got)
+					sort.Strings(tc.expectedNewID)
+					require.Equal(t, tc.expectedNewID, got)
+					// Old id should still resolve via replacement chain.
+					gotOld := c.get(tc.oldID)
+					sort.Strings(gotOld)
+					require.Equal(t, tc.expectedNewID, gotOld)
+				})
+			}
+		})
+
+		t.Run("no-op", func(t *testing.T) {
+			testCases := []struct {
+				name          string
+				setup         func(*scriptsCache)
+				oldID         string
+				newID         string
+				expectedOldID []string
+				expectedNewID []string
+			}{
+				{
+					name:          "replace non-existent subscription is no-op",
+					setup:         func(_ *scriptsCache) {},
+					oldID:         "sub1",
+					newID:         "sub2",
+					expectedOldID: nil,
+					expectedNewID: nil,
+				},
+				{
+					name: "self-replacement is no-op",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+					},
+					oldID:         "sub1",
+					newID:         "sub1",
+					expectedOldID: []string{"script1"},
+					expectedNewID: []string{"script1"},
+				},
+				{
+					name: "replace to existing id is no-op",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.add("sub2", []string{"script2"})
+					},
+					oldID:         "sub1",
+					newID:         "sub2",
+					expectedOldID: []string{"script1"},
+					expectedNewID: []string{"script2"},
+				},
+				{
+					name: "replacement cycle is prevented",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+					},
+					oldID:         "sub2",
+					newID:         "sub1",
+					expectedOldID: []string{"script1"},
+					expectedNewID: []string{"script1"},
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					c := newScriptsCache()
+					tc.setup(c)
+					c.replace(tc.oldID, tc.newID)
+					got := c.get(tc.oldID)
+					sort.Strings(got)
+					sort.Strings(tc.expectedOldID)
+					require.Equal(t, tc.expectedOldID, got)
+					got = c.get(tc.newID)
+					sort.Strings(got)
+					sort.Strings(tc.expectedNewID)
+					require.Equal(t, tc.expectedNewID, got)
+				})
+			}
+		})
+	})
+
+	t.Run("concurrent access", func(t *testing.T) {
+		c := newScriptsCache()
+		var wg sync.WaitGroup
+		for i := range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				id := "sub1"
+				scripts := []string{fmt.Sprintf("script_%d", i)}
+				c.add(id, scripts)
+				c.get(id)
+				c.removeScripts(id, scripts)
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/pkg/client-lib/indexer/grpc/cache_test.go
+++ b/pkg/client-lib/indexer/grpc/cache_test.go
@@ -270,6 +270,24 @@ func TestScriptsCache(t *testing.T) {
 					otherScripts: []string{"script2"},
 				},
 				{
+					name: "remove from middle of chain cleans upstream and downstream",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id: "sub2",
+				},
+				{
+					name: "remove from tail of chain cleans upstream hops",
+					setup: func(c *scriptsCache) {
+						c.add("sub1", []string{"script1"})
+						c.replace("sub1", "sub2")
+						c.replace("sub2", "sub3")
+					},
+					id: "sub3",
+				},
+				{
 					name:  "remove non-existent subscription is no-op",
 					setup: func(_ *scriptsCache) {},
 					id:    "sub1",
@@ -288,6 +306,8 @@ func TestScriptsCache(t *testing.T) {
 						sort.Strings(tc.otherScripts)
 						require.Equal(t, tc.otherScripts, got)
 					}
+					// Make sure the replacement chain is cleaned
+					require.Empty(t, c.replacements)
 				})
 			}
 		})

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -545,7 +545,6 @@ func (a *grpcClient) NewSubscription(
 					At:             event.At,
 					DisconnectedAt: event.DisconnectedAt,
 					Err:            event.Err,
-					// Metadata:       event.Metadata,
 				},
 			}
 		},

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -572,8 +572,7 @@ func (a *grpcClient) UpdateSubscription(
 		return fmt.Errorf("missing scripts to add or remove")
 	}
 
-	scripts := a.scripts.get(subscriptionId)
-	if len(scripts) <= 0 {
+	if !a.scripts.exists(subscriptionId) {
 		return fmt.Errorf("subscription not found with id %s", subscriptionId)
 	}
 
@@ -634,18 +633,18 @@ func (a *grpcClient) svc() arkv1.IndexerServiceClient {
 func (a *grpcClient) subscribeForScripts(
 	ctx context.Context, subscriptionId string, scripts []string,
 ) error {
+	subId := a.scripts.resolveId(subscriptionId)
+
 	req := &arkv1.SubscribeForScriptsRequest{
-		Scripts: scripts,
-	}
-	if len(subscriptionId) > 0 {
-		req.SubscriptionId = subscriptionId
+		Scripts:        scripts,
+		SubscriptionId: subId,
 	}
 
 	if _, err := a.svc().SubscribeForScripts(ctx, req); err != nil {
 		return err
 	}
 
-	a.scripts.add(subscriptionId, scripts)
+	a.scripts.add(subId, scripts)
 
 	return nil
 }
@@ -653,18 +652,18 @@ func (a *grpcClient) subscribeForScripts(
 func (a *grpcClient) unsubscribeForScripts(
 	ctx context.Context, subscriptionId string, scripts []string,
 ) error {
+	subId := a.scripts.resolveId(subscriptionId)
+
 	req := &arkv1.UnsubscribeForScriptsRequest{
-		Scripts: scripts,
-	}
-	if len(subscriptionId) > 0 {
-		req.SubscriptionId = subscriptionId
+		Scripts:        scripts,
+		SubscriptionId: subId,
 	}
 
 	if _, err := a.svc().UnsubscribeForScripts(ctx, req); err != nil {
 		return err
 	}
 
-	a.scripts.removeScripts(subscriptionId, scripts)
+	a.scripts.removeScripts(subId, scripts)
 
 	return nil
 }

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -444,10 +444,18 @@ func (a *grpcClient) GetBatchSweepTxs(
 	return resp.GetSweptBy(), nil
 }
 
-func (a *grpcClient) GetSubscription(
-	ctx context.Context, subscriptionId string,
-) (<-chan indexer.ScriptEvent, func(), error) {
-	return utils.StartReconnectingStream(ctx, utils.ReconnectingStreamConfig[
+func (a *grpcClient) NewSubscription(
+	ctx context.Context, scripts []string,
+) (string, <-chan indexer.ScriptEvent, func(), error) {
+	resp, err := a.svc().SubscribeForScripts(ctx, &arkv1.SubscribeForScriptsRequest{
+		Scripts: scripts,
+	})
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	subscriptionId := resp.GetSubscriptionId()
+	stream, closeFn, err := utils.StartReconnectingStream(ctx, utils.ReconnectingStreamConfig[
 		arkv1.IndexerService_GetSubscriptionClient,
 		*arkv1.GetSubscriptionResponse,
 		indexer.ScriptEvent,
@@ -457,17 +465,26 @@ func (a *grpcClient) GetSubscription(
 				SubscriptionId: subscriptionId,
 			})
 		},
-		Reconnect: func(ctx context.Context) (arkv1.IndexerService_GetSubscriptionClient, error) {
-			scripts := a.scripts.get()
+		Reconnect: func(
+			ctx context.Context,
+		) (string, arkv1.IndexerService_GetSubscriptionClient, error) {
+			scripts := a.scripts.get(subscriptionId)
 			resp, err := a.svc().SubscribeForScripts(ctx, &arkv1.SubscribeForScriptsRequest{
 				Scripts: scripts,
 			})
 			if err != nil {
-				return nil, err
+				return "", nil, err
 			}
-			return a.svc().GetSubscription(ctx, &arkv1.GetSubscriptionRequest{
-				SubscriptionId: resp.GetSubscriptionId(),
+			newSubscriptionId := resp.GetSubscriptionId()
+			stream, err := a.svc().GetSubscription(ctx, &arkv1.GetSubscriptionRequest{
+				SubscriptionId: newSubscriptionId,
 			})
+			if err != nil {
+				return "", nil, err
+			}
+			// Update the cache by replacing the subscription id for the watched scripts
+			a.scripts.replace(subscriptionId, newSubscriptionId)
+			return newSubscriptionId, stream, nil
 		},
 		Recv: func(
 			stream arkv1.IndexerService_GetSubscriptionClient,
@@ -528,49 +545,49 @@ func (a *grpcClient) GetSubscription(
 					At:             event.At,
 					DisconnectedAt: event.DisconnectedAt,
 					Err:            event.Err,
+					// Metadata:       event.Metadata,
 				},
 			}
 		},
 	})
-}
-
-func (a *grpcClient) SubscribeForScripts(
-	ctx context.Context, subscriptionId string, scripts []string,
-) (string, error) {
-	req := &arkv1.SubscribeForScriptsRequest{
-		Scripts: scripts,
-	}
-	if len(subscriptionId) > 0 {
-		req.SubscriptionId = subscriptionId
-	}
-
-	resp, err := a.svc().SubscribeForScripts(ctx, req)
 	if err != nil {
-		return "", err
+		return "", nil, nil, err
 	}
 
-	a.scripts.add(scripts)
+	a.scripts.add(subscriptionId, scripts)
 
-	return resp.GetSubscriptionId(), nil
+	cancelFn := func() {
+		closeFn()
+		a.scripts.removeSubscription(subscriptionId)
+	}
+	return subscriptionId, stream, cancelFn, nil
 }
 
-func (a *grpcClient) UnsubscribeForScripts(
-	ctx context.Context, subscriptionId string, scripts []string,
+func (a *grpcClient) UpdateSubscription(
+	ctx context.Context, subscriptionId string, scriptsToAdd, scriptsToRemove []string,
 ) error {
-	req := &arkv1.UnsubscribeForScriptsRequest{
-		Scripts: scripts,
+	if subscriptionId == "" {
+		return fmt.Errorf("missing subscription id to update")
 	}
-	if len(subscriptionId) > 0 {
-		req.SubscriptionId = subscriptionId
-	}
-
-	_, err := a.svc().UnsubscribeForScripts(ctx, req)
-	if err != nil {
-		return err
+	if len(scriptsToAdd) <= 0 && len(scriptsToRemove) <= 0 {
+		return fmt.Errorf("missing scripts to add or remove")
 	}
 
-	a.scripts.remove(scripts)
+	scripts := a.scripts.get(subscriptionId)
+	if len(scripts) <= 0 {
+		return fmt.Errorf("subscription not found with id %s", subscriptionId)
+	}
 
+	if len(scriptsToAdd) > 0 {
+		if err := a.subscribeForScripts(ctx, subscriptionId, scriptsToAdd); err != nil {
+			return err
+		}
+	}
+	if len(scriptsToRemove) > 0 {
+		if err := a.unsubscribeForScripts(ctx, subscriptionId, scriptsToRemove); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -613,6 +630,44 @@ func (a *grpcClient) svc() arkv1.IndexerServiceClient {
 	a.connMu.RLock()
 	defer a.connMu.RUnlock()
 	return arkv1.NewIndexerServiceClient(a.conn)
+}
+
+func (a *grpcClient) subscribeForScripts(
+	ctx context.Context, subscriptionId string, scripts []string,
+) error {
+	req := &arkv1.SubscribeForScriptsRequest{
+		Scripts: scripts,
+	}
+	if len(subscriptionId) > 0 {
+		req.SubscriptionId = subscriptionId
+	}
+
+	if _, err := a.svc().SubscribeForScripts(ctx, req); err != nil {
+		return err
+	}
+
+	a.scripts.add(subscriptionId, scripts)
+
+	return nil
+}
+
+func (a *grpcClient) unsubscribeForScripts(
+	ctx context.Context, subscriptionId string, scripts []string,
+) error {
+	req := &arkv1.UnsubscribeForScriptsRequest{
+		Scripts: scripts,
+	}
+	if len(subscriptionId) > 0 {
+		req.SubscriptionId = subscriptionId
+	}
+
+	if _, err := a.svc().UnsubscribeForScripts(ctx, req); err != nil {
+		return err
+	}
+
+	a.scripts.removeScripts(subscriptionId, scripts)
+
+	return nil
 }
 
 func toStreamConnectionState(

--- a/pkg/client-lib/indexer/grpc/reconnect_get_subscription_stream_test.go
+++ b/pkg/client-lib/indexer/grpc/reconnect_get_subscription_stream_test.go
@@ -119,11 +119,14 @@ func TestSubscriptionLifecycleEventsAndDeltaFetchByTimestamp(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
-	eventsCh, closeFn, err := c.GetSubscription(ctx, "sub-1")
+	subId, eventsCh, closeFn, err := c.NewSubscription(ctx, []string{"script1", "script2"})
 	require.NoError(t, err)
-	defer closeFn()
+	require.NotEmpty(t, subId)
+	require.NotNil(t, eventsCh)
+	require.NotNil(t, closeFn)
+	t.Cleanup(closeFn)
 
 	var (
 		disconnectedAt time.Time

--- a/pkg/client-lib/indexer/service.go
+++ b/pkg/client-lib/indexer/service.go
@@ -33,11 +33,12 @@ type Indexer interface {
 		ctx context.Context, txids []string, opts ...PageOption,
 	) (*VirtualTxsResponse, error)
 	GetBatchSweepTxs(ctx context.Context, batchOutpoint types.Outpoint) ([]string, error)
-	SubscribeForScripts(
-		ctx context.Context, subscriptionId string, scripts []string,
-	) (string, error)
-	UnsubscribeForScripts(ctx context.Context, subscriptionId string, scripts []string) error
-	GetSubscription(ctx context.Context, subscriptionId string) (<-chan ScriptEvent, func(), error)
+	NewSubscription(
+		ctx context.Context, scripts []string,
+	) (string, <-chan ScriptEvent, func(), error)
+	UpdateSubscription(
+		ctx context.Context, subscriptionId string, scriptsToAdd, scriptsToRemove []string,
+	) error
 	GetAsset(ctx context.Context, assetID string) (*AssetInfo, error)
 
 	Close()

--- a/pkg/client-lib/internal/utils/stream_retry.go
+++ b/pkg/client-lib/internal/utils/stream_retry.go
@@ -33,7 +33,7 @@ type ReconnectingStreamConfig[S grpcClientStream, R any, E any] struct {
 	// Connect creates a new stream instance. Called once at startup
 	Connect func(context.Context) (S, error)
 	// Reconnect creates a new stream instance after retryable failures while reconnecting.
-	Reconnect func(context.Context) (S, error)
+	Reconnect func(context.Context) (string, S, error)
 	// Recv reads one response from the current stream instance.
 	Recv func(S) (*R, error)
 	// HandleResp maps one response into domain events and writes them to eventsCh.
@@ -67,6 +67,7 @@ type ReconnectingStreamStateEvent struct {
 	At             time.Time
 	DisconnectedAt time.Time
 	Err            error
+	Metadata       map[string]string
 }
 
 // recvResult holds the outcome of a single cfg.Recv call made by startRecvLoop.
@@ -323,7 +324,7 @@ func StartReconnectingStream[S grpcClientStream, R any, E any](
 					case <-time.After(sleepDuration):
 					}
 
-					newStream, dialErr := cfg.Reconnect(ctx)
+					newId, newStream, dialErr := cfg.Reconnect(ctx)
 					if dialErr != nil {
 						shouldRetryDial, dialRetryDelay := ShouldReconnect(dialErr)
 						if !shouldRetryDial {
@@ -353,6 +354,7 @@ func StartReconnectingStream[S grpcClientStream, R any, E any](
 								State:          ReconnectingStreamStateReconnected,
 								At:             time.Now(),
 								DisconnectedAt: disconnectedAt,
+								Metadata:       map[string]string{"id": newId},
 							}) {
 								return
 							}
@@ -418,7 +420,7 @@ func applyJitter(d time.Duration, jitter float64) time.Duration {
 		jitter = 0.999
 	}
 
-	randomFactor := 2.0*rand.Float64()-1.0 // [-1, +1] factor
+	randomFactor := 2.0*rand.Float64() - 1.0 // [-1, +1] factor
 	jitterFactor := 1.0 + jitter*randomFactor
 	return time.Duration(float64(d) * jitterFactor)
 }

--- a/pkg/client-lib/internal/utils/stream_retry.go
+++ b/pkg/client-lib/internal/utils/stream_retry.go
@@ -67,7 +67,6 @@ type ReconnectingStreamStateEvent struct {
 	At             time.Time
 	DisconnectedAt time.Time
 	Err            error
-	Metadata       map[string]string
 }
 
 // recvResult holds the outcome of a single cfg.Recv call made by startRecvLoop.
@@ -324,7 +323,7 @@ func StartReconnectingStream[S grpcClientStream, R any, E any](
 					case <-time.After(sleepDuration):
 					}
 
-					newId, newStream, dialErr := cfg.Reconnect(ctx)
+					_, newStream, dialErr := cfg.Reconnect(ctx)
 					if dialErr != nil {
 						shouldRetryDial, dialRetryDelay := ShouldReconnect(dialErr)
 						if !shouldRetryDial {
@@ -354,7 +353,6 @@ func StartReconnectingStream[S grpcClientStream, R any, E any](
 								State:          ReconnectingStreamStateReconnected,
 								At:             time.Now(),
 								DisconnectedAt: disconnectedAt,
-								Metadata:       map[string]string{"id": newId},
 							}) {
 								return
 							}

--- a/pkg/client-lib/internal/utils/stream_retry_test.go
+++ b/pkg/client-lib/internal/utils/stream_retry_test.go
@@ -522,7 +522,7 @@ func TestStartReconnectingStream(t *testing.T) {
 
 		cfg := ReconnectingStreamConfig[*mockStream, string, testEvent]{
 			Connect:   func(ctx context.Context) (*mockStream, error) { return newMockStream(), nil },
-			Reconnect: func(ctx context.Context) (*mockStream, error) { return newMockStream(), nil },
+			Reconnect: func(ctx context.Context) (string, *mockStream, error) { return "", newMockStream(), nil },
 			Recv:      func(ms *mockStream) (*string, error) { return &msg, nil },
 			HandleResp: func(_ context.Context, _ chan<- testEvent, _ string) error {
 				return fatalErr()
@@ -606,8 +606,11 @@ func makeConfig(
 	recv func(*mockStream) (*string, error),
 ) ReconnectingStreamConfig[*mockStream, string, testEvent] {
 	return ReconnectingStreamConfig[*mockStream, string, testEvent]{
-		Connect:    connect,
-		Reconnect:  reconnect,
+		Connect: connect,
+		Reconnect: func(ctx context.Context) (string, *mockStream, error) {
+			stream, err := reconnect(ctx)
+			return "", stream, err
+		},
 		Recv:       recv,
 		HandleResp: func(_ context.Context, _ chan<- testEvent, _ string) error { return nil },
 		ErrorEvent: func(err error) testEvent { return testEvent{err: err} },

--- a/pkg/client-lib/types/types.go
+++ b/pkg/client-lib/types/types.go
@@ -64,8 +64,7 @@ type StreamConnectionEvent struct {
 	DisconnectedAt time.Time
 	Err            error
 	// Temporary field to be able to pass the new subscription id back to clients after reconnection
-	// TOOD: Drop me in https://github.com/arkade-os/arkd/pull/951
-	Metadata map[string]string
+	// TODO: Drop me in https://github.com/arkade-os/arkd/pull/951
 }
 
 type FeeInfo struct {

--- a/pkg/client-lib/types/types.go
+++ b/pkg/client-lib/types/types.go
@@ -63,6 +63,9 @@ type StreamConnectionEvent struct {
 	At             time.Time
 	DisconnectedAt time.Time
 	Err            error
+	// Temporary field to be able to pass the new subscription id back to clients after reconnection
+	// TOOD: Drop me in https://github.com/arkade-os/arkd/pull/951
+	Metadata map[string]string
 }
 
 type FeeInfo struct {

--- a/pkg/client-lib/types/types.go
+++ b/pkg/client-lib/types/types.go
@@ -63,8 +63,6 @@ type StreamConnectionEvent struct {
 	At             time.Time
 	DisconnectedAt time.Time
 	Err            error
-	// Temporary field to be able to pass the new subscription id back to clients after reconnection
-	// TODO: Drop me in https://github.com/arkade-os/arkd/pull/951
 }
 
 type FeeInfo struct {


### PR DESCRIPTION
Breaking changes to the indexer client to abstract and hide to the user the handling of the subscription id.

These changes are temporary and will be subject to changes in #951.

The indexer client's cache now tracks subs and related scripts with a map `subId -> (indexed) scripts (map[string]map[string]struct{})`, this way scripts are not merged into a single subscription if reconnection happens.

The user doesn't even need to be notified about the new subscription id. The indexer client, when reconnecting, keeps track of the chain of subs id replacements, this way the client can  just use the original sub id he got when he called `NewSubscription` in first place.

Please @louisinger @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now return a subscription ID, event channel, and cleanup in a single operation.
  * Added UpdateSubscription to add/remove scripts from an existing subscription without recreating it.
  * Reconnection events now include metadata with subscription identifiers to improve reconnection visibility.

* **Tests**
  * Added comprehensive tests validating subscription cache behavior and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->