### PR TITLE
Redis live store: pop on intent with nil body

### DIFF
--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -141,10 +141,7 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 		}
 
 		if intent == nil {
-			// remove id with nil value from the cache
-			if err := s.rdb.SRem(ctx, intentStoreIdsKey, id).Err(); err != nil {
-				log.Warnf("failed to remove intent with nil body (id=%s): %v", id, err)
-			}
+			log.Warnf("got nil intent for id %s", id)
 			continue
 		}
 

--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -140,6 +140,14 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 			return nil, fmt.Errorf("failed to get intent %s: %v", id, err)
 		}
 
+		if intent == nil {
+			// remove id with nil value from the cache
+			if err := s.rdb.SRem(ctx, intentStoreIdsKey, id).Err(); err != nil {
+				log.Warnf("failed to remove intent with nil body (id=%s): %v", id, err)
+			}
+			continue
+		}
+
 		if len(intent.Receivers) > 0 {
 			intentsByTime = append(intentsByTime, *intent)
 		}

--- a/internal/infrastructure/live-store/redis/intents_test.go
+++ b/internal/infrastructure/live-store/redis/intents_test.go
@@ -20,7 +20,7 @@ func TestPopNilIntent(t *testing.T) {
 
 	// delete all to not make the other tests won't fail
 	err = store.DeleteAll(ctx)
-	require.NoError(t, store.DeleteAll(ctx))
+	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.DeleteAll(ctx) })
 
 	// push an intent with "nil" body

--- a/internal/infrastructure/live-store/redis/intents_test.go
+++ b/internal/infrastructure/live-store/redis/intents_test.go
@@ -1,0 +1,37 @@
+package redislivestore
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPopNilIntent ensures Pop doesn't panic when intent:ids contains an id whose intent:<id> body is "nil"
+func TestPopNilIntent(t *testing.T) {
+	ctx := t.Context()
+	
+	redisOpts, err := redis.ParseURL("redis://localhost:6379/0")
+	require.NoError(t, err)
+	rdb := redis.NewClient(redisOpts)
+
+	store := NewIntentStore(rdb, 5)
+
+	// delete all to not make the other tests won't fail
+	err = store.DeleteAll(ctx)
+	require.NoError(t, store.DeleteAll(ctx))
+	t.Cleanup(func() { _ = store.DeleteAll(ctx) })
+
+	// push an intent with "nil" body
+	orphanId := "nilvalueintent-" + uuid.New().String()
+	redisCmd := rdb.SAdd(ctx, intentStoreIdsKey, orphanId)
+	require.NoError(t, redisCmd.Err())
+
+	// try to pop the intent, verify it doesn't panic
+	require.NotPanics(t, func() {
+		popped, err := store.Pop(ctx, 10)
+		require.NoError(t, err)
+		require.Empty(t, popped)
+	})
+}


### PR DESCRIPTION
11ff7c491becf536f391338bd2c8b3310dfa5323 adds unit test replicating the issue.
bc5ff9ff8c0bd98a0f4ce06fead0bcf443ec235f makes the test pass + clean the "nil" intent.

@sekulicd @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes and ensures stable behavior when intent records are missing or orphaned by skipping nil entries.
  * Adds warning-level logging for detected missing intents to aid diagnosis.
* **Tests**
  * Adds a test verifying safe handling of orphaned intent identifiers (no panic, no error, empty result).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->