### PR TITLE
redis: reject duplicate boarding input

### DIFF
--- a/internal/infrastructure/live-store/live_store_test.go
+++ b/internal/infrastructure/live-store/live_store_test.go
@@ -139,6 +139,15 @@ func runLiveStoreTests(t *testing.T, store ports.LiveStore) {
 		)
 		require.NoError(t, err)
 
+		// try to push an intent with the same boarding input but different Id
+		intent2DuplicateBoarding := intent2.Intent
+		intent2DuplicateBoarding.Id = uuid.New().String()
+		err = store.Intents().Push(
+			ctx, intent2DuplicateBoarding, intent2.BoardingInputs, intent2.CosignersPublicKeys,
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicated input")
+
 		// ViewAll
 		all, err := store.Intents().ViewAll(
 			ctx, []string{intent1.Intent.Id, intent2.Intent.Id, "nonexistent"},

--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -88,6 +88,21 @@ func (s *intentStore) Push(
 				}
 			}
 
+			for _, boardingInput := range boardingInputs {
+				key := boardingInput.String()
+				exists, err := s.rdb.SIsMember(ctx, intentStoreVtxosKey, key).Result()
+				if err != nil {
+					return fmt.Errorf(
+						"failed to check existence of boarding input %s: %v", key, err,
+					)
+				}
+				if exists {
+					return fmt.Errorf(
+						"duplicated input, %s already registered by another intent", key,
+					)
+				}
+			}
+
 			now := time.Now()
 			timedIntent := &ports.TimedIntent{
 				Intent:              intent,
@@ -108,12 +123,15 @@ func (s *intentStore) Push(
 					}
 					pipe.SAdd(ctx, intentStoreVtxosKey, vtxo.Outpoint.String())
 				}
+				for _, boardingInput := range boardingInputs {
+					pipe.SAdd(ctx, intentStoreVtxosKey, boardingInput.String())
+				}
 
 				return nil
 			})
 
 			return err
-		}, intentStoreVtxosKey, intentStoreIdsKey) // WATCH both keys
+		}, intentStoreVtxosKey, intentStoreIdsKey) // WATCH dedup keys
 		if err == nil {
 			return nil
 		}
@@ -153,11 +171,14 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 	}
 
 	result := make([]ports.TimedIntent, 0, num)
-	var vtxosToRemove []string
+	var inputsToRemove []string
 	for _, intent := range intentsByTime[:num] {
 		result = append(result, intent)
 		for _, vtxo := range intent.Inputs {
-			vtxosToRemove = append(vtxosToRemove, vtxo.Outpoint.String())
+			inputsToRemove = append(inputsToRemove, vtxo.Outpoint.String())
+		}
+		for _, boardingInput := range intent.BoardingInputs {
+			inputsToRemove = append(inputsToRemove, boardingInput.String())
 		}
 
 		if err := s.intents.Delete(ctx, intent.Id); err != nil {
@@ -167,8 +188,8 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 		s.rdb.SRem(ctx, intentStoreIdsKey, intent.Id)
 	}
 
-	if len(vtxosToRemove) > 0 {
-		s.rdb.SAdd(ctx, intentStoreVtxosToRemoveKey, vtxosToRemove)
+	if len(inputsToRemove) > 0 {
+		s.rdb.SAdd(ctx, intentStoreVtxosToRemoveKey, inputsToRemove)
 	}
 
 	if len(result) > 0 {
@@ -281,6 +302,9 @@ func (s *intentStore) Delete(ctx context.Context, ids []string) error {
 		for _, vtxo := range intent.Inputs {
 			s.rdb.SRem(ctx, intentStoreVtxosKey, vtxo.Outpoint.String())
 		}
+		for _, boardingInput := range intent.BoardingInputs {
+			s.rdb.SRem(ctx, intentStoreVtxosKey, boardingInput.String())
+		}
 
 		if err := s.intents.Delete(ctx, id); err != nil {
 			log.Warnf("delete:failed to delete intent %s: %v", id, err)
@@ -308,10 +332,7 @@ func (s *intentStore) DeleteAll(ctx context.Context) error {
 	for range s.numOfRetries {
 		if err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
 			_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				pipe.Del(
-					ctx, intentStoreIdsKey, intentStoreVtxosKey,
-					intentStoreVtxosToRemoveKey, selectedIntentsKey,
-				)
+				pipe.Del(ctx, keys...)
 				return nil
 			})
 			return err
@@ -324,17 +345,17 @@ func (s *intentStore) DeleteAll(ctx context.Context) error {
 }
 
 func (s *intentStore) DeleteVtxos(ctx context.Context) error {
-	vtxosToRemove, err := s.rdb.SMembers(ctx, intentStoreVtxosToRemoveKey).Result()
+	inputsToRemove, err := s.rdb.SMembers(ctx, intentStoreVtxosToRemoveKey).Result()
 	if err != nil {
-		return fmt.Errorf("failed to get vtxos to remove: %v", err)
+		return fmt.Errorf("failed to get inputs to remove: %v", err)
 	}
 
 	for range s.numOfRetries {
 		if err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
 			_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-				if len(vtxosToRemove) > 0 {
-					members := make([]interface{}, len(vtxosToRemove))
-					for i, v := range vtxosToRemove {
+				if len(inputsToRemove) > 0 {
+					members := make([]interface{}, len(inputsToRemove))
+					for i, v := range inputsToRemove {
 						members[i] = v
 					}
 					pipe.SRem(ctx, intentStoreVtxosKey, members...)


### PR DESCRIPTION
c5b689527a654bc44ca614404c7b641a43453db9 add unit test for duplicate boarding input in intent.
b16bccd6dc27da67c7784e99030ae3d4af39f526 fix.

@altafan @sekulicd please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test case for duplicate input detection.

* **Bug Fixes**
  * Enhanced duplicate detection logic to prevent conflicting boarding inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->