### PR TITLE
Refactor: remove unused intent.proof index

### DIFF
--- a/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.down.sql
+++ b/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_intent_proof ON intent(proof);

--- a/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.up.sql
+++ b/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.up.sql
@@ -1,1 +1,1 @@
- DROP INDEX IF EXISTS idx_intent_proof
+DROP INDEX IF EXISTS idx_intent_proof;

--- a/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.up.sql
+++ b/internal/infrastructure/db/postgres/migration/20260420102643_drop_intent_proof_index.up.sql
@@ -1,0 +1,1 @@
+ DROP INDEX IF EXISTS idx_intent_proof

--- a/internal/infrastructure/db/service_test.go
+++ b/internal/infrastructure/db/service_test.go
@@ -442,6 +442,7 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		roundsMatch(t, *round, *roundById)
 
 		commitmentTxid := randomString(32)
+		largeProof := randomString(3000)
 		newEvents := []domain.Event{
 			domain.IntentsRegistered{
 				RoundEvent: domain.RoundEvent{
@@ -451,7 +452,7 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 				Intents: []domain.Intent{
 					{
 						Id:      uuid.New().String(),
-						Proof:   "proof",
+						Proof:   largeProof,
 						Txid:    txida,
 						Message: "message",
 						Inputs: []domain.Vtxo{
@@ -528,7 +529,7 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		// get intents by txid
 		intent, err := svc.Rounds().GetIntentByTxid(ctx, txida)
 		require.NoError(t, err)
-		require.Equal(t, "proof", intent.Proof)
+		require.Equal(t, largeProof, intent.Proof)
 		require.Equal(t, "message", intent.Message)
 		require.NotEqual(t, "", intent.Id)
 		require.NotEqual(t, "", intent.Txid)

--- a/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.down.sql
+++ b/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_intent_proof ON intent(proof);

--- a/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.up.sql
+++ b/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.up.sql
@@ -1,1 +1,1 @@
- DROP INDEX IF EXISTS idx_intent_proof
+DROP INDEX IF EXISTS idx_intent_proof;

--- a/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.up.sql
+++ b/internal/infrastructure/db/sqlite/migration/20260420102650_drop_intent_proof_index.up.sql
@@ -1,0 +1,1 @@
+ DROP INDEX IF EXISTS idx_intent_proof


### PR DESCRIPTION
Changes:
- Add a large proof to the round repository tests.
- Add a migration to remove `idx_intent_proof` SQL index.

The index is unused and can sometimes result in Postgres DB write failures if the proof is very large, see ed3e38c619a893df744e10a76862253281e0bbb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal database structure by removing an unused performance index across all supported database systems.
  * Enhanced internal testing to validate system stability with large-scale data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->